### PR TITLE
Release 0.1.0-beta1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.0-beta1</VersionPrefix>
     <PackageReleaseNotes>Initial release of Termina - a reactive terminal UI (TUI) framework for .NET.
 
 **Features**:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Termina
 
-[![NuGet Version](https://img.shields.io/nuget/v/Termina.svg)](https://www.nuget.org/packages/Termina)
-[![Build Status](https://github.com/Aaronontheweb/Termina/actions/workflows/pr-validation.yml/badge.svg)](https://github.com/Aaronontheweb/Termina/actions)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/Termina)](https://www.nuget.org/packages/Termina) ![GitHub License](https://img.shields.io/github/license/Aaronontheweb/Termina) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Aaronontheweb/Termina/pr_validation.yml) ![GitHub Release](https://img.shields.io/github/v/release/Aaronontheweb/Termina)
 
 **Termina** is a reactive terminal UI (TUI) framework for .NET built on top of [Spectre.Console](https://spectreconsole.net/). It provides an MVVM architecture with source-generated reactive properties, ASP.NET Core-style routing, and seamless integration with Microsoft.Extensions.Hosting.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 0.1.0 December 11th 2025 ####
+#### 0.1.0-beta1 December 11th 2025 ####
 
 Initial release of Termina - a reactive terminal UI (TUI) framework for .NET.
 


### PR DESCRIPTION
## Summary
Prepare for initial beta release 0.1.0-beta1 of Termina.

This PR updates:
- RELEASE_NOTES.md with version 0.1.0-beta1 and release date
- Directory.Build.props with updated VersionPrefix and PackageReleaseNotes

## Changes
- Set version to 0.1.0-beta1
- Updated release notes for December 11th 2025

## Next Steps
After this PR is merged:
1. Sync local dev branch
2. Create and push git tag 0.1.0-beta1
3. CI/CD will automatically create the GitHub release