### PR TITLE
Fix TextInputNode timer disposal race condition

### DIFF
--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -21,6 +21,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     private int _selectionStart = -1;
     private int _scrollOffset;
     private bool _cursorVisible = true;
+    private bool _disposed;
 
     /// <inheritdoc />
     public event Action? Invalidated;
@@ -214,6 +215,10 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// </summary>
     public bool HandleInput(ConsoleKeyInfo key)
     {
+        // Don't process input if disposed
+        if (_disposed)
+            return false;
+
         // Reset cursor to visible on any input
         _cursorVisible = true;
         _cursorTimer.Stop();
@@ -668,6 +673,10 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// <inheritdoc />
     public override void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         _cursorTimer.Stop();
         _cursorTimer.Dispose();
         base.Dispose();


### PR DESCRIPTION
## Summary
- Add `_disposed` flag to `TextInputNode` to track disposal state
- Check flag in `HandleInput` to prevent `ObjectDisposedException` when key events arrive after timer is disposed
- Add idempotency to `Dispose()` method

## Problem
When shutting down the streaming demo app in test mode, a race condition could occur where:
1. `Dispose()` is called, which stops and disposes the `_cursorTimer`
2. A key event arrives and `HandleInput` is called
3. `HandleInput` tries to call `_cursorTimer.Stop()` and `_cursorTimer.Start()` on the disposed timer
4. `ObjectDisposedException` is thrown

## Test plan
- [x] All 337 unit tests pass
- [x] `Termina.Demo --test` exits cleanly
- [x] `Termina.Demo.V2 --test` exits cleanly  
- [x] `Termina.Demo.Streaming --test` exits cleanly (previously crashed)