### PR TITLE
Improve todo demo with text input and fix PreserveState subscription leak

### DIFF
--- a/src/Termina.Demo/Pages/TodoListPage.cs
+++ b/src/Termina.Demo/Pages/TodoListPage.cs
@@ -31,14 +31,33 @@ public class TodoListPage : ReactivePage<TodoListViewModel>
                             .AsLayout())
                     .Fill())
             .WithChild(
-                new TextNode("[↑/↓] Navigate [Space] Toggle [A] Add [D] Delete [C] Counter [Q] Quit")
-                    .WithForeground(Color.BrightBlack)
+                // Show text input row when adding, otherwise show help text
+                ViewModel.IsAddingItemChanged
+                    .CombineLatest(ViewModel.NewItemTextChanged, (isAdding, text) => (isAdding, text))
+                    .Select(tuple => tuple.isAdding
+                        ? BuildTextInputRow(tuple.text)
+                        : new TextNode("[↑/↓] Navigate [Space] Toggle [A] Add [D] Delete [C] Counter [Q] Quit")
+                            .WithForeground(Color.BrightBlack))
+                    .AsLayout()
                     .Height(1))
             .WithChild(
                 ViewModel.StatusMessageChanged
                     .Select(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
                     .Height(1));
+    }
+
+    private static ILayoutNode BuildTextInputRow(string text)
+    {
+        return Layouts.Horizontal()
+            .WithChild(
+                new TextNode("New task: ")
+                    .WithForeground(Color.Yellow)
+                    .Width(11))
+            .WithChild(
+                new TextNode(text + "▌")
+                    .WithForeground(Color.White)
+                    .Fill());
     }
 
     private static ILayoutNode BuildTodoList(IReadOnlyList<TodoItem> items, int selectedIndex)

--- a/src/Termina.Demo/Pages/TodoListViewModel.cs
+++ b/src/Termina.Demo/Pages/TodoListViewModel.cs
@@ -20,6 +20,8 @@ public partial class TodoListViewModel : ReactiveViewModel
 
     [Reactive] private int _selectedIndex;
     [Reactive] private string _statusMessage = "Navigate with ↑/↓, Space to toggle, C for counter, Q to quit";
+    [Reactive] private bool _isAddingItem;
+    [Reactive] private string _newItemText = "";
 
     public override void OnActivated()
     {
@@ -31,6 +33,13 @@ public partial class TodoListViewModel : ReactiveViewModel
 
     private void HandleKeyPress(KeyPressed key)
     {
+        // Handle input differently when in text entry mode
+        if (IsAddingItem)
+        {
+            HandleTextEntryKeyPress(key);
+            return;
+        }
+
         switch (key.KeyInfo.Key)
         {
             case ConsoleKey.UpArrow:
@@ -54,7 +63,7 @@ public partial class TodoListViewModel : ReactiveViewModel
                 break;
 
             case ConsoleKey.A:
-                AddItem();
+                StartAddingItem();
                 break;
 
             case ConsoleKey.D:
@@ -69,6 +78,65 @@ public partial class TodoListViewModel : ReactiveViewModel
                 Shutdown();
                 break;
         }
+    }
+
+    private void HandleTextEntryKeyPress(KeyPressed key)
+    {
+        switch (key.KeyInfo.Key)
+        {
+            case ConsoleKey.Enter:
+                ConfirmAddItem();
+                break;
+            case ConsoleKey.Escape:
+                CancelAddItem();
+                break;
+            case ConsoleKey.Backspace:
+                if (NewItemText.Length > 0)
+                {
+                    NewItemText = NewItemText[..^1];
+                }
+                break;
+            default:
+                // Add printable characters
+                if (key.KeyInfo.KeyChar != '\0' && !char.IsControl(key.KeyInfo.KeyChar))
+                {
+                    NewItemText += key.KeyInfo.KeyChar;
+                }
+                break;
+        }
+    }
+
+    private void StartAddingItem()
+    {
+        IsAddingItem = true;
+        NewItemText = "";
+        StatusMessage = "Type task name, Enter to add, Escape to cancel";
+    }
+
+    private void ConfirmAddItem()
+    {
+        if (!string.IsNullOrWhiteSpace(NewItemText))
+        {
+            var newItems = Items.ToList();
+            newItems.Add(new TodoItem(NewItemText.Trim(), false));
+            Items = newItems;
+            SelectedIndex = Items.Count - 1;
+            StatusMessage = $"Added: {NewItemText.Trim()}";
+        }
+        else
+        {
+            StatusMessage = "Cancelled - empty task name";
+        }
+
+        IsAddingItem = false;
+        NewItemText = "";
+    }
+
+    private void CancelAddItem()
+    {
+        IsAddingItem = false;
+        NewItemText = "";
+        StatusMessage = "Cancelled adding item";
     }
 
     private void ToggleSelected()
@@ -86,14 +154,6 @@ public partial class TodoListViewModel : ReactiveViewModel
         StatusMessage = newItem.IsCompleted
             ? $"Completed: {newItem.Description}"
             : $"Uncompleted: {newItem.Description}";
-    }
-
-    private void AddItem()
-    {
-        var newItems = Items.ToList();
-        newItems.Add(new TodoItem($"New task {Items.Count + 1}", false));
-        Items = newItems;
-        StatusMessage = "Added new item";
     }
 
     private void DeleteSelected()

