### PR TITLE
Update PackageProjectUrl to documentation website

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,7 +76,7 @@ This release represents a complete architectural redesign from the beta, removin
   <!-- NuGet .nupkg options -->
   <PropertyGroup>
     <PackageTags>tui;terminal;console;ansi;reactive;mvvm;cli;dotnet</PackageTags>
-    <PackageProjectUrl>https://github.com/Aaronontheweb/Termina</PackageProjectUrl>
+    <PackageProjectUrl>https://aaronstannard.com/Termina/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Aaronontheweb/Termina</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>termina-icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- Update NuGet package project URL to point to the documentation website at https://aaronstannard.com/Termina/
- Repository URL remains unchanged at https://github.com/Aaronontheweb/Termina

## Test plan
- [ ] Verify NuGet package metadata shows correct project URL after next release