### PR TITLE
Add logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Termina
 
+![Termina Logo](https://raw.githubusercontent.com/Aaronontheweb/Termina/refs/heads/dev/assets/termina-icon.png)
+
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Termina)](https://www.nuget.org/packages/Termina) ![GitHub License](https://img.shields.io/github/license/Aaronontheweb/Termina) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Aaronontheweb/Termina/pr_validation.yml) ![GitHub Release](https://img.shields.io/github/v/release/Aaronontheweb/Termina)
 
 **Termina** is a reactive terminal UI (TUI) framework for .NET built on top of [Spectre.Console](https://spectreconsole.net/). It provides an MVVM architecture with source-generated reactive properties, ASP.NET Core-style routing, and seamless integration with Microsoft.Extensions.Hosting.


### PR DESCRIPTION
Adds the Termina logo to the README using the raw.githubusercontent.com URL for better visibility.