### PR TITLE
Fix auto-disposal of BehaviorSubject backing fields (#47)

### DIFF
--- a/src/Termina.Generators/ReactivePropertyGenerator.cs
+++ b/src/Termina.Generators/ReactivePropertyGenerator.cs
@@ -28,6 +28,19 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
     private const string FromRouteAttributeName = "FromRoute";
     private const string FromRouteAttributeFullName = "Termina.Routing.FromRouteAttribute";
 
+    /// <summary>
+    /// Diagnostic reported when a ReactiveViewModel subclass has a custom Dispose() method
+    /// but needs to call DisposeReactiveFields() to properly dispose generated BehaviorSubjects.
+    /// </summary>
+    private static readonly DiagnosticDescriptor MustCallDisposeReactiveFields = new(
+        id: "TERMINA001",
+        title: "Must call DisposeReactiveFields() in custom Dispose() override",
+        messageFormat: "Class '{0}' inherits from ReactiveViewModel and has [Reactive] fields, but defines a custom Dispose() method. You must call DisposeReactiveFields() in your Dispose() implementation to properly dispose generated BehaviorSubject backing fields.",
+        category: "Termina.Reactive",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "When a ReactiveViewModel subclass has [Reactive] fields and defines its own Dispose() method, it must call the generated DisposeReactiveFields() method to ensure BehaviorSubject backing fields are properly disposed.");
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Find all field declarations with [Reactive] or [FromRoute] attribute
@@ -138,6 +151,49 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
             : containingType.ContainingNamespace.ToDisplayString();
         var typeName = containingType.Name;
 
+        // Check if the containing type inherits from ReactiveViewModel
+        var inheritsFromReactiveViewModel = InheritsFromType(containingType, "Termina.Reactive.ReactiveViewModel");
+
+        // Check if the class already has a Dispose() method defined
+        var disposeMethod = containingType.GetMembers("Dispose")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m.Parameters.Length == 0 &&
+                      m.ReturnType.SpecialType == SpecialType.System_Void &&
+                      !m.IsImplicitlyDeclared);
+        var hasExistingDisposeMethod = disposeMethod is not null;
+
+        // Check if the existing Dispose method calls DisposeReactiveFields()
+        var disposeCallsDisposeReactiveFields = false;
+        if (disposeMethod is not null)
+        {
+            // Get the syntax reference for the dispose method
+            var syntaxRef = disposeMethod.DeclaringSyntaxReferences.FirstOrDefault();
+            if (syntaxRef is not null)
+            {
+                var disposeSyntax = syntaxRef.GetSyntax();
+                // Check if the method body contains a call to DisposeReactiveFields
+                disposeCallsDisposeReactiveFields = disposeSyntax.DescendantNodes()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Any(inv =>
+                    {
+                        // Check for direct call: DisposeReactiveFields()
+                        if (inv.Expression is IdentifierNameSyntax id &&
+                            id.Identifier.Text == "DisposeReactiveFields")
+                            return true;
+
+                        // Check for this.DisposeReactiveFields()
+                        if (inv.Expression is MemberAccessExpressionSyntax ma &&
+                            ma.Name.Identifier.Text == "DisposeReactiveFields")
+                            return true;
+
+                        return false;
+                    });
+            }
+        }
+
+        // Get the location of the type declaration for diagnostics
+        var typeLocation = typeDeclaration.Identifier.GetLocation();
+
         return new FieldInfo(
             namespaceName,
             typeName,
@@ -147,7 +203,38 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
             containingType.ToDisplayString(),
             hasReactiveAttribute,
             hasFromRouteAttribute,
-            routeParameterName);
+            routeParameterName,
+            inheritsFromReactiveViewModel,
+            hasExistingDisposeMethod,
+            disposeCallsDisposeReactiveFields,
+            typeLocation);
+    }
+
+    private static bool InheritsFromType(INamedTypeSymbol? type, string baseTypeName)
+    {
+        var current = type?.BaseType;
+        while (current != null)
+        {
+            // Check against multiple possible display formats
+            var displayString = current.ToDisplayString();
+            if (displayString == baseTypeName)
+                return true;
+
+            // Also check the fully qualified name (namespace + name)
+            var fullyQualifiedName = current.ContainingNamespace.IsGlobalNamespace
+                ? current.Name
+                : $"{current.ContainingNamespace.ToDisplayString()}.{current.Name}";
+            if (fullyQualifiedName == baseTypeName)
+                return true;
+
+            // Also check just by type name and namespace separately (for metadata types)
+            if (current.Name == "ReactiveViewModel" &&
+                current.ContainingNamespace.ToDisplayString() == "Termina.Reactive")
+                return true;
+
+            current = current.BaseType;
+        }
+        return false;
     }
 
     private static void GenerateSource(SourceProductionContext context, ImmutableArray<FieldInfo?> fields)
