### PR TITLE
Migrate all events to IObservable<T> for pure reactive architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Termina Development Guidelines
+
+## Architectural Principles
+
+### Reactive-Only Pattern
+
+**Do NOT mix System.Reactive with .NET events.** Termina uses System.Reactive (Rx) throughout. All asynchronous communication, state changes, and notifications must use observables.
+
+- Use `IObservable<T>` for all event-like patterns
+- Use `Subject<T>`, `BehaviorSubject<T>`, or `ReplaySubject<T>` for event sources
+- Do NOT use `event Action` or `event EventHandler<T>`
+- The only exception is the existing `IInvalidatingNode.Invalidated` event (legacy - consider migrating)
+
+**Correct:**
+```csharp
+public IObservable<IReadOnlyList<T>> SelectionConfirmed => _selectionConfirmed.AsObservable();
+private readonly Subject<IReadOnlyList<T>> _selectionConfirmed = new();
+
+// To emit:
+_selectionConfirmed.OnNext(selectedItems);
+```
+
+**Incorrect:**
+```csharp
+public event Action<IReadOnlyList<T>>? SelectionConfirmed;  // NO - don't use events
+```
+
+### Fluent API Pattern
+
+All layout nodes use fluent builder pattern with `With*` methods that return `this`.
+
+### Constraint-Based Layout
+
+Use `SizeConstraint` (Fixed, Fill, Auto, Percent) for sizing rather than hardcoded values.

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
@@ -60,8 +60,10 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         ChatHistory.AppendLine("   Ask me anything and watch the streaming response!", foreground: Color.BrightBlack);
         ChatHistory.AppendLine("");
 
-        // Wire up submit event from the text input component
-        PromptInput.Submitted += HandleSubmit;
+        // Wire up submit observable from the text input component
+        PromptInput.Submitted
+            .Subscribe(HandleSubmit)
+            .DisposeWith(Subscriptions);
     }
 
     public override void OnActivated()

--- a/docs/components/text-input-node.md
+++ b/docs/components/text-input-node.md
@@ -9,7 +9,7 @@ var input = new TextInputNode()
     .WithPlaceholder("Enter text...");
 
 // Handle submission
-input.Submitted += text => Console.WriteLine($"Submitted: {text}");
+input.Submitted.Subscribe(text => Console.WriteLine($"Submitted: {text}"));
 ```
 
 ## Features
@@ -67,7 +67,7 @@ new TextInputNode()
 
 ## Handling Input
 
-TextInputNode exposes events and the `HandleInput` method for integration with your ViewModel:
+TextInputNode exposes observables and the `HandleInput` method for integration with your ViewModel:
 
 ```csharp
 public partial class MyViewModel : ReactiveViewModel
@@ -83,7 +83,9 @@ public partial class MyViewModel : ReactiveViewModel
             .DisposeWith(Subscriptions);
 
         // Handle submission
-        PromptInput.Submitted += OnSubmitted;
+        PromptInput.Submitted
+            .Subscribe(OnSubmitted)
+            .DisposeWith(Subscriptions);
     }
 
     private void OnSubmitted(string text)
@@ -94,13 +96,13 @@ public partial class MyViewModel : ReactiveViewModel
 }
 ```
 
-## Events
+## Observables
 
-| Event | Type | Description |
-|-------|------|-------------|
-| `TextChanged` | `Action<string>` | Fired when text changes |
-| `Submitted` | `Action<string>` | Fired when Enter is pressed |
-| `Invalidated` | `Action` | Fired when redraw is needed |
+| Observable | Type | Description |
+|------------|------|-------------|
+| `TextChanged` | `IObservable<string>` | Emits when text changes |
+| `Submitted` | `IObservable<string>` | Emits when Enter is pressed |
+| `Invalidated` | `IObservable<Unit>` | Emits when redraw is needed |
 
 ## API Reference
 

--- a/docs/tutorials/streaming-chat.md
+++ b/docs/tutorials/streaming-chat.md
@@ -59,8 +59,10 @@ public TextInputNode PromptInput { get; } = new TextInputNode()
     .WithPlaceholder("Enter your question...")
     .WithForeground(Color.Cyan);
 
-// Wire up submit event
-PromptInput.Submitted += HandleSubmit;
+// Wire up submit observable
+PromptInput.Submitted
+    .Subscribe(HandleSubmit)
+    .DisposeWith(Subscriptions);
 ```
 
 `TextInputNode` provides full text editing with cursor, selection, and history.
