### PR TITLE
Exclude demo project from NuGet packaging

### DIFF
--- a/src/Termina.Demo/Termina.Demo.csproj
+++ b/src/Termina.Demo/Termina.Demo.csproj
@@ -10,6 +10,9 @@
     <!-- AOT Publishing Support -->
     <PublishAot>true</PublishAot>
     <IsAotCompatible>true</IsAotCompatible>
+
+    <!-- Don't publish demo as NuGet package -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds `<IsPackable>false</IsPackable>` to Termina.Demo.csproj to prevent the demo app from being published as a NuGet package.