### PR TITLE
Refactor TextInputNode to move history management to ViewModel

### DIFF
--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -43,20 +43,24 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                         : (ILayoutNode)new EmptyNode())
                     .AsLayout())
             .WithChild(new EmptyNode().Height(1))
-            // Input panel
+            // Input panel - NOT reactive to avoid disposing the shared TextInputNode
             .WithChild(
-                ViewModel.IsGeneratingChanged
-                    .Select(isGenerating => BuildInputPanel(isGenerating))
-                    .AsLayout()
+                new PanelNode()
+                    .WithTitle("Your Prompt")
+                    .WithTitleColor(Color.Cyan)
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Cyan)
+                    .WithContent(ViewModel.PromptInput)
                     .Height(3))
             // Status bar with dynamic hints
             .WithChild(
                 ViewModel.IsGeneratingChanged
                     .Select(isGenerating => new TextNode(
                         isGenerating
-                            ? "[Esc] Cancel generation [↑/↓] Scroll [Ctrl+Q] Quit"
-                            : "[Enter] Send [↑/↓] Scroll [←/→] Edit [Esc] Clear/Quit [Ctrl+Q] Quit")
-                        .WithForeground(Color.BrightBlack))
+                            ? "[Esc] Cancel [PgUp/PgDn] Scroll [Ctrl+Q] Quit"
+                            : "[Enter] Send [↑/↓] History [PgUp/PgDn] Scroll [Esc] Clear/Quit [Ctrl+Q] Quit")
+                        .WithForeground(Color.BrightBlack)
+                        .NoWrap())
                     .AsLayout()
                     .Height(1))
             .WithChild(
@@ -80,14 +84,4 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                     .Height(5));
     }
 
-    private ILayoutNode BuildInputPanel(bool isGenerating)
-    {
-        var borderColor = isGenerating ? Color.Gray : Color.Cyan;
-        return new PanelNode()
-            .WithTitle("Your Prompt")
-            .WithTitleColor(Color.Cyan)
-            .WithBorder(BorderStyle.Rounded)
-            .WithBorderColor(borderColor)
-            .WithContent(ViewModel.PromptInput);
-    }
 }

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
@@ -20,6 +20,8 @@ namespace Termina.Demo.Streaming.Pages;
 public partial class StreamingChatViewModel : ReactiveViewModel
 {
     private readonly IRequiredActor<LlmSimulatorActor> _llmActorProvider;
+    private readonly List<string> _promptHistory = new();
+    private int _historyIndex = -1;
     private IActorRef? _llmActor;
     private CancellationTokenSource? _generationCts;
 
@@ -101,7 +103,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         // Escape handling
         if (keyInfo.Key == ConsoleKey.Escape)
         {
-            if (_isGenerating)
+            if (IsGenerating)
             {
                 CancelGeneration();
             }
@@ -121,10 +123,64 @@ public partial class StreamingChatViewModel : ReactiveViewModel
             return;
         }
 
-        // When not generating, let the text input handle keys
-        if (!_isGenerating)
+        // Page Up/Down always scroll chat history (works during generation too)
+        // Use reasonable defaults for viewport (scrolls ~10 lines per page)
+        if (ChatHistory.HandleInput(keyInfo, viewportHeight: 10, viewportWidth: 80))
         {
+            return;
+        }
+
+        // When not generating, handle input
+        if (!IsGenerating)
+        {
+            // Handle history navigation (Up/Down arrows)
+            if (keyInfo.Key == ConsoleKey.UpArrow)
+            {
+                NavigateHistoryUp();
+                return;
+            }
+            if (keyInfo.Key == ConsoleKey.DownArrow)
+            {
+                NavigateHistoryDown();
+                return;
+            }
+
+            // Let the text input handle other keys
             PromptInput.HandleInput(keyInfo);
+        }
+    }
+
+    private void NavigateHistoryUp()
+    {
+        if (_promptHistory.Count == 0)
+            return;
+
+        if (_historyIndex < 0)
+        {
+            _historyIndex = _promptHistory.Count - 1;
+        }
+        else if (_historyIndex > 0)
+        {
+            _historyIndex--;
+        }
+
+        PromptInput.Text = _promptHistory[_historyIndex];
+    }
+
+    private void NavigateHistoryDown()
+    {
+        if (_historyIndex < 0)
+            return;
+
+        if (_historyIndex < _promptHistory.Count - 1)
+        {
+            _historyIndex++;
+            PromptInput.Text = _promptHistory[_historyIndex];
+        }
+        else
+        {
+            _historyIndex = -1;
+            PromptInput.Text = "";
         }
     }
 