@@ -160,8 +247,25 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
 
         foreach (var group in fieldsByType)
         {
-            var firstField = group.First();
-            var source = GeneratePartialClass(firstField.Namespace, firstField.TypeName, group.ToList());
+            var fieldList = group.ToList();
+            var firstField = fieldList.First();
+            var reactiveFields = fieldList.Where(f => f.IsReactive).ToList();
+
+            // Report diagnostic if user has custom Dispose() but doesn't call DisposeReactiveFields()
+            if (reactiveFields.Count > 0 &&
+                firstField.InheritsFromReactiveViewModel &&
+                firstField.HasExistingDisposeMethod &&
+                !firstField.DisposeCallsDisposeReactiveFields &&
+                firstField.TypeLocation is not null)
+            {
+                var diagnostic = Diagnostic.Create(
+                    MustCallDisposeReactiveFields,
+                    firstField.TypeLocation,
+                    firstField.TypeName);
+                context.ReportDiagnostic(diagnostic);
+            }
+
+            var source = GeneratePartialClass(firstField.Namespace, firstField.TypeName, fieldList);
             context.AddSource($"{firstField.TypeName}.Reactive.g.cs", SourceText.From(source, Encoding.UTF8));
         }
     }
@@ -224,6 +328,20 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
             GenerateSetRouteParameters(sb, fromRouteFields);
         }
 
+        // Generate disposal method for reactive fields
+        if (reactiveFields.Count > 0)
+        {
+            GenerateDisposeReactiveFields(sb, reactiveFields);
+
+            // Generate Dispose() override for ReactiveViewModel subclasses
+            // (only if user hasn't already defined one)
+            var firstField = reactiveFields.First();
+            if (firstField.InheritsFromReactiveViewModel && !firstField.HasExistingDisposeMethod)
+            {
+                GenerateDisposeOverride(sb);
+            }
+        }
+
         sb.AppendLine("}");
 
         return sb.ToString();
@@ -275,6 +393,37 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
             sb.AppendLine($"            {field.FieldName} = ({field.FieldType}){field.FieldName}Value;");
         }
 
+        sb.AppendLine("    }");
+    }
+
+    private static void GenerateDisposeReactiveFields(StringBuilder sb, List<FieldInfo> reactiveFields)
+    {
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Disposes all BehaviorSubject backing fields generated by [Reactive] attributes.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    protected void DisposeReactiveFields()");
+        sb.AppendLine("    {");
+
+        foreach (var field in reactiveFields)
+        {
+            var subjectFieldName = $"{field.FieldName}Subject";
+            sb.AppendLine($"        {subjectFieldName}.Dispose();");
+        }
+
+        sb.AppendLine("    }");
+    }
+
+    private static void GenerateDisposeOverride(StringBuilder sb)
+    {
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Disposes reactive property backing fields and calls base disposal.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    public override void Dispose()");
+        sb.AppendLine("    {");
+        sb.AppendLine("        DisposeReactiveFields();");
+        sb.AppendLine("        base.Dispose();");
         sb.AppendLine("    }");
     }
 