@@ -250,10 +252,12 @@ private void CancelGeneration()
 }
 ```
 
-### Input Component Events
+### Input Component Observables
 
 ```csharp
-PromptInput.Submitted += HandleSubmit;
+PromptInput.Submitted
+    .Subscribe(HandleSubmit)
+    .DisposeWith(Subscriptions);
 
 // In input handling:
 if (ChatHistory.HandleInput(keyInfo, viewportHeight: 10, viewportWidth: 80))

--- a/src/Termina/Layout/ConditionalNode.cs
+++ b/src/Termina/Layout/ConditionalNode.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
+using System.Reactive.Subjects;
 using Termina.Rendering;
 
 namespace Termina.Layout;
@@ -11,12 +13,13 @@ namespace Termina.Layout;
 public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
 {
     private readonly IDisposable _subscription;
+    private readonly Subject<Unit> _invalidated = new();
     private bool _condition;
     private readonly ILayoutNode _thenNode;
     private readonly ILayoutNode _elseNode;
 
     /// <inheritdoc />
-    public event Action? Invalidated;
+    public IObservable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Create a conditional node that shows/hides based on an observable condition.
@@ -35,7 +38,7 @@ public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
                 if (_condition != value)
                 {
                     _condition = value;
-                    Invalidated?.Invoke();
+                    _invalidated.OnNext(Unit.Default);
                 }
             },
             onError: _ => { },
@@ -60,6 +63,8 @@ public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
     public override void Dispose()
     {
         _subscription.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
         _thenNode.Dispose();
         _elseNode.Dispose();
         base.Dispose();

--- a/src/Termina/Layout/ILayoutNode.cs
+++ b/src/Termina/Layout/ILayoutNode.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using Termina.Rendering;
 
 namespace Termina.Layout;
@@ -55,9 +56,9 @@ public interface IContainerNode : ILayoutNode
 public interface IInvalidatingNode : ILayoutNode
 {
     /// <summary>
-    /// Raised when this node's content has changed and needs re-rendering.
+    /// Observable that emits when this node's content has changed and needs re-rendering.
     /// </summary>
-    event Action? Invalidated;
+    IObservable<Unit> Invalidated { get; }
 }
 
 /// <summary>

--- a/src/Termina/Layout/ReactiveLayoutNode.cs
+++ b/src/Termina/Layout/ReactiveLayoutNode.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Subjects;
 using Termina.Rendering;
 
 namespace Termina.Layout;
@@ -13,11 +15,12 @@ namespace Termina.Layout;
 public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
 {
     private readonly IDisposable _subscription;
+    private readonly Subject<Unit> _invalidated = new();
     private ILayoutNode _currentChild;
     private Size _lastMeasuredSize;
 
     /// <inheritdoc />
-    public event Action? Invalidated;
+    public IObservable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Create a reactive layout node from an observable of layout nodes.
@@ -32,7 +35,7 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
                 // Dispose old child
                 _currentChild.Dispose();
                 _currentChild = node;
-                Invalidated?.Invoke();
+                _invalidated.OnNext(Unit.Default);
             },
             onError: _ => { },
             onCompleted: () => { });
@@ -61,6 +64,8 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
     public override void Dispose()
     {
         _subscription.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
         _currentChild.Dispose();
         base.Dispose();
     }
@@ -73,10 +78,11 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
 {
     private readonly Func<T, ILayoutNode> _transform;
     private readonly IDisposable _subscription;
+    private readonly Subject<Unit> _invalidated = new();
     private ILayoutNode _currentChild;
 
     /// <inheritdoc />
-    public event Action? Invalidated;
+    public IObservable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Create a reactive layout node from an observable with a transform function.
@@ -91,7 +97,7 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
             {
                 _currentChild.Dispose();
                 _currentChild = _transform(value);
-                Invalidated?.Invoke();
+                _invalidated.OnNext(Unit.Default);
             },
             onError: _ => { },
             onCompleted: () => { });
@@ -118,6 +124,8 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
     public override void Dispose()
     {
         _subscription.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
         _currentChild.Dispose();
         base.Dispose();
     }

--- a/src/Termina/Layout/ScrollableContainerNode.cs
+++ b/src/Termina/Layout/ScrollableContainerNode.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Subjects;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -39,9 +42,11 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     private int _contentHeight;
     private int _viewportHeight;
     private int _previousContentHeight;
