### PR TITLE
Implement per-page RenderMode for native terminal scrollback

### DIFF
--- a/src/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/src/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -11,10 +11,15 @@ namespace Termina.Demo.Streaming.Pages;
 /// </summary>
 public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
 {
+    /// <summary>
+    /// Use scrolling mode for chat - natural terminal scrollback instead of fixed layout.
+    /// </summary>
+    public override RenderMode RenderMode => RenderMode.Scrolling;
+
     // Status bar (owned by page for layout)
     private readonly StatusBar _statusBar = new()
     {
-        Hints = "[Enter] Send [↑/↓] Scroll [Esc] Clear/Quit [Ctrl+Q] Quit"
+        Hints = "[Enter] Send [Esc] Clear/Quit [Ctrl+Q] Quit"
     };
 
     protected override void OnBound()
@@ -24,8 +29,8 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
             .Subscribe(isGenerating =>
             {
                 _statusBar.Hints = isGenerating
-                    ? "[Esc] Cancel generation [↑/↓] Scroll [Ctrl+Q] Quit"
-                    : "[Enter] Send [↑/↓] Scroll [←/→] Edit [Esc] Clear/Quit [Ctrl+Q] Quit";
+                    ? "[Esc] Cancel generation [Ctrl+Q] Quit"
+                    : "[Enter] Send [←/→] Edit [Esc] Clear/Quit [Ctrl+Q] Quit";
             })
             .DisposeWith(Subscriptions);
 

--- a/src/Termina/Pages/IPage.cs
+++ b/src/Termina/Pages/IPage.cs
@@ -10,6 +10,19 @@ namespace Termina.Pages;
 public interface IPage
 {
     /// <summary>
+    /// Gets the render mode for this page.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    ///   <item><see cref="RenderMode.LiveDisplay"/> (default): Fixed layout, redraws in place.
+    ///   Best for settings, menus, dashboards.</item>
+    ///   <item><see cref="RenderMode.Scrolling"/>: Natural terminal scrolling.
+    ///   Best for chat, logs, streaming content.</item>
+    /// </list>
+    /// </remarks>
+    RenderMode RenderMode => RenderMode.LiveDisplay;
+
+    /// <summary>
     /// Called when the page becomes active (navigated to).
     /// Use this to initialize or refresh component state.
     /// </summary>

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -47,6 +47,19 @@ public abstract class ReactivePage<TViewModel> : IBindablePage
     protected TViewModel ViewModel { get; private set; } = default!;
 
     /// <summary>
+    /// Gets the render mode for this page. Override to change from the default LiveDisplay mode.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    ///   <item><see cref="RenderMode.LiveDisplay"/> (default): Fixed layout, redraws in place.
+    ///   Best for settings, menus, dashboards.</item>
+    ///   <item><see cref="RenderMode.Scrolling"/>: Natural terminal scrolling.
+    ///   Best for chat, logs, streaming content.</item>
+    /// </list>
+    /// </remarks>
+    public virtual RenderMode RenderMode => RenderMode.LiveDisplay;
+
+    /// <summary>
     /// Composite disposable for page subscriptions.
     /// Subscriptions are automatically cleared when navigating away.
     /// </summary>

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -295,26 +295,8 @@ public sealed class TerminaApplication
 
         try
         {
-            // Initial render
-            var rootRenderable = RenderCurrentPage();
-
-            await _console.Live(rootRenderable)
-                .AutoClear(false)
-                .StartAsync(async ctx =>
-                {
-                    // Initial render - don't wait for first event
-                    ctx.Refresh();
-
-                    // Single-threaded event loop - all input sources merge here
-                    await foreach (var evt in _eventChannel.Reader.ReadAllAsync(linkedToken))
-                    {
-                        ProcessEvent(evt);
-
-                        // Re-render after event processing
-                        ctx.UpdateTarget(RenderCurrentPage());
-                        ctx.Refresh();
-                    }
-                });
+            // Dispatch to appropriate render loop based on current page's render mode
+            await RunRenderLoopAsync(linkedToken);
         }
         catch (OperationCanceledException)
         {
@@ -339,6 +321,107 @@ public sealed class TerminaApplication
         {
             _shutdownCts.Dispose();
             _shutdownCts = null;
+        }
+    }
+
+    /// <summary>
+    /// Main render loop that dispatches to the appropriate mode-specific loop.
+    /// Handles transitions between render modes during navigation.
+    /// </summary>
+    private async Task RunRenderLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var currentMode = _currentPage?.RenderMode ?? RenderMode.LiveDisplay;
+
+            try
+            {
+                if (currentMode == RenderMode.Scrolling)
+                {
+                    await RunScrollingLoopAsync(cancellationToken);
+                }
+                else
+                {
+                    await RunLiveDisplayLoopAsync(cancellationToken);
+                }
+            }
+            catch (RenderModeChangedException)
+            {
+                // Page navigated to a different render mode - restart the loop
+                continue;
+            }
+
+            // If we get here without exception, we're done
+            break;
+        }
+    }
+
+    /// <summary>
+    /// Render loop for LiveDisplay mode - redraws in place.
+    /// </summary>
+    private async Task RunLiveDisplayLoopAsync(CancellationToken cancellationToken)
+    {
+        var initialMode = _currentPage?.RenderMode ?? RenderMode.LiveDisplay;
+        var rootRenderable = RenderCurrentPage();
+
+        await _console.Live(rootRenderable)
+            .AutoClear(false)
+            .StartAsync(async ctx =>
+            {
+                // Initial render - don't wait for first event
+                ctx.Refresh();
+
+                // Single-threaded event loop - all input sources merge here
+                await foreach (var evt in _eventChannel.Reader.ReadAllAsync(cancellationToken))
+                {
+                    ProcessEvent(evt);
+
+                    // Check if render mode changed after event processing
+                    var newMode = _currentPage?.RenderMode ?? RenderMode.LiveDisplay;
+                    if (newMode != initialMode)
+                    {
+                        throw new RenderModeChangedException();
+                    }
+
+                    // Re-render after event processing
+                    ctx.UpdateTarget(RenderCurrentPage());
+                    ctx.Refresh();
+                }
+            });
+    }
+
+    /// <summary>
+    /// Render loop for Scrolling mode - writes to console with natural scrollback.
+    /// </summary>
+    private async Task RunScrollingLoopAsync(CancellationToken cancellationToken)
+    {
+        var initialMode = _currentPage?.RenderMode ?? RenderMode.Scrolling;
+
+        // Initial render
+        _console.Write(RenderCurrentPage());
+
+        // Track what we've rendered to avoid full redraws
+        IRenderable? lastRendered = null;
+
+        await foreach (var evt in _eventChannel.Reader.ReadAllAsync(cancellationToken))
+        {
+            ProcessEvent(evt);
+
+            // Check if render mode changed after event processing
+            var newMode = _currentPage?.RenderMode ?? RenderMode.Scrolling;
+            if (newMode != initialMode)
+            {
+                throw new RenderModeChangedException();
+            }
+
+            // In scrolling mode, we write new content to the console
+            // The page is responsible for only returning new/changed content
+            var renderable = RenderCurrentPage();
+            if (!ReferenceEquals(renderable, lastRendered))
+            {
+                _console.Write(renderable);
+                lastRendered = renderable;
+            }
         }
     }
 