@@ -330,6 +479,10 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
         public bool IsReactive { get; }
         public bool IsFromRoute { get; }
         public string? RouteParameterName { get; }
+        public bool InheritsFromReactiveViewModel { get; }
+        public bool HasExistingDisposeMethod { get; }
+        public bool DisposeCallsDisposeReactiveFields { get; }
+        public Location? TypeLocation { get; }
 
         public FieldInfo(
             string? @namespace,
@@ -340,7 +493,11 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
             string fullTypeName,
             bool isReactive,
             bool isFromRoute,
-            string? routeParameterName)
+            string? routeParameterName,
+            bool inheritsFromReactiveViewModel,
+            bool hasExistingDisposeMethod,
+            bool disposeCallsDisposeReactiveFields,
+            Location? typeLocation)
         {
             Namespace = @namespace;
             TypeName = typeName;
@@ -351,6 +508,10 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
             IsReactive = isReactive;
             IsFromRoute = isFromRoute;
             RouteParameterName = routeParameterName;
+            InheritsFromReactiveViewModel = inheritsFromReactiveViewModel;
+            HasExistingDisposeMethod = hasExistingDisposeMethod;
+            DisposeCallsDisposeReactiveFields = disposeCallsDisposeReactiveFields;
+            TypeLocation = typeLocation;
         }
     }
 }

--- a/src/Termina.Generators/Termina.Generators.csproj
+++ b/src/Termina.Generators/Termina.Generators.csproj
@@ -17,6 +17,9 @@
     <PublishAot>false</PublishAot>
     <PublishTrimmed>false</PublishTrimmed>
 
+    <!-- Suppress RS2008 - release tracking is overkill for a single diagnostic -->
+    <NoWarn>$(NoWarn);RS2008</NoWarn>
+
     <!-- NuGet packaging - package as analyzer, not as lib reference -->
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/tests/Termina.Tests/ReactiveViewModelTests.cs
+++ b/tests/Termina.Tests/ReactiveViewModelTests.cs
@@ -119,6 +119,83 @@ public class ReactiveViewModelTests
         Assert.True(vm.WasDeactivating);
     }
 
+    [Fact]
+    public void ReactiveViewModel_WithReactiveFields_HasDisposeReactiveFieldsMethod()
+    {
+        var vm = new TestReactiveViewModel();
+
+        // The generated DisposeReactiveFields method should be callable
+        // It's generated as protected, so we access it through Dispose()
+        Assert.NotNull(vm);
+        vm.Count = 5;
+        Assert.Equal(5, vm.Count);
+
+        // Dispose should call DisposeReactiveFields automatically
+        vm.Dispose();
+
+        // After disposal, setting a value should throw ObjectDisposedException
+        Assert.Throws<ObjectDisposedException>(() => vm.Count = 10);
+    }
+
+    [Fact]
+    public void ReactiveViewModel_WithReactiveFields_DisposesAllSubjects()
+    {
+        var vm = new TestReactiveViewModel();
+
+        // Set some values to ensure subjects are active
+        vm.Count = 42;
+        vm.Message = "Hello";
+
+        Assert.Equal(42, vm.Count);
+        Assert.Equal("Hello", vm.Message);
+
+        // Dispose the ViewModel
+        vm.Dispose();
+
+        // Both subjects should be disposed
+        Assert.Throws<ObjectDisposedException>(() => vm.Count = 1);
+        Assert.Throws<ObjectDisposedException>(() => vm.Message = "test");
+    }
+
+    [Fact]
+    public void ReactiveViewModel_WithReactiveFields_CannotSetValueAfterDispose()
+    {
+        var vm = new TestReactiveViewModel();
+        var valuesReceived = new List<int>();
+
+        // Subscribe to track values
+        vm.CountChanged.Subscribe(v => valuesReceived.Add(v));
+
+        // Set a value before dispose
+        vm.Count = 42;
+        Assert.Contains(42, valuesReceived);
+
+        // Dispose
+        vm.Dispose();
+
+        // Attempting to set value after dispose throws
+        Assert.Throws<ObjectDisposedException>(() => vm.Count = 100);
+    }
+
+    [Fact]
+    public void ReactiveViewModel_WithCustomDispose_CallsDisposeReactiveFields()
+    {
+        var vm = new TestReactiveViewModelWithCustomDispose();
+
+        // Set a value
+        vm.Value = 42;
+        Assert.Equal(42, vm.Value);
+
+        // Dispose
+        vm.Dispose();
+
+        // Custom dispose was called
+        Assert.True(vm.CustomDisposeWasCalled);
+
+        // Reactive fields were disposed (setting value throws)
+        Assert.Throws<ObjectDisposedException>(() => vm.Value = 100);
+    }
+
     private class TestViewModel : ReactiveViewModel
     {
         public bool WasActivated { get; private set; }
@@ -142,5 +219,33 @@ public class ReactiveViewModelTests
             base.OnDeactivating();
             WasDeactivating = true;
         }