+    private readonly Subject<Unit> _invalidated = new();
+    private IDisposable? _contentSubscription;
 
     /// <inheritdoc />
-    public event Action? Invalidated;
+    public IObservable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Gets or sets the automatic scroll policy.
@@ -98,13 +103,15 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     /// </summary>
     public ScrollableContainerNode WithContent(ILayoutNode content)
     {
+        // Dispose previous subscription and content
+        _contentSubscription?.Dispose();
         _content.Dispose();
         _content = content;
 
-        // If content is invalidating, wire up the event
+        // If content is invalidating, subscribe to the observable
         if (_content is IInvalidatingNode invalidating)
         {
-            invalidating.Invalidated += OnContentInvalidated;
+            _contentSubscription = invalidating.Invalidated.Subscribe(_ => OnContentInvalidated());
         }
 
         return this;
@@ -146,7 +153,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
         if (CanScrollDown)
         {
             _scrollOffset++;
-            Invalidated?.Invoke();
+            _invalidated.OnNext(Unit.Default);
         }
     }
 
@@ -158,7 +165,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
         if (CanScrollUp)
         {
             _scrollOffset--;
-            Invalidated?.Invoke();
+            _invalidated.OnNext(Unit.Default);
         }
     }
 
@@ -171,7 +178,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
         if (newOffset != _scrollOffset)
         {
             _scrollOffset = newOffset;
-            Invalidated?.Invoke();
+            _invalidated.OnNext(Unit.Default);
         }
     }
 
@@ -184,7 +191,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
         if (newOffset != _scrollOffset)
         {
             _scrollOffset = newOffset;
-            Invalidated?.Invoke();
+            _invalidated.OnNext(Unit.Default);
         }
     }
 
@@ -197,7 +204,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
         if (newOffset != _scrollOffset)
         {
             _scrollOffset = newOffset;
-            Invalidated?.Invoke();
+            _invalidated.OnNext(Unit.Default);
         }
     }
 
@@ -221,7 +228,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     {
         // Content changed - check if we need to auto-scroll
         ApplyAutoScrollPolicy();
-        Invalidated?.Invoke();
+        _invalidated.OnNext(Unit.Default);
     }
 
     private void ApplyAutoScrollPolicy()
@@ -336,10 +343,9 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     /// <inheritdoc />
     public override void Dispose()
     {
-        if (_content is IInvalidatingNode invalidating)
-        {
-            invalidating.Invalidated -= OnContentInvalidated;
-        }
+        _contentSubscription?.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
         _content.Dispose();
         base.Dispose();
     }

--- a/src/Termina/Layout/SpinnerNode.cs
+++ b/src/Termina/Layout/SpinnerNode.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
+using System.Reactive.Subjects;
 using System.Timers;
 using Termina.Rendering;
 using Termina.Terminal;
@@ -62,6 +64,7 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     private readonly Timer _timer;
     private readonly string[] _frames;
+    private readonly Subject<Unit> _invalidated = new();
     private int _currentFrame;
 
     /// <summary>
@@ -80,7 +83,7 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     public Color? LabelColor { get; private set; }
 
     /// <inheritdoc />
-    public event Action? Invalidated;
+    public IObservable<Unit> Invalidated => _invalidated;
 
     /// <inheritdoc />
     public bool IsAnimating { get; private set; }
@@ -149,7 +152,7 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     private void OnTimerTick(object? sender, ElapsedEventArgs e)
     {
         _currentFrame = (_currentFrame + 1) % _frames.Length;
-        Invalidated?.Invoke();
+        _invalidated.OnNext(Unit.Default);
     }
 
     /// <inheritdoc />
@@ -203,6 +206,8 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     {
         _timer.Stop();
         _timer.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
         base.Dispose();
     }
 }

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -19,15 +19,15 @@ namespace Termina.Layout;
 public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
 {
     private readonly IStreamingTextBuffer _buffer;
-    private readonly Subject<Unit> _contentChanged = new();
+    private readonly Subject<Unit> _invalidated = new();
 
     /// <inheritdoc />
-    public event Action? Invalidated;
+    public IObservable<Unit> Invalidated => _invalidated;
 
     /// <summary>
-    /// Observable that emits when content changes.
+    /// Observable that emits when content changes. Alias for Invalidated.
     /// </summary>
-    public IObservable<Unit> ContentChanged => _contentChanged;
+    public IObservable<Unit> ContentChanged => _invalidated;
 
     /// <summary>
     /// Gets or sets the foreground color.
@@ -234,8 +234,7 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
 
     private void NotifyChanged()
     {
-        _contentChanged.OnNext(Unit.Default);
-        Invalidated?.Invoke();
+        _invalidated.OnNext(Unit.Default);
     }
 
     /// <summary>
@@ -354,8 +353,8 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
     /// <inheritdoc />
     public override void Dispose()
     {
-        _contentChanged.OnCompleted();
-        _contentChanged.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
         base.Dispose();
     }
 }

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
+using System.Reactive.Subjects;
 using System.Timers;
 using Termina.Rendering;
 using Termina.Terminal;
