### PR TITLE
Add automatic terminal resize detection via polling

### DIFF
--- a/src/Termina/Input/ConsoleInputSource.cs
+++ b/src/Termina/Input/ConsoleInputSource.cs
@@ -3,14 +3,20 @@ using System.Threading.Channels;
 namespace Termina.Input;
 
 /// <summary>
-/// Real console input source that reads from Console.ReadKey.
+/// Real console input source that reads from Console.ReadKey and detects terminal resize.
 /// Runs on a background thread since ReadKey is blocking.
 /// </summary>
 public sealed class ConsoleInputSource : IInputSource
 {
+    private int _lastWidth;
+    private int _lastHeight;
+
     /// <inheritdoc />
     public async Task RunAsync(ChannelWriter<object> writer, CancellationToken cancellationToken)
     {
+        // Initialize dimensions for resize detection
+        InitializeDimensions();
+
         // Run blocking Console.ReadKey on thread pool
         await Task.Run(async () =>
         {
@@ -27,7 +33,45 @@ public sealed class ConsoleInputSource : IInputSource
                     // Brief yield to check cancellation
                     await Task.Delay(10, cancellationToken);
                 }
+
+                // Check for terminal resize (polling)
+                await CheckForResizeAsync(writer, cancellationToken);
             }
         }, cancellationToken);
+    }
+
+    private void InitializeDimensions()
+    {
+        try
+        {
+            _lastWidth = Console.WindowWidth;
+            _lastHeight = Console.WindowHeight;
+        }
+        catch (IOException)
+        {
+            // No TTY available - use defaults
+            _lastWidth = 80;
+            _lastHeight = 24;
+        }
+    }
+
+    private async Task CheckForResizeAsync(ChannelWriter<object> writer, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var width = Console.WindowWidth;
+            var height = Console.WindowHeight;
+
+            if (width != _lastWidth || height != _lastHeight)
+            {
+                _lastWidth = width;
+                _lastHeight = height;
+                await writer.WriteAsync(new ResizeEvent(width, height), cancellationToken);
+            }
+        }
+        catch (IOException)
+        {
+            // No TTY available - ignore resize checks
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add automatic terminal resize detection to `ConsoleInputSource`
- Polls `Console.WindowWidth/Height` every 10ms and emits `ResizeEvent` when dimensions change
- UI now automatically re-renders when users resize the terminal window

## Approach
Uses cross-platform polling which works on all platforms without complex P/Invoke. This is adequate because:
- Terminal resize is a rare user action
- 10ms polling interval is imperceptible for resize UX
- Polling is already used in the input loop

## Test plan
- [x] Build succeeds
- [x] All 337 tests pass
- [ ] Manual testing: resize terminal window and verify UI adjusts automatically