+    }
+}
+
+/// <summary>
+/// Test ViewModel with [Reactive] fields to verify source generator disposal.
+/// This must be partial and outside the test class for the generator to work.
+/// </summary>
+public partial class TestReactiveViewModel : ReactiveViewModel
+{
+    [Reactive] private int _count;
+    [Reactive] private string _message = "Initial";
+}
+
+/// <summary>
+/// Test ViewModel with custom Dispose() that properly calls DisposeReactiveFields().
+/// This should NOT trigger TERMINA001 error.
+/// </summary>
+public partial class TestReactiveViewModelWithCustomDispose : ReactiveViewModel
+{
+    [Reactive] private int _value;
+
+    public bool CustomDisposeWasCalled { get; private set; }
+
+    public override void Dispose()
+    {
+        CustomDisposeWasCalled = true;
+        DisposeReactiveFields();
+        base.Dispose();
     }
 }

--- a/tests/Termina.Tests/Termina.Tests.csproj
+++ b/tests/Termina.Tests/Termina.Tests.csproj
@@ -20,6 +20,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Termina\Termina.csproj" />
+    <ProjectReference Include="..\..\src\Termina.Generators\Termina.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Fixes #47 - Auto-dispose `BehaviorSubject` backing fields generated by `[Reactive]` source generator.

- Generate `DisposeReactiveFields()` method for any class with `[Reactive]` fields
- Auto-generate `Dispose()` override for `ReactiveViewModel` subclasses that don't define their own
- Add TERMINA001 compiler error when a custom `Dispose()` doesn't call `DisposeReactiveFields()`

## Changes

### Generated code behavior

**For ReactiveViewModel subclasses (automatic disposal):**
```csharp
partial class CounterViewModel
{
    private readonly BehaviorSubject<int> _countSubject = new(0);
    public int Count { get => _countSubject.Value; set => _countSubject.OnNext(value); }
    public IObservable<int> CountChanged => _countSubject.AsObservable();

    protected void DisposeReactiveFields()
    {
        _countSubject.Dispose();
    }

    public override void Dispose()
    {
        DisposeReactiveFields();
        base.Dispose();
    }
}
```

**For classes with custom Dispose():**
If a `ReactiveViewModel` subclass defines its own `Dispose()` but doesn't call `DisposeReactiveFields()`, the build fails with:
```
error TERMINA001: Class 'ClassName' inherits from ReactiveViewModel and has [Reactive] fields, 
but defines a custom Dispose() method. You must call DisposeReactiveFields() in your Dispose() 
implementation to properly dispose generated BehaviorSubject backing fields.
```

## Test plan

- [x] Verify `DisposeReactiveFields()` is generated for classes with `[Reactive]` fields
- [x] Verify `Dispose()` override is auto-generated for `ReactiveViewModel` subclasses
- [x] Verify TERMINA001 error is raised when custom `Dispose()` doesn't call `DisposeReactiveFields()`
- [x] Verify no error when custom `Dispose()` properly calls `DisposeReactiveFields()`
- [x] All 463 tests pass