--- a/src/Termina.Demo/Program.cs
+++ b/src/Termina.Demo/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Hosting;
 using Termina.Demo.Pages;
 using Termina.Hosting;
 using Termina.Input;
+using Termina.Pages;
 
 // Check for --test flag (used in CI/CD to run scripted test and exit)
 var testMode = args.Contains("--test");
@@ -17,10 +18,11 @@ if (testMode)
 }
 
 // Register Termina with reactive pages using route-based navigation
+// Use PreserveState so state persists when navigating between pages
 builder.Services.AddTermina("/counter", termina =>
 {
-    termina.RegisterRoute<CounterPage, CounterViewModel>("/counter");
-    termina.RegisterRoute<TodoListPage, TodoListViewModel>("/todos");
+    termina.RegisterRoute<CounterPage, CounterViewModel>("/counter", NavigationBehavior.PreserveState);
+    termina.RegisterRoute<TodoListPage, TodoListViewModel>("/todos", NavigationBehavior.PreserveState);
 });
 
 var host = builder.Build();

--- a/src/Termina/Reactive/ReactiveViewModel.cs
+++ b/src/Termina/Reactive/ReactiveViewModel.cs
@@ -46,13 +46,23 @@ namespace Termina.Reactive;
 /// </example>
 public abstract class ReactiveViewModel : IDisposable
 {
-    private readonly CompositeDisposable _subscriptions = new();
+    private CompositeDisposable _subscriptions = new();
 
     /// <summary>
     /// Composite disposable for managing subscriptions.
     /// Use <see cref="RxExtensions.DisposeWith{T}"/> to add subscriptions.
-    /// All subscriptions are disposed when the ViewModel is disposed.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Subscriptions added in <see cref="OnActivated"/> are automatically disposed when
+    /// <see cref="OnDeactivating"/> is called. This prevents duplicate subscriptions when using
+    /// <see cref="Pages.NavigationBehavior.PreserveState"/>.
+    /// </para>
+    /// <para>
+    /// For subscriptions that should persist across activations (e.g., subscriptions created in
+    /// the constructor), store the disposable manually and dispose it in <see cref="Dispose"/>.
+    /// </para>
+    /// </remarks>
     protected CompositeDisposable Subscriptions => _subscriptions;
 
     /// <summary>
@@ -108,8 +118,17 @@ public abstract class ReactiveViewModel : IDisposable
     /// Called when the page is being deactivated (navigating away).
     /// Override to perform cleanup or state saving.
     /// </summary>
+    /// <remarks>
+    /// The base implementation disposes all <see cref="Subscriptions"/> to prevent
+    /// duplicate subscriptions when using <see cref="Pages.NavigationBehavior.PreserveState"/>.
+    /// If you override this method, always call the base implementation.
+    /// </remarks>
     public virtual void OnDeactivating()
     {
+        // Dispose subscriptions and create a new container for next activation
+        // This prevents duplicate subscriptions with PreserveState navigation
+        _subscriptions.Dispose();
+        _subscriptions = new CompositeDisposable();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add text input mode for naming new todo items (press A, type name, Enter)
- Use PreserveState navigation to preserve state between page switches
- Fix ReactiveViewModel to auto-dispose Subscriptions in OnDeactivating()
  This prevents duplicate subscriptions when navigating back to a page

## Test plan
- [x] Run `dotnet test`
- [x] Run `dotnet run --project src/Termina.Demo -- --test`
- [ ] Manual testing: navigate between counter and todo pages multiple times, verify count increments by 1 (not multiplying)