### PR TITLE
Add --skip-duplicate to NuGet push

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -38,7 +38,7 @@ jobs:
       run:  dotnet pack /p:PackageVersion=${{ github.ref_name }} -c Release -o ./output
 
     - name: Push Packages
-      run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Prevents workflow failure when re-pushing a tag for the same version that was already published to NuGet.