@@ -20,6 +22,9 @@ namespace Termina.Layout;
 public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 {
     private readonly Timer _cursorTimer;
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly Subject<string> _textChanged = new();
+    private readonly Subject<string> _submitted = new();
     private string _text = "";
     private int _cursorPosition;
     private int _selectionStart = -1;
@@ -28,17 +33,17 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     private bool _disposed;
 
     /// <inheritdoc />
-    public event Action? Invalidated;
+    public IObservable<Unit> Invalidated => _invalidated;
 
     /// <summary>
-    /// Event raised when the text value changes.
+    /// Observable that emits when the text value changes.
     /// </summary>
-    public event Action<string>? TextChanged;
+    public IObservable<string> TextChanged => _textChanged;
 
     /// <summary>
-    /// Event raised when Enter is pressed.
+    /// Observable that emits when Enter is pressed.
     /// </summary>
-    public event Action<string>? Submitted;
+    public IObservable<string> Submitted => _submitted;
 
     /// <inheritdoc />
     public bool IsAnimating { get; private set; }
@@ -56,8 +61,8 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
                 _text = value ?? "";
                 _cursorPosition = Math.Min(_cursorPosition, _text.Length);
                 _selectionStart = -1;
-                TextChanged?.Invoke(_text);
-                Invalidated?.Invoke();
+                _textChanged.OnNext(_text);
+                _invalidated.OnNext(Unit.Default);
             }
         }
     }
@@ -204,14 +209,14 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             _cursorTimer.Stop();
             IsAnimating = false;
             _cursorVisible = false;
-            Invalidated?.Invoke();
+            _invalidated.OnNext(Unit.Default);
         }
     }
 
     private void OnCursorBlink(object? sender, ElapsedEventArgs e)
     {
         _cursorVisible = !_cursorVisible;
-        Invalidated?.Invoke();
+        _invalidated.OnNext(Unit.Default);
     }
 
     /// <summary>
@@ -246,7 +251,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
         if (handled)
         {
-            Invalidated?.Invoke();
+            _invalidated.OnNext(Unit.Default);
         }
 
         return handled;
@@ -289,7 +294,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         // Insert character
         _text = _text.Insert(_cursorPosition, c.ToString());
         _cursorPosition++;
-        TextChanged?.Invoke(_text);
+        _textChanged.OnNext(_text);
         return true;
     }
 
@@ -298,7 +303,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         if (HasSelection)
         {
             DeleteSelection();
-            TextChanged?.Invoke(_text);
+            _textChanged.OnNext(_text);
             return true;
         }
 
@@ -319,7 +324,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             _cursorPosition--;
         }
 
-        TextChanged?.Invoke(_text);
+        _textChanged.OnNext(_text);
         return true;
     }
 
@@ -328,7 +333,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         if (HasSelection)
         {
             DeleteSelection();
-            TextChanged?.Invoke(_text);
+            _textChanged.OnNext(_text);
             return true;
         }
 
@@ -347,7 +352,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             _text = _text.Remove(_cursorPosition, 1);
         }
 
-        TextChanged?.Invoke(_text);
+        _textChanged.OnNext(_text);
         return true;
     }
 
@@ -425,8 +430,8 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     private bool HandleEnter()
     {
-        // Just fire the event - ViewModel decides what to do (add to history, clear text, etc.)
-        Submitted?.Invoke(_text);
+        // Emit to observable - ViewModel decides what to do (add to history, clear text, etc.)
+        _submitted.OnNext(_text);
         return true;
     }
 
@@ -440,8 +445,8 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         _cursorPosition = 0;
         _selectionStart = -1;
         _scrollOffset = 0;
