### PR TITLE
Fix GitHub release workflow permissions

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -5,14 +5,14 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   publish-nuget:
 
     name: publish-nuget
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
     - name: "Checkout"
@@ -40,21 +40,13 @@ jobs:
     - name: Push Packages
       run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
 
-    - name: release
-      uses: actions/create-release@v1
-      id: create_release
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
       with:
-        draft: false
-        prerelease: false
-        release_name: 'Termina ${{ github.ref_name }}'
-        tag_name: ${{ github.ref }}
+        name: 'Termina ${{ github.ref_name }}'
         body_path: RELEASE_NOTES.md
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    - name: Upload Release Asset
-      uses: AButler/upload-release-assets@v3.0
-      with:
-          repo-token: ${{ github.token }}
-          release-tag: ${{ github.ref_name }}
-          files: 'output/*.nupkg'
+        draft: false
+        prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}
+        files: |
+          output/*.nupkg
+          output/*.snupkg


### PR DESCRIPTION
## Summary
- Add `contents: write` permission for creating releases
- Replace deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`
- Auto-detect prerelease from tag name (beta, alpha, rc)
- Simplified matrix (single ubuntu-latest runner)
- Include `.snupkg` symbol packages in release assets

Fixes "Resource not accessible by integration" error when creating GitHub releases.