@@ -133,6 +189,13 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         prompt = prompt.Trim();
         if (string.IsNullOrEmpty(prompt))
             return;
+
+        // Add to history and reset index
+        _promptHistory.Add(prompt);
+        _historyIndex = -1;
+
+        // Clear the input
+        PromptInput.Clear();
 
         // Add user message to chat
         ChatHistory.AppendLine($"👤 You: {prompt}");
@@ -156,6 +219,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
             return;
         }
 
+        var completedNormally = false;
         try
         {
             // Ask actor for the stream
@@ -186,6 +250,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
                     case LlmMessages.GenerationComplete:
                         CleanupGeneration();
                         StatusMessage = "Ready. Enter another question.";
+                        completedNormally = true;
                         break;
                 }
             }
@@ -198,6 +263,15 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         {
             CleanupGeneration($" [error: {ex.Message}]");
             StatusMessage = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            // Ensure IsGenerating is always reset, even if stream ends unexpectedly
+            if (!completedNormally && IsGenerating)
+            {
+                CleanupGeneration();
+                StatusMessage = "Ready. Enter another question.";
+            }
         }
     }
 

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -145,6 +145,47 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
         }
     }
 
+    /// <summary>
+    /// Handle keyboard input for scrolling. Returns true if the input was handled.
+    /// </summary>
+    /// <param name="key">The key info to handle.</param>
+    /// <param name="viewportHeight">The height of the visible area (for page scrolling).</param>
+    /// <param name="viewportWidth">The width of the visible area (for word wrap calculations).</param>
+    public bool HandleInput(ConsoleKeyInfo key, int viewportHeight, int viewportWidth)
+    {
+        // Only PersistedStreamBuffer supports scrolling
+        if (_buffer is not PersistedStreamBuffer)
+            return false;
+
+        switch (key.Key)
+        {
+            case ConsoleKey.PageUp:
+                ScrollUp(Math.Max(1, viewportHeight - 1), viewportWidth);
+                return true;
+
+            case ConsoleKey.PageDown:
+                ScrollDown(Math.Max(1, viewportHeight - 1));
+                return true;
+
+            case ConsoleKey.Home when key.Modifiers.HasFlag(ConsoleModifiers.Control):
+                // Ctrl+Home scrolls to top
+                if (_buffer is PersistedStreamBuffer persisted)
+                {
+                    persisted.ScrollToTop(viewportWidth);
+                    NotifyChanged();
+                }
+                return true;
+
+            case ConsoleKey.End when key.Modifiers.HasFlag(ConsoleModifiers.Control):
+                // Ctrl+End scrolls to bottom
+                ScrollToBottom();
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
     private void NotifyChanged()
     {
         _contentChanged.OnNext(Unit.Default);

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -9,13 +9,17 @@ using Timer = System.Timers.Timer;
 namespace Termina.Layout;
 
 /// <summary>
-/// A stateful layout node that handles text input with cursor, selection, and history.
+/// A stateful layout node that handles text input with cursor and selection.
 /// </summary>
+/// <remarks>
+/// TextInputNode is a pure UI component that handles text editing (cursor movement, selection,
+/// typing). It does NOT handle input history - that is the responsibility of the ViewModel
+/// which can decide whether to enable history, how many entries to keep, and whether to
+/// persist it across sessions.
+/// </remarks>
 public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 {
     private readonly Timer _cursorTimer;
-    private readonly List<string> _history = new();
-    private int _historyIndex = -1;
     private string _text = "";
     private int _cursorPosition;
     private int _selectionStart = -1;
@@ -232,8 +236,8 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             ConsoleKey.RightArrow => HandleRightArrow(key.Modifiers),
             ConsoleKey.Home => HandleHome(key.Modifiers),
             ConsoleKey.End => HandleEnd(key.Modifiers),
-            ConsoleKey.UpArrow => HandleUpArrow(),
-            ConsoleKey.DownArrow => HandleDownArrow(),
+            ConsoleKey.UpArrow => false, // Let ViewModel handle history
+            ConsoleKey.DownArrow => false, // Let ViewModel handle history
             ConsoleKey.Enter => HandleEnter(),
             ConsoleKey.Escape => HandleEscape(),
             _ when key.KeyChar != '\0' && !char.IsControl(key.KeyChar) => HandleCharacter(key.KeyChar, key.Modifiers),
@@ -419,62 +423,25 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         return true;
     }
 
-    private bool HandleUpArrow()
-    {
-        // Navigate history
-        if (_history.Count == 0)
-            return false;
-
-        if (_historyIndex < 0)
-        {
-            _historyIndex = _history.Count - 1;
-        }
-        else if (_historyIndex > 0)
-        {
-            _historyIndex--;
-        }
-
-        _text = _history[_historyIndex];
-        _cursorPosition = _text.Length;
-        _selectionStart = -1;
-        return true;
-    }
-
-    private bool HandleDownArrow()
-    {
-        if (_historyIndex < 0)
-            return false;
-
-        if (_historyIndex < _history.Count - 1)
-        {
-            _historyIndex++;
-            _text = _history[_historyIndex];
-        }
-        else
-        {
-            _historyIndex = -1;
-            _text = "";
-        }
-
-        _cursorPosition = _text.Length;
-        _selectionStart = -1;
-        return true;
-    }
-
     private bool HandleEnter()
     {
-        if (!string.IsNullOrWhiteSpace(_text))
-        {
-            _history.Add(_text);
-            _historyIndex = -1;
-        }
-
+        // Just fire the event - ViewModel decides what to do (add to history, clear text, etc.)
         Submitted?.Invoke(_text);
+        return true;
+    }
+
+    /// <summary>
+    /// Clears the text and resets cursor position.
+    /// Call this from ViewModel after handling submission.
+    /// </summary>
+    public void Clear()
+    {
         _text = "";
         _cursorPosition = 0;
         _selectionStart = -1;
+        _scrollOffset = 0;
         TextChanged?.Invoke(_text);
-        return true;
+        Invalidated?.Invoke();
     }
 
     private bool HandleEscape()

--- a/tests/Termina.Tests/Layout/TextInputNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextInputNodeTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Termina.Layout;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for the TextInputNode layout component.
+/// </summary>
+public class TextInputNodeTests : IDisposable
+{
+    private readonly TextInputNode _node;
+
+    public TextInputNodeTests()
+    {
+        _node = new TextInputNode();
+    }
+
+    public void Dispose()
+    {
+        _node.Dispose();
+    }
+
+    [Fact]
+    public void HandleInput_UpArrow_ReturnsFalse_ForViewModelToHandle()
+    {
+        // Up arrow should return false so ViewModel can handle history
+        var handled = _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false));
+        Assert.False(handled);
+    }
+
+    [Fact]
+    public void HandleInput_DownArrow_ReturnsFalse_ForViewModelToHandle()
+    {
+        // Down arrow should return false so ViewModel can handle history
+        var handled = _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false));
+        Assert.False(handled);
+    }
+
+    [Fact]
+    public void HandleInput_Enter_DoesNotClearText()
+    {
+        // Type some text
+        TypeText("test text");
+
+        // Press Enter
+        _node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        // Text should NOT be cleared - ViewModel decides when to clear
+        Assert.Equal("test text", _node.Text);
+    }
+
+    [Fact]
+    public void Clear_ResetsTextAndCursor()
+    {
+        // Type some text
+        TypeText("test text");
+
+        // Clear
+        _node.Clear();
+
+        // Text should be cleared
+        Assert.Equal("", _node.Text);
+    }
+
+    [Fact]
+    public void Submitted_EventFired_OnEnter()
+    {
+        string? submittedText = null;
+        _node.Submitted += text => submittedText = text;
+
+        TypeText("test submission");
+        _node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("test submission", submittedText);
+    }
+
+    [Fact]
+    public void TextChanged_EventFired_OnCharacterInput()
+    {
+        var changeCount = 0;
+        _node.TextChanged += _ => changeCount++;
+
+        TypeText("abc");
+
+        Assert.Equal(3, changeCount);
+    }
+
+    [Fact]
+    public void TextChanged_EventFired_OnClear()
+    {
+        TypeText("test");
+
+        string? changedText = null;
+        _node.TextChanged += text => changedText = text;
+
+        _node.Clear();
+
+        Assert.Equal("", changedText);
+    }
+
+    [Fact]
+    public void HandleInput_LeftArrow_MovesCursor()
+    {
+        TypeText("hello");
+
+        // Move left
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false));
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false));
+
+        // Type at cursor position
+        _node.HandleInput(new ConsoleKeyInfo('X', (ConsoleKey)0, false, false, false));
+
+        Assert.Equal("helXlo", _node.Text);
+    }
+
+    [Fact]
+    public void HandleInput_RightArrow_MovesCursor()
+    {
+        TypeText("hello");
+
+        // Move to start
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false));
+
+        // Move right twice
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, false, false, false));
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, false, false, false));
+
+        // Type at cursor position
+        _node.HandleInput(new ConsoleKeyInfo('X', (ConsoleKey)0, false, false, false));
+
+        Assert.Equal("heXllo", _node.Text);
+    }
+
+    [Fact]
+    public void HandleInput_Home_MovesCursorToStart()
+    {
+        TypeText("hello");
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false));
+        _node.HandleInput(new ConsoleKeyInfo('X', (ConsoleKey)0, false, false, false));
+
+        Assert.Equal("Xhello", _node.Text);
+    }
+
+    [Fact]
+    public void HandleInput_End_MovesCursorToEnd()
+    {
+        TypeText("hello");
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false));
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false));
+        _node.HandleInput(new ConsoleKeyInfo('X', (ConsoleKey)0, false, false, false));
+
+        Assert.Equal("helloX", _node.Text);
+    }
+
+    [Fact]
+    public void HandleInput_Backspace_DeletesCharacter()
+    {
+        TypeText("hello");
+        _node.HandleInput(new ConsoleKeyInfo('\b', ConsoleKey.Backspace, false, false, false));
+
+        Assert.Equal("hell", _node.Text);
+    }
+
+    [Fact]
+    public void HandleInput_Delete_DeletesCharacterAhead()
+    {
+        TypeText("hello");
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false));
+        _node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false));
+
+        Assert.Equal("ello", _node.Text);
+    }
+
+    [Fact]
+    public void HandleInput_Escape_ClearsText()
+    {
+        TypeText("hello");
+        _node.HandleInput(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false));
+
+        Assert.Equal("", _node.Text);
+    }
+
+    private void TypeText(string text)
+    {
+        foreach (var c in text)
+        {
+            _node.HandleInput(new ConsoleKeyInfo(c, (ConsoleKey)0, false, false, false));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Remove built-in history from `TextInputNode` which was causing disposal issues when used in reactive layouts
- `TextInputNode` is now a pure UI component handling text editing only
- Up/Down arrows return `false` to let ViewModel handle history navigation
- Enter no longer auto-clears text; added `Clear()` method for ViewModel to call
- Add Page Up/Down scrolling support to `StreamingTextNode`
- Fix streaming demo: move history management to `StreamingChatViewModel`
- Fix reactive layout disposal bug by using static input panel
- Add comprehensive `TextInputNode` unit tests

## Background

The `TextInputNode` was storing input history internally, but this caused issues when the node was used inside a `ReactiveLayoutNode`. When the layout rebuilt (e.g., when `IsGenerating` changed), the old `PanelNode` was disposed, which cascaded to dispose the shared `TextInputNode`, losing all history and breaking input.

The fix moves history management to the ViewModel where it belongs - this follows proper separation of concerns and allows the application to control whether history is enabled, how many entries to keep, and whether to persist it.

## Test plan

- [x] All existing tests pass (374 tests)
- [x] New `TextInputNodeTests` cover cursor movement, editing, and event firing
- [ ] Manual testing: Run streaming demo, submit multiple prompts, verify Up/Down navigates history