@@ -400,5 +483,16 @@ internal sealed class ReactivePageRegistration
         Behavior = behavior;
         PageFactory = pageFactory;
         ViewModelFactory = viewModelFactory;
+    }
+}
+
+/// <summary>
+/// Internal exception used to signal that the render mode has changed during navigation.
+/// This triggers a restart of the render loop with the new mode.
+/// </summary>
+internal sealed class RenderModeChangedException : Exception
+{
+    public RenderModeChangedException() : base("Render mode changed during navigation")
+    {
     }
 }


### PR DESCRIPTION
## Summary

- Adds `RenderMode` property to `IPage` interface and `ReactivePage` base class
- Allows pages to choose between `LiveDisplay` (fixed layout, redraws in place) or `Scrolling` (natural terminal scrollback)
- `TerminaApplication` dispatches to the appropriate render loop based on the current page's `RenderMode`
- Handles transitions between render modes during navigation via `RenderModeChangedException`
- `StreamingChatPage` now uses `RenderMode.Scrolling` for native terminal scrollback

## Test plan

- [x] Build succeeds without errors
- [x] All 164 tests pass
- [x] Publish succeeds (AOT validation)
- [ ] Manual testing: Run `Termina.Demo.Streaming` and verify scrollback works naturally
- [ ] Manual testing: Navigate between pages with different render modes

Closes #25