-        TextChanged?.Invoke(_text);
-        Invalidated?.Invoke();
+        _textChanged.OnNext(_text);
+        _invalidated.OnNext(Unit.Default);
     }
 
     private bool HandleEscape()
@@ -456,7 +461,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         {
             _text = "";
             _cursorPosition = 0;
-            TextChanged?.Invoke(_text);
+            _textChanged.OnNext(_text);
             return true;
         }
 
@@ -646,6 +651,14 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         _disposed = true;
         _cursorTimer.Stop();
         _cursorTimer.Dispose();
+
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        _textChanged.OnCompleted();
+        _textChanged.Dispose();
+        _submitted.OnCompleted();
+        _submitted.Dispose();
+
         base.Dispose();
     }
 }

--- a/src/Termina/Rendering/ScrollableContent.cs
+++ b/src/Termina/Rendering/ScrollableContent.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
+using System.Reactive.Subjects;
 using Termina.Terminal;
 
 namespace Termina.Rendering;
@@ -8,10 +10,11 @@ namespace Termina.Rendering;
 /// <summary>
 /// A container that provides vertical scrolling for content that exceeds the viewport height.
 /// </summary>
-public sealed class ScrollableContent : IRenderable
+public sealed class ScrollableContent : IRenderable, IDisposable
 {
     private string[] _lines = Array.Empty<string>();
     private int _viewportHeight;
+    private readonly Subject<Unit> _dirty = new();
 
     /// <summary>
     /// Gets or sets the renderable content.
@@ -70,9 +73,9 @@ public sealed class ScrollableContent : IRenderable
     public bool CanScrollUp => ScrollOffset > 0;
 
     /// <summary>
-    /// Event raised when the component needs to be re-rendered.
+    /// Observable that emits when the component needs to be re-rendered.
     /// </summary>
-    public event Action? OnDirty;
+    public IObservable<Unit> Dirty => _dirty;
 
     /// <summary>
     /// Set the content as an array of text lines.
@@ -278,7 +281,17 @@ public sealed class ScrollableContent : IRenderable
 
     private void MarkDirty()
     {
-        OnDirty?.Invoke();
+        _dirty.OnNext(Unit.Default);
+    }
+
+    /// <summary>
+    /// Disposes the component.
+    /// </summary>
+    public void Dispose()
+    {
+        _dirty.OnCompleted();
+        _dirty.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>

--- a/src/Termina/Rendering/TextInput.cs
+++ b/src/Termina/Rendering/TextInput.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
+using System.Reactive.Subjects;
 using Termina.Terminal;
 
 namespace Termina.Rendering;
@@ -22,15 +24,19 @@ public sealed class TextInput : IRenderable, IDisposable
     private bool _cursorVisible = true;
     private int _blinkIntervalMs = 530; // Standard cursor blink rate
 
-    /// <summary>
-    /// Event raised when Enter is pressed.
-    /// </summary>
-    public event Action<string>? OnSubmit;
+    // Reactive observables
+    private readonly Subject<string> _submitted = new();
+    private readonly Subject<Unit> _dirty = new();
 
     /// <summary>
-    /// Event raised when the component needs to be re-rendered.
+    /// Observable that emits when Enter is pressed, providing the submitted text.
     /// </summary>
-    public event Action? OnDirty;
+    public IObservable<string> Submitted => _submitted;
+
+    /// <summary>
+    /// Observable that emits when the component needs to be re-rendered.
+    /// </summary>
+    public IObservable<Unit> Dirty => _dirty;
 
     /// <summary>
     /// Gets or sets the label displayed before the input.
@@ -162,7 +168,7 @@ public sealed class TextInput : IRenderable, IDisposable
         switch (key.Key)
         {
             case ConsoleKey.Enter:
-                OnSubmit?.Invoke(_text);
+                _submitted.OnNext(_text);
                 return true;
 
             case ConsoleKey.Backspace:
@@ -349,7 +355,7 @@ public sealed class TextInput : IRenderable, IDisposable
     /// </summary>
     private void MarkDirty()
     {
-        OnDirty?.Invoke();
+        _dirty.OnNext(Unit.Default);
     }
 
     /// <summary>
@@ -402,6 +408,10 @@ public sealed class TextInput : IRenderable, IDisposable
     public void Dispose()
     {
         StopBlinking();
+        _submitted.OnCompleted();
+        _submitted.Dispose();
+        _dirty.OnCompleted();
+        _dirty.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/tests/Termina.Tests/Layout/StreamingTextNodeStyledTests.cs
+++ b/tests/Termina.Tests/Layout/StreamingTextNodeStyledTests.cs
@@ -157,7 +157,7 @@ public class StreamingTextNodeStyledTests
     {
         var node = StreamingTextNode.Create();
         var fired = false;
-        node.Invalidated += () => fired = true;
+        node.Invalidated.Subscribe(_ => fired = true);
 
         node.Append("Hello", foreground: Color.Red);
 

--- a/tests/Termina.Tests/Layout/TextInputNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextInputNodeTests.cs
@@ -68,7 +68,7 @@ public class TextInputNodeTests : IDisposable
     public void Submitted_EventFired_OnEnter()
     {
         string? submittedText = null;
-        _node.Submitted += text => submittedText = text;
+        _node.Submitted.Subscribe(text => submittedText = text);
 
         TypeText("test submission");
         _node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
@@ -80,7 +80,7 @@ public class TextInputNodeTests : IDisposable
     public void TextChanged_EventFired_OnCharacterInput()
     {
         var changeCount = 0;
-        _node.TextChanged += _ => changeCount++;
+        _node.TextChanged.Subscribe(_ => changeCount++);
 
         TypeText("abc");
 
@@ -93,7 +93,7 @@ public class TextInputNodeTests : IDisposable
         TypeText("test");
 
         string? changedText = null;
-        _node.TextChanged += text => changedText = text;
+        _node.TextChanged.Subscribe(text => changedText = text);
 
         _node.Clear();
 

--- a/tests/Termina.Tests/Rendering/TextInputTests.cs
+++ b/tests/Termina.Tests/Rendering/TextInputTests.cs
@@ -263,7 +263,7 @@ public class TextInputTests
     {
         var input = new TextInput { IsFocused = true, Text = "Hello" };
         string? submittedText = null;
-        input.OnSubmit += text => submittedText = text;
+        input.Submitted.Subscribe(text => submittedText = text);
 
         var handled = input.HandleKey(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
 
@@ -449,7 +449,7 @@ public class TextInputTests
     {
         var input = new TextInput();
         var dirtyCount = 0;
-        input.OnDirty += () => dirtyCount++;
+        input.Dirty.Subscribe(_ => dirtyCount++);
 
         input.IsFocused = true;
 
@@ -461,7 +461,7 @@ public class TextInputTests
     {
         var input = new TextInput { IsFocused = true };
         var dirtyCount = 0;
-        input.OnDirty += () => dirtyCount++;
+        input.Dirty.Subscribe(_ => dirtyCount++);
 
         input.IsFocused = false;
 


### PR DESCRIPTION
## Summary

This PR establishes a consistent reactive-only pattern throughout Termina by migrating all .NET events to `IObservable<T>` using System.Reactive Subjects.

**This is a breaking change** - consumers using `+=` event subscriptions must migrate to `.Subscribe()`.

### Changes

**Interface changes:**
- `IInvalidatingNode.Invalidated`: `event Action?` → `IObservable<Unit>`

**Layout nodes migrated:**
- `TextInputNode`: `Submitted`, `TextChanged`, `Invalidated` → observables
- `SpinnerNode`, `ConditionalNode`, `ReactiveLayoutNode`: use `Subject<Unit>`
- `ScrollableContainerNode`: migrated with proper subscription management  
- `StreamingTextNode`: `ContentChanged` now alias for `Invalidated` observable

**Rendering classes migrated:**
- `TextInput`: `OnSubmit` → `Submitted`, `OnDirty` → `Dirty`
- `ScrollableContent`: `OnDirty` → `Dirty`, now implements `IDisposable`

**Documentation & guidelines:**
- Added `CLAUDE.md` establishing architectural principle: no mixing System.Reactive with .NET events
- Updated docs and tutorials with observable patterns

### Migration Guide

Before:
```csharp
input.Submitted += HandleSubmit;
node.Invalidated += () => RequestRedraw();
```

After:
```csharp
input.Submitted
    .Subscribe(HandleSubmit)
    .DisposeWith(Subscriptions);
    
node.Invalidated
    .Subscribe(_ => RequestRedraw())
    .DisposeWith(Subscriptions);
```

## Test plan

- [x] All 463 existing tests pass
- [x] Demo project builds and runs correctly
- [x] Documentation updated with new patterns

Preparatory work for #43