### PR TITLE
Add focus management system, ModalNode, and SelectionListNode components

### DIFF
--- a/demos/Termina.Demo/Pages/TodoListPage.cs
+++ b/demos/Termina.Demo/Pages/TodoListPage.cs
@@ -43,24 +43,25 @@ public class TodoListPage : ReactivePage<TodoListViewModel>
 
         // Build the layer with modal overlays
         // The stack layout renders children in order, with later children on top
+        //
+        // We use Layouts.Deferred() because modals are created in OnActivated (which runs
+        // after BuildLayout) and we don't want the modal to be disposed when hidden.
         return Layouts.Stack()
             .WithChild(mainContent)
             .WithChild(
                 // Show add modal when IsAddingItem is true and ShowPriorityModal is false
                 ViewModel.IsAddingItemChanged
-                    .CombineLatest(ViewModel.ShowPriorityModalChanged, (adding, showPriority) => (adding, showPriority))
-                    .Select(state =>
-                        state.adding && !state.showPriority && ViewModel.AddModal != null
-                            ? (ILayoutNode)ViewModel.AddModal
-                            : Layouts.Empty())
+                    .CombineLatest(ViewModel.ShowPriorityModalChanged, (adding, showPriority) => adding && !showPriority)
+                    .Select(showModal => showModal
+                        ? Layouts.Deferred(() => ViewModel.AddModal)
+                        : (ILayoutNode)Layouts.Empty())
                     .AsLayout())
             .WithChild(
                 // Show priority selection modal when ShowPriorityModal is true
                 ViewModel.ShowPriorityModalChanged
-                    .Select(showPriority =>
-                        showPriority && ViewModel.PriorityModal != null
-                            ? (ILayoutNode)ViewModel.PriorityModal
-                            : Layouts.Empty())
+                    .Select(showPriority => showPriority
+                        ? Layouts.Deferred(() => ViewModel.PriorityModal)
+                        : (ILayoutNode)Layouts.Empty())
                     .AsLayout());
     }
 

--- a/demos/Termina.Demo/Pages/TodoListPage.cs
+++ b/demos/Termina.Demo/Pages/TodoListPage.cs
@@ -12,13 +12,14 @@ namespace Termina.Demo.Pages;
 
 /// <summary>
 /// Page for the todo list demo.
-/// Demonstrates list components and state binding with the new declarative layout API.
+/// Demonstrates list components and state binding with modal dialogs.
 /// </summary>
 public class TodoListPage : ReactivePage<TodoListViewModel>
 {
     public override ILayoutNode BuildLayout()
     {
-        return Layouts.Vertical()
+        // Build the main content
+        var mainContent = Layouts.Vertical()
             .WithChild(
                 new PanelNode()
                     .WithTitle("Todo List Demo")
@@ -31,33 +32,36 @@ public class TodoListPage : ReactivePage<TodoListViewModel>
                             .AsLayout())
                     .Fill())
             .WithChild(
-                // Show text input row when adding, otherwise show help text
-                ViewModel.IsAddingItemChanged
-                    .CombineLatest(ViewModel.NewItemTextChanged, (isAdding, text) => (isAdding, text))
-                    .Select(tuple => tuple.isAdding
-                        ? BuildTextInputRow(tuple.text)
-                        : new TextNode("[↑/↓] Navigate [Space] Toggle [A] Add [D] Delete [C] Counter [Q] Quit")
-                            .WithForeground(Color.BrightBlack))
-                    .AsLayout()
+                new TextNode("[↑/↓] Navigate [Space] Toggle [A] Add [D] Delete [C] Counter [Q] Quit")
+                    .WithForeground(Color.BrightBlack)
                     .Height(1))
             .WithChild(
                 ViewModel.StatusMessageChanged
                     .Select(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
                     .Height(1));
-    }
 
-    private static ILayoutNode BuildTextInputRow(string text)
-    {
-        return Layouts.Horizontal()
+        // Build the layer with modal overlays
+        // The stack layout renders children in order, with later children on top
+        return Layouts.Stack()
+            .WithChild(mainContent)
             .WithChild(
-                new TextNode("New task: ")
-                    .WithForeground(Color.Yellow)
-                    .Width(11))
+                // Show add modal when IsAddingItem is true and ShowPriorityModal is false
+                ViewModel.IsAddingItemChanged
+                    .CombineLatest(ViewModel.ShowPriorityModalChanged, (adding, showPriority) => (adding, showPriority))
+                    .Select(state =>
+                        state.adding && !state.showPriority && ViewModel.AddModal != null
+                            ? (ILayoutNode)ViewModel.AddModal
+                            : Layouts.Empty())
+                    .AsLayout())
             .WithChild(
-                new TextNode(text + "▌")
-                    .WithForeground(Color.White)
-                    .Fill());
+                // Show priority selection modal when ShowPriorityModal is true
+                ViewModel.ShowPriorityModalChanged
+                    .Select(showPriority =>
+                        showPriority && ViewModel.PriorityModal != null
+                            ? (ILayoutNode)ViewModel.PriorityModal
+                            : Layouts.Empty())
+                    .AsLayout());
     }
 
     private static ILayoutNode BuildTodoList(IReadOnlyList<TodoItem> items, int selectedIndex)

--- a/demos/Termina.Demo/Pages/TodoListViewModel.cs
+++ b/demos/Termina.Demo/Pages/TodoListViewModel.cs
@@ -1,12 +1,14 @@
 using System.Reactive.Linq;
 using Termina.Input;
+using Termina.Layout;
 using Termina.Reactive;
+using Termina.Rendering;
 
 namespace Termina.Demo.Pages;
 
 /// <summary>
 /// ViewModel for a todo list demo.
-/// Demonstrates list selection and state management.
+/// Demonstrates list selection and state management with modal dialogs.
 /// </summary>
 public partial class TodoListViewModel : ReactiveViewModel
 {
@@ -22,6 +24,14 @@ public partial class TodoListViewModel : ReactiveViewModel
     [Reactive] private string _statusMessage = "Navigate with ↑/↓, Space to toggle, C for counter, Q to quit";
     [Reactive] private bool _isAddingItem;
     [Reactive] private string _newItemText = "";
+    [Reactive] private bool _showPriorityModal;
+    [Reactive] private string _pendingTaskText = "";
+
+    // Modal and selection list instances (created once, reused)
+    private ModalNode? _addModal;
+    private ModalNode? _priorityModal;
+    private SelectionListNode<string>? _priorityList;
+    private TextInputNode? _textInput;
 
     public override void OnActivated()
     {
@@ -29,7 +39,104 @@ public partial class TodoListViewModel : ReactiveViewModel
         Input.OfType<KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
+
+        // Create the text input for the add modal
+        _textInput = new TextInputNode()
+            .WithPlaceholder("Enter task description...");
+
+        // Subscribe to text input submission
+        _textInput.Submitted
+            .Subscribe(text =>
+            {
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    PendingTaskText = text.Trim();
+                    ShowPrioritySelection();
+                }
+                else
+                {
+                    CancelAddItem();
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        // Create priority selection list
+        _priorityList = Layouts.SelectionList("High", "Medium", "Low")
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Terminal.Color.Black, Terminal.Color.Cyan)
+            .WithOtherOption("Custom priority...");
+
+        // Subscribe to priority selection
+        _priorityList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                var priority = selected.FirstOrDefault() ?? "Normal";
+                AddNewItem(PendingTaskText, priority);
+            })
+            .DisposeWith(Subscriptions);
+
+        _priorityList.OtherSelected
+            .Subscribe(customPriority =>
+            {
+                AddNewItem(PendingTaskText, customPriority);
+            })
+            .DisposeWith(Subscriptions);
+
+        _priorityList.Cancelled
+            .Subscribe(_ =>
+            {
+                // Go back to text input
+                ShowPriorityModal = false;
+                Focus.PopFocus();
+            })
+            .DisposeWith(Subscriptions);
+
+        // Create modals
+        _addModal = Layouts.Modal()
+            .WithTitle("Add New Task")
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Terminal.Color.Cyan)
+            .WithBackdrop(BackdropStyle.Dim)
+            .WithPosition(ModalPosition.Center)
+            .WithPadding(1)
+            .WithContent(_textInput)
+            .WithDismissOnEscape(true);
+
+        _addModal.Dismissed
+            .Subscribe(_ => CancelAddItem())
+            .DisposeWith(Subscriptions);
+
+        _priorityModal = Layouts.Modal()
+            .WithTitle("Select Priority")
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Terminal.Color.Yellow)
+            .WithBackdrop(BackdropStyle.Dim)
+            .WithPosition(ModalPosition.Center)
+            .WithPadding(1)
+            .WithContent(_priorityList)
+            .WithDismissOnEscape(true);
+
+        _priorityModal.Dismissed
+            .Subscribe(_ =>
+            {
+                ShowPriorityModal = false;
+                IsAddingItem = false;
+                Focus.PopFocus();
+                StatusMessage = "Cancelled adding item";
+            })
+            .DisposeWith(Subscriptions);
     }
+
+    /// <summary>
+    /// Gets the modal for adding items (used by the Page).
+    /// </summary>
+    public ModalNode? AddModal => _addModal;
+
+    /// <summary>
+    /// Gets the modal for priority selection (used by the Page).
+    /// </summary>
+    public ModalNode? PriorityModal => _priorityModal;
 
     private void HandleKeyPress(KeyPressed key)
     {
@@ -109,8 +216,49 @@ public partial class TodoListViewModel : ReactiveViewModel
     private void StartAddingItem()
     {
         IsAddingItem = true;
+        ShowPriorityModal = false;
         NewItemText = "";
-        StatusMessage = "Type task name, Enter to add, Escape to cancel";
+        PendingTaskText = "";
+        _textInput?.Clear();
+        StatusMessage = "Enter task name and press Enter, or Escape to cancel";
+
+        // Push focus to the modal for keyboard input
+        if (_addModal != null)
+        {
+            Focus.PushFocus(_addModal);
+        }
+    }
+
+    private void ShowPrioritySelection()
+    {
+        ShowPriorityModal = true;
+
+        // Switch focus from text input modal to priority modal
+        Focus.PopFocus(); // Remove add modal focus
+
+        if (_priorityModal != null && _priorityList != null)
+        {
+            Focus.PushFocus(_priorityModal);
+            Focus.PushFocus(_priorityList); // Selection list needs focus for keyboard input
+        }
+
+        StatusMessage = "Select priority with ↑/↓ or number keys, Enter to confirm";
+    }
+
+    private void AddNewItem(string description, string priority)
+    {
+        var newItems = Items.ToList();
+        var displayText = priority != "Normal" ? $"[{priority}] {description}" : description;
+        newItems.Add(new TodoItem(displayText, false));
+        Items = newItems;
+        SelectedIndex = Items.Count - 1;
+        StatusMessage = $"Added: {displayText}";
+
+        // Clean up modal state
+        ShowPriorityModal = false;
+        IsAddingItem = false;
+        PendingTaskText = "";
+        Focus.ClearFocus();
     }
 
     private void ConfirmAddItem()
@@ -135,7 +283,10 @@ public partial class TodoListViewModel : ReactiveViewModel
     private void CancelAddItem()
     {
         IsAddingItem = false;
+        ShowPriorityModal = false;
         NewItemText = "";
+        PendingTaskText = "";
+        Focus.ClearFocus();
         StatusMessage = "Cancelled adding item";
     }
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,13 +46,16 @@ export default defineConfig({
         { text: 'TextNode', link: '/components/text-node' },
         { text: 'PanelNode', link: '/components/panel-node' },
         { text: 'TextInputNode', link: '/components/text-input-node' },
+        { text: 'SelectionListNode', link: '/components/selection-list-node' },
         { text: 'SpinnerNode', link: '/components/spinner-node' },
         { text: 'StreamingTextNode', link: '/components/streaming-text-node' },
         { text: 'ScrollableContainer', link: '/components/scrollable-container' },
         { text: 'StackLayout', link: '/components/stack-layout' },
+        { text: 'ModalNode', link: '/components/modal-node' },
         { text: 'ReactiveLayoutNode', link: '/components/reactive-layout' },
         { text: 'ConditionalNode', link: '/components/conditional-node' },
-        { text: 'EmptyNode', link: '/components/empty-node' }
+        { text: 'EmptyNode', link: '/components/empty-node' },
+        { text: 'DeferredNode', link: '/components/deferred-node' }
       ],
       '/styling/': [
         { text: 'Styling Guide', link: '/styling/' },

--- a/docs/components/deferred-node.md
+++ b/docs/components/deferred-node.md
@@ -1,0 +1,147 @@
+# DeferredNode
+
+A layout node that delegates to another node without owning or disposing it. Essential for showing/hiding modals and other components that should persist across layout changes.
+
+## The Problem
+
+When using reactive layouts with `AsLayout()`, the previous layout node is disposed whenever a new value is emitted:
+
+```csharp
+// Problem: Modal gets disposed when hidden!
+ViewModel.ShowModalChanged
+    .Select(show => show ? ViewModel.Modal : Layouts.Empty())
+    .AsLayout()  // When show becomes false, Modal is disposed!
+```
+
+This causes `ObjectDisposedException` when you try to show the modal again.
+
+## The Solution
+
+`DeferredNode` wraps access to a node without taking ownership:
+
+```csharp
+// Solution: Use Layouts.Deferred()
+ViewModel.ShowModalChanged
+    .Select(show => show
+        ? Layouts.Deferred(() => ViewModel.Modal)  // Doesn't dispose the modal
+        : (ILayoutNode)Layouts.Empty())
+    .AsLayout()
+```
+
+## Basic Usage
+
+```csharp
+// Create a node you want to reuse
+var modal = Layouts.Modal()
+    .WithTitle("My Modal")
+    .WithContent(content);
+
+// In your layout, wrap it with Deferred
+var layout = Layouts.Stack()
+    .WithChild(mainContent)
+    .WithChild(
+        showModalObservable
+            .Select(show => show
+                ? Layouts.Deferred(() => modal)
+                : (ILayoutNode)Layouts.Empty())
+            .AsLayout());
+```
+
+## How It Works
+
+- `DeferredNode` calls the provided factory function on each render
+- When `DeferredNode` is disposed (layout changes), it does NOT dispose the underlying node
+- The underlying node's lifecycle is managed by its owner (typically a ViewModel)
+
+## Complete Example
+
+```csharp
+public partial class MyViewModel : ReactiveViewModel
+{
+    [Reactive] private bool _showConfirmation;
+
+    private ModalNode? _confirmModal;
+
+    public ModalNode? ConfirmModal => _confirmModal;
+
+    public override void OnActivated()
+    {
+        _confirmModal = Layouts.Modal()
+            .WithTitle("Confirm")
+            .WithContent(new TextNode("Are you sure?"));
+
+        _confirmModal.Dismissed
+            .Subscribe(_ => ShowConfirmation = false)
+            .DisposeWith(Subscriptions);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        // ViewModel owns the modal and disposes it here
+        _confirmModal?.Dispose();
+        base.Dispose(disposing);
+    }
+}
+
+public class MyPage : ReactivePage<MyViewModel>
+{
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Stack()
+            .WithChild(BuildMainContent())
+            .WithChild(
+                // Deferred prevents disposal when modal is hidden
+                ViewModel.ShowConfirmationChanged
+                    .Select(show => show
+                        ? Layouts.Deferred(() => ViewModel.ConfirmModal)
+                        : (ILayoutNode)Layouts.Empty())
+                    .AsLayout());
+    }
+}
+```
+
+## When to Use DeferredNode
+
+Use `Layouts.Deferred()` when:
+
+1. **Modals** - Components that show/hide but should retain state
+2. **Tabs or panels** - Content that switches but shouldn't reset
+3. **Cached views** - Pre-rendered content you want to reuse
+4. **Any node owned by ViewModel** - Where lifecycle is managed externally
+
+## When NOT to Use DeferredNode
+
+Don't use `Layouts.Deferred()` when:
+
+1. **Creating new nodes each time** - Just return the node directly
+2. **Nodes should be recreated** - Fresh state on each show
+3. **Simple conditional content** - Use `When.True()` or `ConditionalNode`
+
+## API Reference
+
+### Factory Method
+
+```csharp
+Layouts.Deferred(Func<ILayoutNode?> getNode)
+```
+
+### Behavior
+
+| Method | DeferredNode Behavior |
+|--------|----------------------|
+| `Measure()` | Delegates to underlying node |
+| `Render()` | Delegates to underlying node |
+| `Dispose()` | Does nothing - node is NOT disposed |
+
+### Properties
+
+| Property | Behavior |
+|----------|----------|
+| `WidthConstraint` | Returns underlying node's constraint (or AutoSize if null) |
+| `HeightConstraint` | Returns underlying node's constraint (or AutoSize if null) |
+
+## Source Code
+
+::: details View DeferredNode implementation
+<<< @/../src/Termina/Layout/DeferredNode.cs{csharp}
+:::

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -16,6 +16,7 @@ Termina provides a set of built-in layout nodes (components) for building termin
 | Component | Description |
 |-----------|-------------|
 | [TextInputNode](/components/text-input-node) | Single-line text input with cursor |
+| [SelectionListNode](/components/selection-list-node) | Interactive list selection with keyboard navigation |
 
 ## Container Components
 
@@ -23,6 +24,7 @@ Termina provides a set of built-in layout nodes (components) for building termin
 |-----------|-------------|
 | [ScrollableContainer](/components/scrollable-container) | Vertical scrolling container |
 | [StackLayout](/components/stack-layout) | Overlapping children (z-stack) |
+| [ModalNode](/components/modal-node) | Modal overlay with backdrop |
 
 ## Reactive Components
 
@@ -36,6 +38,7 @@ Termina provides a set of built-in layout nodes (components) for building termin
 | Component | Description |
 |-----------|-------------|
 | [EmptyNode](/components/empty-node) | Placeholder that renders nothing |
+| [DeferredNode](/components/deferred-node) | Delegates to node without owning it |
 
 ## Common Patterns
 

--- a/docs/components/modal-node.md
+++ b/docs/components/modal-node.md
@@ -1,0 +1,231 @@
+# ModalNode
+
+A modal overlay component that displays content over the rest of the UI with configurable backdrop, borders, and positioning.
+
+## Basic Usage
+
+```csharp
+var modal = Layouts.Modal()
+    .WithTitle("Confirm Action")
+    .WithContent(new TextNode("Are you sure?"))
+    .WithBorder(BorderStyle.Rounded)
+    .WithBackdrop(BackdropStyle.Dim);
+
+// Show modal by pushing focus
+Focus.PushFocus(modal);
+
+// Handle dismissal
+modal.Dismissed.Subscribe(_ => {
+    Focus.PopFocus();
+    // Handle cancel...
+});
+```
+
+## Features
+
+- Captures all keyboard input when focused (high priority = 100)
+- Configurable backdrop (transparent, dim, solid)
+- Multiple positioning options (center, top, bottom)
+- Border styles matching PanelNode
+- Forwards input to focusable content
+- Escape key dismissal (configurable)
+
+## Backdrop Styles
+
+```csharp
+// Semi-transparent dim effect (default)
+Layouts.Modal().WithBackdrop(BackdropStyle.Dim)
+// ░░░░░░░░░░░░░░░░░
+// ░░╭─ Modal ─╮░░░░
+// ░░│ Content │░░░░
+// ░░╰─────────╯░░░░
+// ░░░░░░░░░░░░░░░░░
+
+// Solid background (fully obscures content)
+Layouts.Modal()
+    .WithBackdrop(BackdropStyle.Solid)
+    .WithBackdropColor(Color.DarkGray)
+
+// Transparent (no backdrop)
+Layouts.Modal().WithBackdrop(BackdropStyle.Transparent)
+```
+
+## Positioning
+
+```csharp
+// Centered (default)
+Layouts.Modal().WithPosition(ModalPosition.Center)
+
+// Near top of screen
+Layouts.Modal().WithPosition(ModalPosition.Top)
+
+// Near bottom of screen
+Layouts.Modal().WithPosition(ModalPosition.Bottom)
+```
+
+## Styling
+
+```csharp
+Layouts.Modal()
+    .WithTitle("Settings")
+    .WithTitleColor(Color.Cyan)
+    .WithBorder(BorderStyle.Double)
+    .WithBorderColor(Color.Blue)
+    .WithBackdrop(BackdropStyle.Dim)
+    .WithBackdropColor(Color.BrightBlack)
+    .WithBackdropChar('░')
+    .WithPadding(2)
+    .WithContent(content)
+```
+
+## With Interactive Content
+
+Modals forward keyboard input to focusable content like TextInputNode or SelectionListNode:
+
+```csharp
+var textInput = new TextInputNode()
+    .WithPlaceholder("Enter name...");
+
+var modal = Layouts.Modal()
+    .WithTitle("Enter Your Name")
+    .WithContent(textInput);
+
+// Handle text submission
+textInput.Submitted.Subscribe(name => {
+    Focus.PopFocus();
+    ProcessName(name);
+});
+
+// Show modal
+Focus.PushFocus(modal);
+```
+
+## Complete Example
+
+Here's a real-world example from a todo list application:
+
+```csharp
+public partial class MyViewModel : ReactiveViewModel
+{
+    private ModalNode? _confirmModal;
+    private TextInputNode? _textInput;
+
+    public ModalNode? ConfirmModal => _confirmModal;
+
+    public override void OnActivated()
+    {
+        // Create text input
+        _textInput = new TextInputNode()
+            .WithPlaceholder("Enter task description...");
+
+        _textInput.Submitted
+            .Subscribe(text => {
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    AddTask(text);
+                }
+                HideModal();
+            })
+            .DisposeWith(Subscriptions);
+
+        // Create modal
+        _confirmModal = Layouts.Modal()
+            .WithTitle("Add New Task")
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Color.Cyan)
+            .WithBackdrop(BackdropStyle.Dim)
+            .WithPadding(1)
+            .WithContent(_textInput)
+            .WithDismissOnEscape(true);
+
+        _confirmModal.Dismissed
+            .Subscribe(_ => HideModal())
+            .DisposeWith(Subscriptions);
+    }
+
+    private void ShowModal()
+    {
+        IsShowingModal = true;
+        _textInput?.Clear();
+        Focus.PushFocus(_confirmModal!);
+    }
+
+    private void HideModal()
+    {
+        IsShowingModal = false;
+        Focus.PopFocus();
+    }
+}
+```
+
+In your page, use `Layouts.Deferred()` to prevent modal disposal when hidden:
+
+```csharp
+public override ILayoutNode BuildLayout()
+{
+    return Layouts.Stack()
+        .WithChild(mainContent)
+        .WithChild(
+            ViewModel.IsShowingModalChanged
+                .Select(show => show
+                    ? Layouts.Deferred(() => ViewModel.ConfirmModal)
+                    : (ILayoutNode)Layouts.Empty())
+                .AsLayout());
+}
+```
+
+## Observables
+
+| Observable | Type | Description |
+|------------|------|-------------|
+| `Dismissed` | `IObservable<Unit>` | Emits when modal is dismissed (Escape) |
+| `Invalidated` | `IObservable<Unit>` | Emits when redraw is needed |
+
+## API Reference
+
+### Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Content` | `ILayoutNode?` | `null` | Modal content |
+| `CanFocus` | `bool` | `true` | Always focusable |
+| `HasFocus` | `bool` | - | Whether modal has focus |
+| `FocusPriority` | `int` | `100` | High priority to capture input |
+
+### Fluent Methods
+
+| Method | Description |
+|--------|-------------|
+| `.WithContent(ILayoutNode)` | Set modal content |
+| `.WithTitle(string)` | Set title in border |
+| `.WithTitleColor(Color)` | Set title color |
+| `.WithBorder(BorderStyle)` | Set border style |
+| `.WithBorderColor(Color)` | Set border color |
+| `.WithBackdrop(BackdropStyle)` | Set backdrop style |
+| `.WithBackdropColor(Color)` | Set backdrop color |
+| `.WithBackdropChar(char)` | Set backdrop character (Dim style) |
+| `.WithPosition(ModalPosition)` | Set vertical position |
+| `.WithPadding(int)` | Set content padding |
+| `.WithDismissOnEscape(bool)` | Enable/disable Escape dismissal |
+
+### Enums
+
+**BackdropStyle**
+| Value | Description |
+|-------|-------------|
+| `Transparent` | No backdrop - content behind visible |
+| `Dim` | Semi-transparent pattern (default) |
+| `Solid` | Solid color background |
+
+**ModalPosition**
+| Value | Description |
+|-------|-------------|
+| `Center` | Centered vertically (default) |
+| `Top` | Near top of screen |
+| `Bottom` | Near bottom of screen |
+
+## Source Code
+
+::: details View ModalNode implementation
+<<< @/../src/Termina/Layout/ModalNode.cs{csharp}
+:::

--- a/docs/components/selection-list-node.md
+++ b/docs/components/selection-list-node.md
@@ -1,0 +1,279 @@
+# SelectionListNode
+
+An interactive list selection component with keyboard navigation, supporting single and multi-select modes.
+
+## Basic Usage
+
+```csharp
+// String list with factory method
+var list = Layouts.SelectionList("Option 1", "Option 2", "Option 3");
+
+// Or from an enumerable
+var list = Layouts.SelectionList(options);
+
+// Typed list with custom display
+var list = Layouts.SelectionList(items, item => item.Name);
+```
+
+## Features
+
+- Arrow key navigation (Up/Down)
+- Home/End to jump to first/last item
+- Space to toggle selection (multi-select mode)
+- Enter to confirm selection
+- Number keys (1-9) for quick selection
+- Escape to cancel
+- Scrolling for long lists
+- Optional "Other" option for custom text input
+
+## Selection Modes
+
+### Single Select (Default)
+
+Only one item can be selected at a time:
+
+```csharp
+var list = Layouts.SelectionList("Low", "Medium", "High")
+    .WithMode(SelectionMode.Single);
+
+list.SelectionConfirmed.Subscribe(selected => {
+    var choice = selected.FirstOrDefault();
+    Console.WriteLine($"Selected: {choice}");
+});
+```
+
+### Multi-Select
+
+Multiple items can be selected with Space, confirmed with Enter:
+
+```csharp
+var list = Layouts.SelectionList("Feature A", "Feature B", "Feature C")
+    .WithMode(SelectionMode.Multi);
+
+list.SelectionConfirmed.Subscribe(selected => {
+    foreach (var item in selected)
+    {
+        Console.WriteLine($"Enabled: {item}");
+    }
+});
+```
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `↑/↓` | Move highlight |
+| `Home` | Jump to first item |
+| `End` | Jump to last item |
+| `Space` | Toggle selection (multi-select) |
+| `Enter` | Confirm selection |
+| `1-9` | Quick select by number |
+| `Escape` | Cancel |
+
+## "Other" Option for Custom Input
+
+Add a custom text input option that appears at the end of the list:
+
+```csharp
+var list = Layouts.SelectionList("High", "Medium", "Low")
+    .WithOtherOption("Custom priority...");
+
+// Handle standard selections
+list.SelectionConfirmed.Subscribe(selected => {
+    ProcessPriority(selected.First());
+});
+
+// Handle custom "Other" input
+list.OtherSelected.Subscribe(customText => {
+    ProcessPriority(customText);
+});
+```
+
+When the user navigates to or selects the "Other" option, a text input appears immediately inline, allowing them to type without pressing Enter first.
+
+## Styling
+
+```csharp
+Layouts.SelectionList("A", "B", "C")
+    .WithHighlightColors(Color.Black, Color.Cyan)  // Highlighted row colors
+    .WithForeground(Color.White)                    // Default text color
+    .WithSelectedForeground(Color.Green)            // Checked items color
+    .WithShowNumbers(true)                          // Show 1. 2. 3. prefixes
+    .WithVisibleRows(5)                             // Max visible before scrolling
+```
+
+## With Typed Items
+
+Use custom types with a display selector:
+
+```csharp
+public record Priority(int Level, string Name);
+
+var priorities = new[]
+{
+    new Priority(1, "Critical"),
+    new Priority(2, "High"),
+    new Priority(3, "Medium"),
+    new Priority(4, "Low")
+};
+
+var list = Layouts.SelectionList(priorities, p => p.Name)
+    .WithMode(SelectionMode.Single);
+
+list.SelectionConfirmed.Subscribe(selected => {
+    Priority priority = selected.First();
+    Console.WriteLine($"Selected level {priority.Level}");
+});
+```
+
+## Inside a Modal
+
+SelectionListNode works seamlessly with ModalNode:
+
+```csharp
+// Create selection list
+var priorityList = Layouts.SelectionList("High", "Medium", "Low")
+    .WithMode(SelectionMode.Single)
+    .WithShowNumbers(true)
+    .WithHighlightColors(Color.Black, Color.Cyan)
+    .WithOtherOption("Custom...");
+
+// Create modal with selection list
+var modal = Layouts.Modal()
+    .WithTitle("Select Priority")
+    .WithBorder(BorderStyle.Rounded)
+    .WithBorderColor(Color.Yellow)
+    .WithBackdrop(BackdropStyle.Dim)
+    .WithContent(priorityList);
+
+// Handle selections
+priorityList.SelectionConfirmed.Subscribe(selected => {
+    HandleSelection(selected.First());
+    Focus.PopFocus();
+});
+
+priorityList.OtherSelected.Subscribe(custom => {
+    HandleSelection(custom);
+    Focus.PopFocus();
+});
+
+priorityList.Cancelled.Subscribe(_ => {
+    Focus.PopFocus();
+});
+
+// Show modal
+Focus.PushFocus(modal);
+Focus.PushFocus(priorityList);  // List needs focus for keyboard input
+```
+
+## Complete Example
+
+```csharp
+public partial class SettingsViewModel : ReactiveViewModel
+{
+    [Reactive] private bool _showThemeSelector;
+
+    private SelectionListNode<string>? _themeList;
+    private ModalNode? _themeModal;
+
+    public ModalNode? ThemeModal => _themeModal;
+
+    public override void OnActivated()
+    {
+        _themeList = Layouts.SelectionList("Light", "Dark", "System Default")
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.White);
+
+        _themeList.SelectionConfirmed
+            .Subscribe(selected => {
+                ApplyTheme(selected.First());
+                HideThemeSelector();
+            })
+            .DisposeWith(Subscriptions);
+
+        _themeList.Cancelled
+            .Subscribe(_ => HideThemeSelector())
+            .DisposeWith(Subscriptions);
+
+        _themeModal = Layouts.Modal()
+            .WithTitle("Choose Theme")
+            .WithBorder(BorderStyle.Rounded)
+            .WithContent(_themeList);
+
+        _themeModal.Dismissed
+            .Subscribe(_ => HideThemeSelector())
+            .DisposeWith(Subscriptions);
+    }
+
+    private void ShowThemeSelector()
+    {
+        ShowThemeSelector = true;
+        Focus.PushFocus(_themeModal!);
+        Focus.PushFocus(_themeList!);
+    }
+
+    private void HideThemeSelector()
+    {
+        ShowThemeSelector = false;
+        Focus.ClearFocus();
+    }
+}
+```
+
+## Observables
+
+| Observable | Type | Description |
+|------------|------|-------------|
+| `SelectionConfirmed` | `IObservable<IReadOnlyList<T>>` | Emits selected items on Enter |
+| `OtherSelected` | `IObservable<string>` | Emits custom text from "Other" option |
+| `Cancelled` | `IObservable<Unit>` | Emits when Escape is pressed |
+| `Invalidated` | `IObservable<Unit>` | Emits when redraw is needed |
+
+## API Reference
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Items` | `IReadOnlyList<SelectionItem<T>>` | All items in the list |
+| `SelectedItems` | `IReadOnlyList<T>` | Currently selected items |
+| `HighlightedItem` | `SelectionItem<T>?` | Currently highlighted item |
+| `CanFocus` | `bool` | Always `true` |
+| `HasFocus` | `bool` | Whether list has focus |
+| `FocusPriority` | `int` | `10` (lower than modal) |
+
+### Fluent Methods
+
+| Method | Description |
+|--------|-------------|
+| `.WithMode(SelectionMode)` | Set Single or Multi select mode |
+| `.WithHighlightColors(fg, bg)` | Set highlight row colors |
+| `.WithForeground(Color)` | Set default text color |
+| `.WithSelectedForeground(Color)` | Set checked item color |
+| `.WithShowNumbers(bool)` | Show/hide number prefixes |
+| `.WithVisibleRows(int)` | Set max visible rows before scroll |
+| `.WithOtherOption(string, Action?)` | Add custom input option |
+
+### SelectionItem Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Value` | `T` | The item value |
+| `DisplayText` | `string` | Text shown in the list |
+| `IsSelected` | `bool` | Whether item is selected |
+| `IsOther` | `bool` | Whether this is the "Other" option |
+
+### Enums
+
+**SelectionMode**
+| Value | Description |
+|-------|-------------|
+| `Single` | Only one item can be selected |
+| `Multi` | Multiple items can be selected |
+
+## Source Code
+
+::: details View SelectionListNode implementation
+<<< @/../src/Termina/Layout/SelectionListNode.cs{csharp}
+:::

--- a/src/Termina/Input/FocusManager.cs
+++ b/src/Termina/Input/FocusManager.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Termina.Layout;
+
+namespace Termina.Input;
+
+/// <summary>
+/// Manages keyboard focus for interactive components using a stack-based model.
+/// </summary>
+/// <remarks>
+/// The focus manager supports nested modals through its stack-based design:
+/// when a modal opens, it pushes itself onto the stack and captures all input.
+/// When it closes, it pops itself off and focus returns to the previous component.
+/// </remarks>
+public sealed class FocusManager : IFocusManager, IDisposable
+{
+    private readonly Stack<IFocusable> _focusStack = new();
+    private readonly BehaviorSubject<IFocusable?> _focusChanged = new(null);
+    private bool _disposed;
+
+    /// <inheritdoc />
+    public IObservable<IFocusable?> FocusChanged => _focusChanged.AsObservable();
+
+    /// <inheritdoc />
+    public IFocusable? CurrentFocus => _focusStack.Count > 0 ? _focusStack.Peek() : null;
+
+    /// <inheritdoc />
+    public void PushFocus(IFocusable focusable)
+    {
+        ArgumentNullException.ThrowIfNull(focusable);
+
+        if (!focusable.CanFocus)
+            return;
+
+        // Blur the current focus if any
+        if (_focusStack.Count > 0)
+        {
+            var current = _focusStack.Peek();
+            current.OnBlurred();
+        }
+
+        // Push and focus the new component
+        _focusStack.Push(focusable);
+        focusable.OnFocused();
+        _focusChanged.OnNext(focusable);
+    }
+
+    /// <inheritdoc />
+    public void PopFocus()
+    {
+        if (_focusStack.Count == 0)
+            return;
+
+        // Blur and remove the current focus
+        var current = _focusStack.Pop();
+        current.OnBlurred();
+
+        // Focus the previous component if any
+        if (_focusStack.Count > 0)
+        {
+            var previous = _focusStack.Peek();
+            previous.OnFocused();
+            _focusChanged.OnNext(previous);
+        }
+        else
+        {
+            _focusChanged.OnNext(null);
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetFocus(IFocusable focusable)
+    {
+        ArgumentNullException.ThrowIfNull(focusable);
+
+        if (!focusable.CanFocus)
+            return;
+
+        // If the stack is empty, just push
+        if (_focusStack.Count == 0)
+        {
+            PushFocus(focusable);
+            return;
+        }
+
+        // Replace the top of the stack
+        var current = _focusStack.Pop();
+        current.OnBlurred();
+
+        _focusStack.Push(focusable);
+        focusable.OnFocused();
+        _focusChanged.OnNext(focusable);
+    }
+
+    /// <inheritdoc />
+    public void ClearFocus()
+    {
+        // Blur all focused components
+        while (_focusStack.Count > 0)
+        {
+            var current = _focusStack.Pop();
+            current.OnBlurred();
+        }
+
+        _focusChanged.OnNext(null);
+    }
+
+    /// <inheritdoc />
+    public bool RouteInput(ConsoleKeyInfo key)
+    {
+        if (_focusStack.Count == 0)
+            return false;
+
+        // Route to the topmost focused component
+        var current = _focusStack.Peek();
+
+        if (!current.CanFocus)
+            return false;
+
+        return current.HandleInput(key);
+    }
+
+    /// <summary>
+    /// Disposes the focus manager and releases all resources.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        ClearFocus();
+        _focusChanged.OnCompleted();
+        _focusChanged.Dispose();
+        _disposed = true;
+    }
+}

--- a/src/Termina/Input/IFocusManager.cs
+++ b/src/Termina/Input/IFocusManager.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Layout;
+
+namespace Termina.Input;
+
+/// <summary>
+/// Manages keyboard focus for interactive components.
+/// </summary>
+/// <remarks>
+/// The focus manager uses a stack-based model to support nested modals:
+/// when a modal opens, it pushes itself onto the stack and captures all input.
+/// When it closes, it pops itself off and focus returns to the previous component.
+/// </remarks>
+public interface IFocusManager
+{
+    /// <summary>
+    /// Observable that emits when focus changes.
+    /// </summary>
+    IObservable<IFocusable?> FocusChanged { get; }
+
+    /// <summary>
+    /// Gets the currently focused component, or null if nothing has focus.
+    /// </summary>
+    IFocusable? CurrentFocus { get; }
+
+    /// <summary>
+    /// Push a focusable onto the focus stack.
+    /// </summary>
+    /// <remarks>
+    /// Use this for modals and overlays that need to capture all input.
+    /// The pushed component becomes the new focus and will receive all input
+    /// until it is popped.
+    /// </remarks>
+    /// <param name="focusable">The component to push onto the focus stack.</param>
+    void PushFocus(IFocusable focusable);
+
+    /// <summary>
+    /// Pop the top focusable from the focus stack.
+    /// </summary>
+    /// <remarks>
+    /// Call this when closing a modal to return focus to the previous component.
+    /// </remarks>
+    void PopFocus();
+
+    /// <summary>
+    /// Set focus to a specific component, replacing the current focus.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="PushFocus"/>, this replaces the current focus rather than
+    /// stacking on top of it. Use for navigating between controls.
+    /// </remarks>
+    /// <param name="focusable">The component to focus.</param>
+    void SetFocus(IFocusable focusable);
+
+    /// <summary>
+    /// Clear all focus, leaving no component focused.
+    /// </summary>
+    void ClearFocus();
+
+    /// <summary>
+    /// Route keyboard input to the currently focused component.
+    /// </summary>
+    /// <param name="key">The key info to route.</param>
+    /// <returns>True if the input was consumed, false if no component handled it.</returns>
+    bool RouteInput(ConsoleKeyInfo key);
+}

--- a/src/Termina/Layout/BackdropStyle.cs
+++ b/src/Termina/Layout/BackdropStyle.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Defines how the modal backdrop is rendered.
+/// </summary>
+public enum BackdropStyle
+{
+    /// <summary>
+    /// No backdrop - content behind is fully visible.
+    /// </summary>
+    Transparent,
+
+    /// <summary>
+    /// Semi-transparent dimmed backdrop using a pattern character.
+    /// </summary>
+    Dim,
+
+    /// <summary>
+    /// Solid colored backdrop that completely obscures content behind.
+    /// </summary>
+    Solid
+}

--- a/src/Termina/Layout/DeferredNode.cs
+++ b/src/Termina/Layout/DeferredNode.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Rendering;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// A layout node that delegates to a lazily-obtained node without owning or disposing it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this wrapper when you need to render a node that is owned elsewhere (like a ViewModel)
+/// and should not be disposed when the layout changes. This is particularly useful for modals
+/// and other overlay components that need to be shown/hidden without being recreated.
+/// </para>
+/// <para>
+/// Example usage with reactive layouts:
+/// <code>
+/// ViewModel.ShowModalChanged
+///     .Select(show => show
+///         ? new DeferredNode(() => ViewModel.MyModal)
+///         : Layouts.Empty())
+///     .AsLayout()
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class DeferredNode : ILayoutNode
+{
+    private readonly Func<ILayoutNode?> _getNode;
+
+    /// <summary>
+    /// Creates a new DeferredNode that delegates to the node returned by the factory.
+    /// </summary>
+    /// <param name="getNode">A function that returns the node to render, or null for no content.</param>
+    public DeferredNode(Func<ILayoutNode?> getNode)
+    {
+        _getNode = getNode ?? throw new ArgumentNullException(nameof(getNode));
+    }
+
+    /// <inheritdoc />
+    public SizeConstraint WidthConstraint => _getNode()?.WidthConstraint ?? SizeConstraint.AutoSize();
+
+    /// <inheritdoc />
+    public SizeConstraint HeightConstraint => _getNode()?.HeightConstraint ?? SizeConstraint.AutoSize();
+
+    /// <inheritdoc />
+    public Size Measure(Size available)
+    {
+        return _getNode()?.Measure(available) ?? Size.Zero;
+    }
+
+    /// <inheritdoc />
+    public void Render(IRenderContext context, Rect bounds)
+    {
+        _getNode()?.Render(context, bounds);
+    }
+
+    /// <summary>
+    /// Does not dispose the underlying node - it is owned by the caller.
+    /// </summary>
+    public void Dispose()
+    {
+        // Intentionally empty - we don't own the node
+    }
+}

--- a/src/Termina/Layout/IFocusable.cs
+++ b/src/Termina/Layout/IFocusable.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Interface for layout nodes that can receive keyboard focus.
+/// </summary>
+/// <remarks>
+/// Components that implement this interface can participate in the focus management system,
+/// which routes keyboard input to the appropriate component based on focus state.
+/// </remarks>
+public interface IFocusable : ILayoutNode
+{
+    /// <summary>
+    /// Gets whether this component can currently receive focus.
+    /// </summary>
+    /// <remarks>
+    /// Return false to temporarily disable focus (e.g., during loading states).
+    /// </remarks>
+    bool CanFocus { get; }
+
+    /// <summary>
+    /// Gets whether this component currently has focus.
+    /// </summary>
+    bool HasFocus { get; }
+
+    /// <summary>
+    /// Gets the focus priority. Higher values capture input first.
+    /// </summary>
+    /// <remarks>
+    /// Use priority to establish a hierarchy of input handlers:
+    /// - 100+ for modals and overlays (capture all input)
+    /// - 10-99 for interactive controls
+    /// - 1-9 for background handlers
+    /// </remarks>
+    int FocusPriority { get; }
+
+    /// <summary>
+    /// Called when this component receives focus.
+    /// </summary>
+    void OnFocused();
+
+    /// <summary>
+    /// Called when this component loses focus.
+    /// </summary>
+    void OnBlurred();
+
+    /// <summary>
+    /// Handle keyboard input.
+    /// </summary>
+    /// <param name="key">The key info to handle.</param>
+    /// <returns>True if the input was consumed, false to pass to the next handler.</returns>
+    bool HandleInput(ConsoleKeyInfo key);
+}

--- a/src/Termina/Layout/Layout.cs
+++ b/src/Termina/Layout/Layout.cs
@@ -63,4 +63,15 @@ public static class Layouts
     /// <param name="items">The string items to display.</param>
     public static SelectionListNode<string> SelectionList(IEnumerable<string> items) =>
         new(items, s => s);
+
+    /// <summary>
+    /// Create a deferred node that delegates to a lazily-obtained node without owning it.
+    /// </summary>
+    /// <remarks>
+    /// Use this when you need to render a node owned elsewhere (like a ViewModel) that should
+    /// not be disposed when the layout changes. Useful for modals and overlays that need to
+    /// be shown/hidden without being recreated.
+    /// </remarks>
+    /// <param name="getNode">A function that returns the node to render, or null for no content.</param>
+    public static DeferredNode Deferred(Func<ILayoutNode?> getNode) => new(getNode);
 }

--- a/src/Termina/Layout/Layout.cs
+++ b/src/Termina/Layout/Layout.cs
@@ -27,4 +27,40 @@ public static class Layouts
     /// Create an empty node (renders nothing, takes no space).
     /// </summary>
     public static EmptyNode Empty() => new();
+
+    /// <summary>
+    /// Create a modal overlay component.
+    /// </summary>
+    /// <remarks>
+    /// Use the focus manager to show/hide modals:
+    /// <code>
+    /// Focus.PushFocus(modal);  // Show modal
+    /// Focus.PopFocus();        // Hide modal
+    /// </code>
+    /// </remarks>
+    public static ModalNode Modal() => new();
+
+    /// <summary>
+    /// Create a selection list with typed items.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the list.</typeparam>
+    /// <param name="items">The items to display.</param>
+    /// <param name="displaySelector">Function to convert items to display text.</param>
+    public static SelectionListNode<T> SelectionList<T>(
+        IEnumerable<T> items,
+        Func<T, string> displaySelector) => new(items, displaySelector);
+
+    /// <summary>
+    /// Create a selection list with string items.
+    /// </summary>
+    /// <param name="items">The string items to display.</param>
+    public static SelectionListNode<string> SelectionList(params string[] items) =>
+        new(items, s => s);
+
+    /// <summary>
+    /// Create a selection list with string items from an enumerable.
+    /// </summary>
+    /// <param name="items">The string items to display.</param>
+    public static SelectionListNode<string> SelectionList(IEnumerable<string> items) =>
+        new(items, s => s);
 }

--- a/src/Termina/Layout/ModalNode.cs
+++ b/src/Termina/Layout/ModalNode.cs
@@ -1,0 +1,381 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// A modal overlay component that displays content over the rest of the UI.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ModalNode captures all keyboard input when focused (FocusPriority = 100).
+/// It supports configurable backdrops, borders, and positioning.
+/// </para>
+/// <para>
+/// Use the focus manager to show/hide modals:
+/// <code>
+/// Focus.PushFocus(modal);  // Show modal
+/// Focus.PopFocus();        // Hide modal
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class ModalNode : IFocusable, IInvalidatingNode
+{
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly Subject<Unit> _dismissed = new();
+    private ILayoutNode? _content;
+    private string? _title;
+    private Color? _titleColor;
+    private BorderStyle _borderStyle = BorderStyle.Rounded;
+    private Color? _borderColor;
+    private BackdropStyle _backdrop = BackdropStyle.Dim;
+    private Color _backdropColor = Color.BrightBlack;
+    private char _backdropChar = '░';
+    private ModalPosition _position = ModalPosition.Center;
+    private int _padding = 1;
+    private bool _dismissOnEscape = true;
+    private bool _hasFocus;
+    private bool _disposed;
+
+    private readonly record struct BorderCharsData(
+        char TopLeft, char TopRight,
+        char BottomLeft, char BottomRight,
+        char Horizontal, char Vertical);
+
+    private static BorderCharsData GetBorderChars(BorderStyle style) => style switch
+    {
+        BorderStyle.Single => new BorderCharsData('┌', '┐', '└', '┘', '─', '│'),
+        BorderStyle.Double => new BorderCharsData('╔', '╗', '╚', '╝', '═', '║'),
+        BorderStyle.Rounded => new BorderCharsData('╭', '╮', '╰', '╯', '─', '│'),
+        BorderStyle.Ascii => new BorderCharsData('+', '+', '+', '+', '-', '|'),
+        _ => new BorderCharsData(' ', ' ', ' ', ' ', ' ', ' ')
+    };
+
+    /// <inheritdoc />
+    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+
+    /// <summary>
+    /// Observable that emits when the modal is dismissed (e.g., Escape pressed).
+    /// </summary>
+    public IObservable<Unit> Dismissed => _dismissed.AsObservable();
+
+    /// <inheritdoc />
+    public SizeConstraint WidthConstraint => SizeConstraint.FillRemaining();
+
+    /// <inheritdoc />
+    public SizeConstraint HeightConstraint => SizeConstraint.FillRemaining();
+
+    /// <inheritdoc />
+    public bool CanFocus => true;
+
+    /// <inheritdoc />
+    public bool HasFocus => _hasFocus;
+
+    /// <summary>
+    /// Modal has high priority to capture all input.
+    /// </summary>
+    public int FocusPriority => 100;
+
+    /// <summary>
+    /// Gets or sets the modal content.
+    /// </summary>
+    public ILayoutNode? Content
+    {
+        get => _content;
+        set
+        {
+            _content = value;
+            Invalidate();
+        }
+    }
+
+    /// <summary>
+    /// Sets the modal content.
+    /// </summary>
+    public ModalNode WithContent(ILayoutNode content)
+    {
+        _content = content;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the modal title.
+    /// </summary>
+    public ModalNode WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the title color.
+    /// </summary>
+    public ModalNode WithTitleColor(Color color)
+    {
+        _titleColor = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the border style.
+    /// </summary>
+    public ModalNode WithBorder(BorderStyle style)
+    {
+        _borderStyle = style;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the border color.
+    /// </summary>
+    public ModalNode WithBorderColor(Color color)
+    {
+        _borderColor = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the backdrop style.
+    /// </summary>
+    public ModalNode WithBackdrop(BackdropStyle style)
+    {
+        _backdrop = style;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the backdrop color.
+    /// </summary>
+    public ModalNode WithBackdropColor(Color color)
+    {
+        _backdropColor = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the backdrop character (for Dim style).
+    /// </summary>
+    public ModalNode WithBackdropChar(char c)
+    {
+        _backdropChar = c;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the modal position.
+    /// </summary>
+    public ModalNode WithPosition(ModalPosition position)
+    {
+        _position = position;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the padding between border and content.
+    /// </summary>
+    public ModalNode WithPadding(int padding)
+    {
+        _padding = Math.Max(0, padding);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets whether Escape key dismisses the modal.
+    /// </summary>
+    public ModalNode WithDismissOnEscape(bool dismiss = true)
+    {
+        _dismissOnEscape = dismiss;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public void OnFocused()
+    {
+        _hasFocus = true;
+        Invalidate();
+    }
+
+    /// <inheritdoc />
+    public void OnBlurred()
+    {
+        _hasFocus = false;
+        Invalidate();
+    }
+
+    /// <inheritdoc />
+    public bool HandleInput(ConsoleKeyInfo key)
+    {
+        // Handle Escape to dismiss
+        if (_dismissOnEscape && key.Key == ConsoleKey.Escape)
+        {
+            _dismissed.OnNext(Unit.Default);
+            return true;
+        }
+
+        // Forward input to content if it's focusable
+        if (_content is IFocusable focusable && focusable.CanFocus)
+        {
+            return focusable.HandleInput(key);
+        }
+
+        // Modal consumes all input to prevent it reaching underlying UI
+        return true;
+    }
+
+    /// <inheritdoc />
+    public Size Measure(Size available)
+    {
+        // Modal takes full available space (for backdrop)
+        return available;
+    }
+
+    /// <inheritdoc />
+    public void Render(IRenderContext context, Rect bounds)
+    {
+        // Draw backdrop
+        RenderBackdrop(context, bounds);
+
+        // Calculate modal size based on content
+        var contentSize = _content?.Measure(new Size(
+            bounds.Width - 4 - (_padding * 2),  // Account for border and padding
+            bounds.Height - 4 - (_padding * 2)
+        )) ?? new Size(20, 5);
+
+        var modalWidth = Math.Min(
+            contentSize.Width + 2 + (_padding * 2),  // +2 for border
+            bounds.Width - 4  // Leave some margin
+        );
+        var modalHeight = Math.Min(
+            contentSize.Height + 2 + (_padding * 2),  // +2 for border
+            bounds.Height - 2  // Leave some margin
+        );
+
+        // Calculate position
+        var x = (bounds.Width - modalWidth) / 2;
+        var y = _position switch
+        {
+            ModalPosition.Top => 1,
+            ModalPosition.Bottom => bounds.Height - modalHeight - 1,
+            _ => (bounds.Height - modalHeight) / 2
+        };
+
+        // Draw modal panel
+        RenderPanel(context, new Rect(x, y, modalWidth, modalHeight));
+    }
+
+    private void RenderBackdrop(IRenderContext context, Rect bounds)
+    {
+        switch (_backdrop)
+        {
+            case BackdropStyle.Dim:
+                context.SetForeground(_backdropColor);
+                context.Fill(0, 0, bounds.Width, bounds.Height, _backdropChar);
+                break;
+
+            case BackdropStyle.Solid:
+                context.SetBackground(_backdropColor);
+                context.Fill(0, 0, bounds.Width, bounds.Height, ' ');
+                context.ResetColors();
+                break;
+
+            // Transparent - don't render anything
+        }
+    }
+
+    private void RenderPanel(IRenderContext context, Rect bounds)
+    {
+        var border = GetBorderChars(_borderStyle);
+
+        // Create a sub-context for this panel's bounds so all coordinates are relative to the panel
+        var panelContext = context.CreateSubContext(bounds);
+
+        // Set border color
+        if (_borderColor.HasValue)
+            panelContext.SetForeground(_borderColor.Value);
+
+        // Draw border
+        // Top
+        panelContext.WriteAt(0, 0, border.TopLeft.ToString());
+        panelContext.WriteAt(1, 0, new string(border.Horizontal, bounds.Width - 2));
+        panelContext.WriteAt(bounds.Width - 1, 0, border.TopRight.ToString());
+
+        // Sides and fill interior
+        for (var row = 1; row < bounds.Height - 1; row++)
+        {
+            panelContext.WriteAt(0, row, border.Vertical.ToString());
+            // Clear interior
+            panelContext.ResetColors();
+            panelContext.WriteAt(1, row, new string(' ', bounds.Width - 2));
+            if (_borderColor.HasValue)
+                panelContext.SetForeground(_borderColor.Value);
+            panelContext.WriteAt(bounds.Width - 1, row, border.Vertical.ToString());
+        }
+
+        // Bottom
+        panelContext.WriteAt(0, bounds.Height - 1, border.BottomLeft.ToString());
+        panelContext.WriteAt(1, bounds.Height - 1, new string(border.Horizontal, bounds.Width - 2));
+        panelContext.WriteAt(bounds.Width - 1, bounds.Height - 1, border.BottomRight.ToString());
+
+        // Draw title if present
+        if (!string.IsNullOrEmpty(_title))
+        {
+            var maxTitleLen = bounds.Width - 4;
+            var displayTitle = _title.Length > maxTitleLen ? _title[..maxTitleLen] : _title;
+            var titleText = $" {displayTitle} ";
+            var titleX = 2;
+
+            if (_titleColor.HasValue)
+                panelContext.SetForeground(_titleColor.Value);
+            else
+                panelContext.ResetColors();
+
+            panelContext.WriteAt(titleX, 0, titleText);
+        }
+
+        panelContext.ResetColors();
+
+        // Render content
+        if (_content != null)
+        {
+            var contentBounds = new Rect(
+                1 + _padding,
+                1 + _padding,
+                bounds.Width - 2 - (_padding * 2),
+                bounds.Height - 2 - (_padding * 2)
+            );
+
+            if (contentBounds.HasArea)
+            {
+                var contentContext = panelContext.CreateSubContext(contentBounds);
+                var innerBounds = new Rect(0, 0, contentBounds.Width, contentBounds.Height);
+                _content.Render(contentContext, innerBounds);
+            }
+        }
+    }
+
+    private void Invalidate()
+    {
+        if (!_disposed)
+            _invalidated.OnNext(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        _dismissed.OnCompleted();
+        _dismissed.Dispose();
+        _content?.Dispose();
+    }
+}

--- a/src/Termina/Layout/ModalPosition.cs
+++ b/src/Termina/Layout/ModalPosition.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Defines where the modal is positioned on the screen.
+/// </summary>
+public enum ModalPosition
+{
+    /// <summary>
+    /// Centered both horizontally and vertically.
+    /// </summary>
+    Center,
+
+    /// <summary>
+    /// Centered horizontally, near the top of the screen.
+    /// </summary>
+    Top,
+
+    /// <summary>
+    /// Centered horizontally, near the bottom of the screen.
+    /// </summary>
+    Bottom
+}

--- a/src/Termina/Layout/SelectionItem.cs
+++ b/src/Termina/Layout/SelectionItem.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Represents an item in a SelectionListNode.
+/// </summary>
+/// <typeparam name="T">The type of the underlying value.</typeparam>
+public sealed class SelectionItem<T>
+{
+    /// <summary>
+    /// Creates a new selection item.
+    /// </summary>
+    /// <param name="value">The underlying value.</param>
+    /// <param name="displayText">The text to display for this item.</param>
+    /// <param name="isOther">Whether this is the "Other..." option.</param>
+    public SelectionItem(T value, string displayText, bool isOther = false)
+    {
+        Value = value;
+        DisplayText = displayText;
+        IsOther = isOther;
+    }
+
+    /// <summary>
+    /// The underlying value for this item.
+    /// </summary>
+    public T Value { get; }
+
+    /// <summary>
+    /// The text displayed for this item.
+    /// </summary>
+    public string DisplayText { get; }
+
+    /// <summary>
+    /// Whether this item is selected.
+    /// </summary>
+    public bool IsSelected { get; internal set; }
+
+    /// <summary>
+    /// Whether this item represents the "Other..." option for custom input.
+    /// </summary>
+    public bool IsOther { get; }
+}

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -277,7 +277,14 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
                 if (index < _items.Count)
                 {
                     _highlightedIndex = index;
-                    if (_mode == SelectionMode.Single)
+                    var selectedItem = _items[index];
+
+                    // If selecting "Other", start text input immediately
+                    if (selectedItem.IsOther)
+                    {
+                        StartOtherInput();
+                    }
+                    else if (_mode == SelectionMode.Single)
                     {
                         // In single mode, number key confirms immediately
                         SelectItem(index);
@@ -303,7 +310,17 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
 
         _highlightedIndex = Math.Clamp(_highlightedIndex + delta, 0, _items.Count - 1);
         EnsureVisible();
-        Invalidate();
+
+        // Auto-start text input when navigating to "Other" option
+        var item = _items[_highlightedIndex];
+        if (item.IsOther && !_isEditingOther)
+        {
+            StartOtherInput();
+        }
+        else
+        {
+            Invalidate();
+        }
     }
 
     private void EnsureVisible()
@@ -380,9 +397,12 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
                 return;
             }
 
-            // In single mode, select the highlighted item if nothing is selected
-            if (_mode == SelectionMode.Single && !_items.Any(i => i.IsSelected && !i.IsOther))
+            // In single mode, always select the highlighted item on Enter
+            if (_mode == SelectionMode.Single)
             {
+                // Clear other selections first
+                foreach (var i in _items)
+                    i.IsSelected = false;
                 item.IsSelected = true;
             }
         }
@@ -399,8 +419,6 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     public Size Measure(Size available)
     {
         var height = Math.Min(_items.Count, _visibleRows);
-        if (_isEditingOther)
-            height++; // Extra row for text input
 
         // Calculate width based on content
         var maxItemWidth = _items.Count > 0
@@ -458,9 +476,17 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
                 break;
 
             var item = _items[itemIndex];
-            var isHighlighted = itemIndex == _highlightedIndex && _hasFocus && !_isEditingOther;
 
-            RenderItem(context, item, itemIndex, row, contentWidth, isHighlighted);
+            // If this is the "Other" item and we're editing, render the text input instead
+            if (item.IsOther && _isEditingOther && _otherInput != null)
+            {
+                RenderOtherInput(context, row, contentWidth, itemIndex);
+            }
+            else
+            {
+                var isHighlighted = itemIndex == _highlightedIndex && _hasFocus && !_isEditingOther;
+                RenderItem(context, item, itemIndex, row, contentWidth, isHighlighted);
+            }
         }
 
         // Render scrollbar if needed
@@ -468,17 +494,29 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
         {
             RenderScrollbar(context, bounds.Width - 1, visibleCount);
         }
+    }
 
-        // Render "Other" text input below the list
-        if (_isEditingOther && _otherInput != null)
+    private void RenderOtherInput(IRenderContext context, int row, int width, int itemIndex)
+    {
+        if (_otherInput == null)
+            return;
+
+        // Render the number prefix (e.g., "4. ") in dimmed color
+        var prefix = _showNumbers && itemIndex < 9 ? $"{itemIndex + 1}. " : "";
+        if (prefix.Length > 0)
         {
-            var inputY = Math.Min(visibleCount, bounds.Height - 1);
-            if (inputY < bounds.Height)
-            {
-                var inputBounds = new Rect(0, inputY, bounds.Width, 1);
-                _otherInput.Render(context, inputBounds);
-            }
+            context.SetForeground(Color.BrightBlack);
+            context.WriteAt(0, row, prefix);
+            context.ResetColors();
         }
+
+        // Render the text input after the prefix
+        var inputX = prefix.Length;
+        var inputWidth = Math.Max(1, width - inputX);
+        var inputBounds = new Rect(inputX, row, inputWidth, 1);
+        var inputContext = context.CreateSubContext(inputBounds);
+        var innerBounds = new Rect(0, 0, inputWidth, 1);
+        _otherInput.Render(inputContext, innerBounds);
     }
 
     private void RenderItem(IRenderContext context, SelectionItem<T> item, int index, int row,

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -1,0 +1,566 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// An interactive list selection component with keyboard navigation.
+/// </summary>
+/// <typeparam name="T">The type of items in the list.</typeparam>
+/// <remarks>
+/// <para>
+/// SelectionListNode provides keyboard-driven item selection with:
+/// - Arrow key navigation (Up/Down)
+/// - Home/End to jump to first/last item
+/// - Space to toggle selection (in Multi mode)
+/// - Enter to confirm selection
+/// - Number keys (1-9) for quick selection
+/// - Escape to cancel
+/// </para>
+/// <para>
+/// Optionally supports an "Other" option for custom text input.
+/// </para>
+/// </remarks>
+public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
+{
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly Subject<IReadOnlyList<T>> _selectionConfirmed = new();
+    private readonly Subject<string> _otherSelected = new();
+    private readonly Subject<Unit> _cancelled = new();
+    private readonly List<SelectionItem<T>> _items = new();
+    private readonly Func<T, string> _displaySelector;
+
+    private int _highlightedIndex;
+    private int _scrollOffset;
+    private int _visibleRows = 10;
+    private bool _isEditingOther;
+    private TextInputNode? _otherInput;
+    private string? _otherLabel;
+    private Action<string>? _otherCallback;
+    private bool _hasFocus;
+    private bool _disposed;
+
+    private SelectionMode _mode = SelectionMode.Single;
+    private Color _highlightForeground = Color.Black;
+    private Color _highlightBackground = Color.White;
+    private Color? _foreground;
+    private Color? _selectedForeground;
+    private bool _showNumbers = true;
+
+    /// <summary>
+    /// Creates a new SelectionListNode with the specified items.
+    /// </summary>
+    /// <param name="items">The items to display.</param>
+    /// <param name="displaySelector">A function to convert items to display text.</param>
+    public SelectionListNode(IEnumerable<T> items, Func<T, string> displaySelector)
+    {
+        _displaySelector = displaySelector ?? throw new ArgumentNullException(nameof(displaySelector));
+
+        foreach (var item in items)
+        {
+            _items.Add(new SelectionItem<T>(item, displaySelector(item)));
+        }
+
+        if (_items.Count > 0)
+            _highlightedIndex = 0;
+    }
+
+    /// <inheritdoc />
+    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+
+    /// <summary>
+    /// Observable that emits the selected items when Enter is pressed.
+    /// </summary>
+    public IObservable<IReadOnlyList<T>> SelectionConfirmed => _selectionConfirmed.AsObservable();
+
+    /// <summary>
+    /// Observable that emits the custom text when "Other" is selected and confirmed.
+    /// </summary>
+    public IObservable<string> OtherSelected => _otherSelected.AsObservable();
+
+    /// <summary>
+    /// Observable that emits when Escape is pressed.
+    /// </summary>
+    public IObservable<Unit> Cancelled => _cancelled.AsObservable();
+
+    /// <inheritdoc />
+    public SizeConstraint WidthConstraint => SizeConstraint.FillRemaining();
+
+    /// <inheritdoc />
+    public SizeConstraint HeightConstraint => SizeConstraint.AutoSize();
+
+    /// <inheritdoc />
+    public bool CanFocus => true;
+
+    /// <inheritdoc />
+    public bool HasFocus => _hasFocus;
+
+    /// <summary>
+    /// Selection list has medium priority (lower than modal).
+    /// </summary>
+    public int FocusPriority => 10;
+
+    /// <summary>
+    /// Gets the currently highlighted item.
+    /// </summary>
+    public SelectionItem<T>? HighlightedItem =>
+        _highlightedIndex >= 0 && _highlightedIndex < _items.Count ? _items[_highlightedIndex] : null;
+
+    /// <summary>
+    /// Gets all selected items.
+    /// </summary>
+    public IReadOnlyList<T> SelectedItems =>
+        _items.Where(i => i.IsSelected && !i.IsOther).Select(i => i.Value).ToList();
+
+    /// <summary>
+    /// Gets the items in the list.
+    /// </summary>
+    public IReadOnlyList<SelectionItem<T>> Items => _items;
+
+    /// <summary>
+    /// Sets the selection mode (Single or Multi).
+    /// </summary>
+    public SelectionListNode<T> WithMode(SelectionMode mode)
+    {
+        _mode = mode;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the highlight colors for the selected row.
+    /// </summary>
+    public SelectionListNode<T> WithHighlightColors(Color foreground, Color background)
+    {
+        _highlightForeground = foreground;
+        _highlightBackground = background;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the default foreground color.
+    /// </summary>
+    public SelectionListNode<T> WithForeground(Color color)
+    {
+        _foreground = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the color for selected (checked) items.
+    /// </summary>
+    public SelectionListNode<T> WithSelectedForeground(Color color)
+    {
+        _selectedForeground = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets whether to show number prefixes (1-9) for quick selection.
+    /// </summary>
+    public SelectionListNode<T> WithShowNumbers(bool show = true)
+    {
+        _showNumbers = show;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum number of visible rows before scrolling.
+    /// </summary>
+    public SelectionListNode<T> WithVisibleRows(int rows)
+    {
+        _visibleRows = Math.Max(1, rows);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an "Other..." option that allows custom text input.
+    /// </summary>
+    /// <param name="label">The label for the "Other" option (default: "Other...").</param>
+    /// <param name="onOther">Callback when custom text is submitted.</param>
+    public SelectionListNode<T> WithOtherOption(string label = "Other...", Action<string>? onOther = null)
+    {
+        _otherLabel = label;
+        _otherCallback = onOther;
+
+        // Add Other as a special item at the end
+        // We use default(T)! as the value since it won't be used
+        _items.Add(new SelectionItem<T>(default!, label, isOther: true));
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public void OnFocused()
+    {
+        _hasFocus = true;
+        Invalidate();
+    }
+
+    /// <inheritdoc />
+    public void OnBlurred()
+    {
+        _hasFocus = false;
+        _isEditingOther = false;
+        Invalidate();
+    }
+
+    /// <inheritdoc />
+    public bool HandleInput(ConsoleKeyInfo key)
+    {
+        // If editing "Other" text, forward to text input
+        if (_isEditingOther && _otherInput != null)
+        {
+            if (key.Key == ConsoleKey.Enter)
+            {
+                var text = _otherInput.Text;
+                _isEditingOther = false;
+                _otherCallback?.Invoke(text);
+                _otherSelected.OnNext(text);
+                Invalidate();
+                return true;
+            }
+
+            if (key.Key == ConsoleKey.Escape)
+            {
+                _isEditingOther = false;
+                Invalidate();
+                return true;
+            }
+
+            return _otherInput.HandleInput(key);
+        }
+
+        // Handle navigation and selection
+        switch (key.Key)
+        {
+            case ConsoleKey.UpArrow:
+                MoveHighlight(-1);
+                return true;
+
+            case ConsoleKey.DownArrow:
+                MoveHighlight(1);
+                return true;
+
+            case ConsoleKey.Home:
+                _highlightedIndex = 0;
+                EnsureVisible();
+                Invalidate();
+                return true;
+
+            case ConsoleKey.End:
+                _highlightedIndex = _items.Count - 1;
+                EnsureVisible();
+                Invalidate();
+                return true;
+
+            case ConsoleKey.Spacebar:
+                ToggleSelection();
+                return true;
+
+            case ConsoleKey.Enter:
+                ConfirmSelection();
+                return true;
+
+            case ConsoleKey.Escape:
+                _cancelled.OnNext(Unit.Default);
+                return true;
+
+            // Number keys for quick selection (1-9)
+            case >= ConsoleKey.D1 and <= ConsoleKey.D9 when _showNumbers:
+                var index = key.Key - ConsoleKey.D1;
+                if (index < _items.Count)
+                {
+                    _highlightedIndex = index;
+                    if (_mode == SelectionMode.Single)
+                    {
+                        // In single mode, number key confirms immediately
+                        SelectItem(index);
+                        ConfirmSelection();
+                    }
+                    else
+                    {
+                        // In multi mode, number key toggles selection
+                        ToggleSelection();
+                    }
+                }
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private void MoveHighlight(int delta)
+    {
+        if (_items.Count == 0)
+            return;
+
+        _highlightedIndex = Math.Clamp(_highlightedIndex + delta, 0, _items.Count - 1);
+        EnsureVisible();
+        Invalidate();
+    }
+
+    private void EnsureVisible()
+    {
+        if (_highlightedIndex < _scrollOffset)
+        {
+            _scrollOffset = _highlightedIndex;
+        }
+        else if (_highlightedIndex >= _scrollOffset + _visibleRows)
+        {
+            _scrollOffset = _highlightedIndex - _visibleRows + 1;
+        }
+    }
+
+    private void ToggleSelection()
+    {
+        if (_highlightedIndex < 0 || _highlightedIndex >= _items.Count)
+            return;
+
+        var item = _items[_highlightedIndex];
+
+        if (item.IsOther)
+        {
+            // Start editing "Other" text
+            StartOtherInput();
+            return;
+        }
+
+        if (_mode == SelectionMode.Single)
+        {
+            // Clear other selections
+            foreach (var i in _items)
+                i.IsSelected = false;
+        }
+
+        item.IsSelected = !item.IsSelected;
+        Invalidate();
+    }
+
+    private void SelectItem(int index)
+    {
+        if (index < 0 || index >= _items.Count)
+            return;
+
+        if (_mode == SelectionMode.Single)
+        {
+            foreach (var i in _items)
+                i.IsSelected = false;
+        }
+
+        _items[index].IsSelected = true;
+        Invalidate();
+    }
+
+    private void StartOtherInput()
+    {
+        _otherInput ??= new TextInputNode()
+            .WithPlaceholder("Enter custom value...");
+
+        _otherInput.Clear();
+        _isEditingOther = true;
+        Invalidate();
+    }
+
+    private void ConfirmSelection()
+    {
+        if (_highlightedIndex >= 0 && _highlightedIndex < _items.Count)
+        {
+            var item = _items[_highlightedIndex];
+
+            if (item.IsOther)
+            {
+                StartOtherInput();
+                return;
+            }
+
+            // In single mode, select the highlighted item if nothing is selected
+            if (_mode == SelectionMode.Single && !_items.Any(i => i.IsSelected && !i.IsOther))
+            {
+                item.IsSelected = true;
+            }
+        }
+
+        var selected = _items
+            .Where(i => i.IsSelected && !i.IsOther)
+            .Select(i => i.Value)
+            .ToList();
+
+        _selectionConfirmed.OnNext(selected);
+    }
+
+    /// <inheritdoc />
+    public Size Measure(Size available)
+    {
+        var height = Math.Min(_items.Count, _visibleRows);
+        if (_isEditingOther)
+            height++; // Extra row for text input
+
+        // Calculate width based on content
+        var maxItemWidth = _items.Count > 0
+            ? _items.Max(i => GetItemDisplayLength(i, _items.IndexOf(i)))
+            : 10;
+
+        var width = Math.Min(maxItemWidth + 2, available.Width);
+
+        return new Size(width, height);
+    }
+
+    private int GetItemDisplayLength(SelectionItem<T> item, int index)
+    {
+        var prefix = GetItemPrefix(item, index);
+        return prefix.Length + item.DisplayText.Length;
+    }
+
+    private string GetItemPrefix(SelectionItem<T> item, int index)
+    {
+        var parts = new List<string>();
+
+        // Number prefix
+        if (_showNumbers && index < 9)
+        {
+            parts.Add($"{index + 1}.");
+        }
+
+        // Checkbox for multi-select
+        if (_mode == SelectionMode.Multi && !item.IsOther)
+        {
+            parts.Add(item.IsSelected ? "[x]" : "[ ]");
+        }
+        else if (_mode == SelectionMode.Single && item.IsSelected && !item.IsOther)
+        {
+            parts.Add("●");
+        }
+
+        return parts.Count > 0 ? string.Join(" ", parts) + " " : "";
+    }
+
+    /// <inheritdoc />
+    public void Render(IRenderContext context, Rect bounds)
+    {
+        if (!bounds.HasArea || _items.Count == 0)
+            return;
+
+        var visibleCount = Math.Min(_visibleRows, bounds.Height);
+        var needsScrollbar = _items.Count > visibleCount;
+        var contentWidth = needsScrollbar ? bounds.Width - 1 : bounds.Width;
+
+        for (var row = 0; row < visibleCount; row++)
+        {
+            var itemIndex = _scrollOffset + row;
+            if (itemIndex >= _items.Count)
+                break;
+
+            var item = _items[itemIndex];
+            var isHighlighted = itemIndex == _highlightedIndex && _hasFocus && !_isEditingOther;
+
+            RenderItem(context, item, itemIndex, row, contentWidth, isHighlighted);
+        }
+
+        // Render scrollbar if needed
+        if (needsScrollbar)
+        {
+            RenderScrollbar(context, bounds.Width - 1, visibleCount);
+        }
+
+        // Render "Other" text input below the list
+        if (_isEditingOther && _otherInput != null)
+        {
+            var inputY = Math.Min(visibleCount, bounds.Height - 1);
+            if (inputY < bounds.Height)
+            {
+                var inputBounds = new Rect(0, inputY, bounds.Width, 1);
+                _otherInput.Render(context, inputBounds);
+            }
+        }
+    }
+
+    private void RenderItem(IRenderContext context, SelectionItem<T> item, int index, int row,
+        int width, bool isHighlighted)
+    {
+        // Set colors
+        if (isHighlighted)
+        {
+            context.SetForeground(_highlightForeground);
+            context.SetBackground(_highlightBackground);
+        }
+        else if (item.IsSelected && _selectedForeground.HasValue)
+        {
+            context.SetForeground(_selectedForeground.Value);
+        }
+        else if (_foreground.HasValue)
+        {
+            context.SetForeground(_foreground.Value);
+        }
+
+        // Build display string
+        var prefix = GetItemPrefix(item, index);
+        var displayText = prefix + item.DisplayText;
+
+        // Truncate if needed
+        if (displayText.Length > width)
+        {
+            displayText = displayText[..(width - 1)] + "…";
+        }
+
+        // Pad to full width for highlight background
+        if (isHighlighted)
+        {
+            displayText = displayText.PadRight(width);
+        }
+
+        context.WriteAt(0, row, displayText);
+        context.ResetColors();
+    }
+
+    private void RenderScrollbar(IRenderContext context, int x, int height)
+    {
+        if (_items.Count <= height)
+            return;
+
+        var thumbSize = Math.Max(1, height * height / _items.Count);
+        var thumbPos = _scrollOffset * (height - thumbSize) / (_items.Count - height);
+
+        context.SetForeground(Color.BrightBlack);
+
+        for (var row = 0; row < height; row++)
+        {
+            var isThumb = row >= thumbPos && row < thumbPos + thumbSize;
+            context.WriteAt(x, row, isThumb ? '█' : '░');
+        }
+
+        context.ResetColors();
+    }
+
+    private void Invalidate()
+    {
+        if (!_disposed)
+            _invalidated.OnNext(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        _selectionConfirmed.OnCompleted();
+        _selectionConfirmed.Dispose();
+        _otherSelected.OnCompleted();
+        _otherSelected.Dispose();
+        _cancelled.OnCompleted();
+        _cancelled.Dispose();
+
+        _otherInput?.Dispose();
+    }
+}

--- a/src/Termina/Layout/SelectionMode.cs
+++ b/src/Termina/Layout/SelectionMode.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Defines the selection behavior for SelectionListNode.
+/// </summary>
+public enum SelectionMode
+{
+    /// <summary>
+    /// Only one item can be selected at a time.
+    /// </summary>
+    Single,
+
+    /// <summary>
+    /// Multiple items can be selected simultaneously.
+    /// </summary>
+    Multi
+}

--- a/src/Termina/Layout/StackLayout.cs
+++ b/src/Termina/Layout/StackLayout.cs
@@ -20,6 +20,15 @@ public sealed class StackLayout : ContainerNode
         WidthConstraint = new SizeConstraint.Fill();
     }
 
+    /// <summary>
+    /// Add a child node fluently.
+    /// </summary>
+    public StackLayout WithChild(ILayoutNode child)
+    {
+        AddChild(child);
+        return this;
+    }
+
     /// <inheritdoc />
     public override Size Measure(Size available)
     {

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -19,7 +19,7 @@ namespace Termina.Layout;
 /// which can decide whether to enable history, how many entries to keep, and whether to
 /// persist it across sessions.
 /// </remarks>
-public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
+public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode, IFocusable
 {
     private readonly Timer _cursorTimer;
     private readonly Subject<Unit> _invalidated = new();
@@ -30,6 +30,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     private int _selectionStart = -1;
     private int _scrollOffset;
     private bool _cursorVisible = true;
+    private bool _hasFocus;
     private bool _disposed;
 
     /// <inheritdoc />
@@ -47,6 +48,34 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     /// <inheritdoc />
     public bool IsAnimating { get; private set; }
+
+    /// <inheritdoc />
+    public bool CanFocus => true;
+
+    /// <inheritdoc />
+    public bool HasFocus => _hasFocus;
+
+    /// <summary>
+    /// Text input has low-medium priority (lower than modal and selection list).
+    /// </summary>
+    public int FocusPriority => 5;
+
+    /// <inheritdoc />
+    public void OnFocused()
+    {
+        _hasFocus = true;
+        _cursorVisible = true;
+        Start(); // Ensure cursor is blinking
+        _invalidated.OnNext(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public void OnBlurred()
+    {
+        _hasFocus = false;
+        Stop(); // Stop cursor blinking when not focused
+        _invalidated.OnNext(Unit.Default);
+    }
 
     /// <summary>
     /// Gets or sets the current text value.

--- a/src/Termina/Reactive/ReactiveViewModel.cs
+++ b/src/Termina/Reactive/ReactiveViewModel.cs
@@ -107,6 +107,12 @@ public abstract class ReactiveViewModel : IDisposable
     protected IObservable<IInputEvent> Input { get; private set; } = null!;
 
     /// <summary>
+    /// The focus manager for managing keyboard focus between interactive components.
+    /// Use this to push/pop focus for modals or set focus to specific controls.
+    /// </summary>
+    protected IFocusManager Focus { get; private set; } = null!;
+
+    /// <summary>
     /// Called when the page becomes active (navigated to).
     /// Override to perform initialization that should happen each time the page is shown.
     /// </summary>
@@ -142,7 +148,7 @@ public abstract class ReactiveViewModel : IDisposable
     }
 
     /// <summary>
-    /// Wires up the navigation, shutdown actions, and input observable.
+    /// Wires up the navigation, shutdown actions, input observable, and focus manager.
     /// Called by the framework when binding to a page.
     /// </summary>
     internal void WireUp(
@@ -150,12 +156,14 @@ public abstract class ReactiveViewModel : IDisposable
         Action<string, object?> navigateWithParams,
         Action shutdown,
         Action requestRedraw,
-        IObservable<IInputEvent> input)
+        IObservable<IInputEvent> input,
+        IFocusManager focusManager)
     {
         Navigate = navigate;
         NavigateWithParams = navigateWithParams;
         Shutdown = shutdown;
         RequestRedraw = requestRedraw;
         Input = input;
+        Focus = focusManager;
     }
 }

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -46,6 +46,7 @@ public sealed class TerminaApplication
     private readonly Dictionary<string, (IPage Page, ReactiveViewModel ViewModel)> _cachedPages = new();
     private readonly Stack<(string Path, IReadOnlyDictionary<string, object>? Parameters)> _history = new();
     private readonly List<IInputSource> _inputSources = new();
+    private readonly FocusManager _focusManager = new();
 
     private string? _currentPath;
     private IReadOnlyDictionary<string, object>? _currentParameters;
@@ -80,6 +81,11 @@ public sealed class TerminaApplication
     /// Observable stream of input events. ViewModels subscribe to this.
     /// </summary>
     public IObservable<IInputEvent> Input => _inputSubject.AsObservable();
+
+    /// <summary>
+    /// Gets the focus manager for routing input to focused components.
+    /// </summary>
+    public IFocusManager Focus => _focusManager;
 
     /// <summary>
     /// Gets the current navigation path, if any.
@@ -213,8 +219,8 @@ public sealed class TerminaApplication
                 receiver.SetRouteParameters(parameters);
             }
 
-            // Wire up ViewModel with navigation, shutdown, and redraw actions
-            _currentViewModel.WireUp(NavigateTo, (t, v) => NavigateTo(t, v), Shutdown, RequestRedraw, Input);
+            // Wire up ViewModel with navigation, shutdown, redraw, and focus manager
+            _currentViewModel.WireUp(NavigateTo, (t, v) => NavigateTo(t, v), Shutdown, RequestRedraw, Input, _focusManager);
 
             // Bind page to ViewModel
             BindPageToViewModel(_currentPage, _currentViewModel);
@@ -370,9 +376,17 @@ public sealed class TerminaApplication
                 return;
         }
 
-        // Route input events to the observable - ViewModels subscribe to this
+        // Route input events through the focus manager first, then to ViewModel
         if (evt is IInputEvent inputEvent)
         {
+            // For key presses, give focused components first chance to handle
+            if (inputEvent is KeyPressed keyPressed)
+            {
+                if (_focusManager.RouteInput(keyPressed.KeyInfo))
+                    return; // Input was consumed by focused component
+            }
+
+            // If not consumed, route to ViewModel via observable
             _inputSubject.OnNext(inputEvent);
         }
     }

--- a/tests/Termina.Tests/Input/FocusManagerTests.cs
+++ b/tests/Termina.Tests/Input/FocusManagerTests.cs
@@ -1,0 +1,245 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Input;
+
+/// <summary>
+/// Tests for the FocusManager class.
+/// </summary>
+public class FocusManagerTests
+{
+    [Fact]
+    public void FocusManager_InitialState_HasNoFocus()
+    {
+        using var focusManager = new FocusManager();
+
+        Assert.Null(focusManager.CurrentFocus);
+    }
+
+    [Fact]
+    public void FocusManager_PushFocus_SetsFocusToComponent()
+    {
+        using var focusManager = new FocusManager();
+        var focusable = new TestFocusable();
+
+        focusManager.PushFocus(focusable);
+
+        Assert.Same(focusable, focusManager.CurrentFocus);
+        Assert.True(focusable.HasFocus);
+    }
+
+    [Fact]
+    public void FocusManager_PushFocus_CallsOnFocused()
+    {
+        using var focusManager = new FocusManager();
+        var focusable = new TestFocusable();
+
+        focusManager.PushFocus(focusable);
+
+        Assert.True(focusable.OnFocusedCalled);
+    }
+
+    [Fact]
+    public void FocusManager_PushFocus_BlursPreviousFocus()
+    {
+        using var focusManager = new FocusManager();
+        var first = new TestFocusable();
+        var second = new TestFocusable();
+
+        focusManager.PushFocus(first);
+        focusManager.PushFocus(second);
+
+        Assert.False(first.HasFocus);
+        Assert.True(first.OnBlurredCalled);
+        Assert.True(second.HasFocus);
+    }
+
+    [Fact]
+    public void FocusManager_PopFocus_RestoresPreviousFocus()
+    {
+        using var focusManager = new FocusManager();
+        var first = new TestFocusable();
+        var second = new TestFocusable();
+
+        focusManager.PushFocus(first);
+        focusManager.PushFocus(second);
+        focusManager.PopFocus();
+
+        Assert.Same(first, focusManager.CurrentFocus);
+        Assert.True(first.HasFocus);
+        Assert.False(second.HasFocus);
+    }
+
+    [Fact]
+    public void FocusManager_PopFocus_EmptyStack_DoesNotThrow()
+    {
+        using var focusManager = new FocusManager();
+
+        // Should not throw
+        focusManager.PopFocus();
+
+        Assert.Null(focusManager.CurrentFocus);
+    }
+
+    [Fact]
+    public void FocusManager_SetFocus_ReplacesCurrentFocus()
+    {
+        using var focusManager = new FocusManager();
+        var first = new TestFocusable();
+        var second = new TestFocusable();
+
+        focusManager.PushFocus(first);
+        focusManager.SetFocus(second);
+
+        Assert.Same(second, focusManager.CurrentFocus);
+        Assert.False(first.HasFocus);
+        Assert.True(second.HasFocus);
+    }
+
+    [Fact]
+    public void FocusManager_ClearFocus_RemovesAllFocus()
+    {
+        using var focusManager = new FocusManager();
+        var first = new TestFocusable();
+        var second = new TestFocusable();
+
+        focusManager.PushFocus(first);
+        focusManager.PushFocus(second);
+        focusManager.ClearFocus();
+
+        Assert.Null(focusManager.CurrentFocus);
+        Assert.False(first.HasFocus);
+        Assert.False(second.HasFocus);
+    }
+
+    [Fact]
+    public void FocusManager_RouteInput_RoutesToCurrentFocus()
+    {
+        using var focusManager = new FocusManager();
+        var focusable = new TestFocusable { HandleInputResult = true };
+
+        focusManager.PushFocus(focusable);
+        var key = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
+        var result = focusManager.RouteInput(key);
+
+        Assert.True(result);
+        Assert.Equal(key, focusable.LastKey);
+    }
+
+    [Fact]
+    public void FocusManager_RouteInput_NoFocus_ReturnsFalse()
+    {
+        using var focusManager = new FocusManager();
+        var key = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
+
+        var result = focusManager.RouteInput(key);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void FocusManager_RouteInput_ComponentDoesNotConsume_ReturnsFalse()
+    {
+        using var focusManager = new FocusManager();
+        var focusable = new TestFocusable { HandleInputResult = false };
+
+        focusManager.PushFocus(focusable);
+        var key = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
+        var result = focusManager.RouteInput(key);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void FocusManager_FocusChanged_EmitsFocusChanges()
+    {
+        using var focusManager = new FocusManager();
+        var focusable = new TestFocusable();
+        var focusChanges = new List<IFocusable?>();
+
+        focusManager.FocusChanged.Subscribe(f => focusChanges.Add(f));
+
+        focusManager.PushFocus(focusable);
+        focusManager.PopFocus();
+
+        Assert.Equal(3, focusChanges.Count); // Initial null + focus + pop
+        Assert.Null(focusChanges[0]); // Initial state (BehaviorSubject)
+        Assert.Same(focusable, focusChanges[1]);
+        Assert.Null(focusChanges[2]);
+    }
+
+    [Fact]
+    public void FocusManager_PushFocus_CannotFocus_DoesNothing()
+    {
+        using var focusManager = new FocusManager();
+        var focusable = new TestFocusable { CanFocusValue = false };
+
+        focusManager.PushFocus(focusable);
+
+        Assert.Null(focusManager.CurrentFocus);
+        Assert.False(focusable.OnFocusedCalled);
+    }
+
+    [Fact]
+    public void FocusManager_Dispose_ClearsAllFocus()
+    {
+        var focusManager = new FocusManager();
+        var first = new TestFocusable();
+        var second = new TestFocusable();
+
+        focusManager.PushFocus(first);
+        focusManager.PushFocus(second);
+        focusManager.Dispose();
+
+        // After dispose, both should be blurred
+        Assert.False(first.HasFocus);
+        Assert.False(second.HasFocus);
+    }
+
+    /// <summary>
+    /// Test implementation of IFocusable for testing focus behavior.
+    /// </summary>
+    private class TestFocusable : IFocusable
+    {
+        public bool CanFocusValue { get; set; } = true;
+        public bool HasFocus { get; private set; }
+        public bool OnFocusedCalled { get; private set; }
+        public bool OnBlurredCalled { get; private set; }
+        public bool HandleInputResult { get; set; } = true;
+        public ConsoleKeyInfo? LastKey { get; private set; }
+
+        public bool CanFocus => CanFocusValue;
+        public int FocusPriority => 10;
+
+        public void OnFocused()
+        {
+            OnFocusedCalled = true;
+            HasFocus = true;
+        }
+
+        public void OnBlurred()
+        {
+            OnBlurredCalled = true;
+            HasFocus = false;
+        }
+
+        public bool HandleInput(ConsoleKeyInfo key)
+        {
+            LastKey = key;
+            return HandleInputResult;
+        }
+
+        // ILayoutNode implementation (minimal)
+        public SizeConstraint WidthConstraint => SizeConstraint.AutoSize();
+        public SizeConstraint HeightConstraint => SizeConstraint.AutoSize();
+        public Size Measure(Size available) => new(0, 0);
+        public void Render(IRenderContext context, Rect bounds) { }
+        public void Dispose() { }
+    }
+}

--- a/tests/Termina.Tests/Layout/ModalNodeTests.cs
+++ b/tests/Termina.Tests/Layout/ModalNodeTests.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for the ModalNode component.
+/// </summary>
+public class ModalNodeTests
+{
+    [Fact]
+    public void ModalNode_CanBeCreated()
+    {
+        using var modal = new ModalNode();
+        Assert.NotNull(modal);
+    }
+
+    [Fact]
+    public void ModalNode_HasDefaultValues()
+    {
+        using var modal = new ModalNode();
+
+        Assert.True(modal.CanFocus);
+        Assert.False(modal.HasFocus);
+        Assert.Equal(100, modal.FocusPriority);
+    }
+
+    [Fact]
+    public void ModalNode_FluentApi_ReturnsThis()
+    {
+        using var modal = new ModalNode();
+
+        var result = modal
+            .WithTitle("Test")
+            .WithTitleColor(Color.White)
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Color.Cyan)
+            .WithBackdrop(BackdropStyle.Dim)
+            .WithBackdropColor(Color.BrightBlack)
+            .WithBackdropChar('░')
+            .WithPosition(ModalPosition.Center)
+            .WithPadding(1)
+            .WithDismissOnEscape(true);
+
+        Assert.Same(modal, result);
+    }
+
+    [Fact]
+    public void ModalNode_WithContent_SetsContent()
+    {
+        using var content = new TextNode("Test content");
+        using var modal = new ModalNode().WithContent(content);
+
+        Assert.Same(content, modal.Content);
+    }
+
+    [Fact]
+    public void ModalNode_OnFocused_SetsHasFocus()
+    {
+        using var modal = new ModalNode();
+        Assert.False(modal.HasFocus);
+
+        modal.OnFocused();
+
+        Assert.True(modal.HasFocus);
+    }
+
+    [Fact]
+    public void ModalNode_OnBlurred_ClearsHasFocus()
+    {
+        using var modal = new ModalNode();
+        modal.OnFocused();
+        Assert.True(modal.HasFocus);
+
+        modal.OnBlurred();
+
+        Assert.False(modal.HasFocus);
+    }
+
+    [Fact]
+    public void ModalNode_HandleInput_Escape_EmitsDismissed()
+    {
+        using var modal = new ModalNode().WithDismissOnEscape(true);
+        var dismissed = false;
+        modal.Dismissed.Subscribe(_ => dismissed = true);
+
+        var escapeKey = new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false);
+        var result = modal.HandleInput(escapeKey);
+
+        Assert.True(result);
+        Assert.True(dismissed);
+    }
+
+    [Fact]
+    public void ModalNode_HandleInput_Escape_DismissDisabled_DoesNotEmit()
+    {
+        using var modal = new ModalNode().WithDismissOnEscape(false);
+        var dismissed = false;
+        modal.Dismissed.Subscribe(_ => dismissed = true);
+
+        var escapeKey = new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false);
+        var result = modal.HandleInput(escapeKey);
+
+        Assert.True(result); // Modal still consumes input
+        Assert.False(dismissed);
+    }
+
+    [Fact]
+    public void ModalNode_HandleInput_OtherKeys_AreConsumed()
+    {
+        using var modal = new ModalNode();
+
+        var aKey = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
+        var result = modal.HandleInput(aKey);
+
+        Assert.True(result); // Modal consumes all input to prevent it reaching underlying UI
+    }
+
+    [Fact]
+    public void ModalNode_HandleInput_ForwardsToFocusableContent()
+    {
+        var focusable = new FocusableTestContent();
+        using var modal = new ModalNode().WithContent(focusable);
+
+        var aKey = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
+        modal.HandleInput(aKey);
+
+        Assert.Equal(aKey, focusable.LastHandledKey);
+    }
+
+    [Fact]
+    public void ModalNode_Invalidated_EmitsOnPropertyChanges()
+    {
+        using var modal = new ModalNode();
+        var invalidated = false;
+        modal.Invalidated.Subscribe(_ => invalidated = true);
+
+        // Setting content triggers invalidation
+        modal.Content = new TextNode("Test");
+
+        Assert.True(invalidated);
+    }
+
+    [Fact]
+    public void ModalNode_Measure_ReturnsFillSize()
+    {
+        using var modal = new ModalNode();
+        var available = new Size(100, 50);
+
+        var size = modal.Measure(available);
+
+        Assert.Equal(available, size);
+    }
+
+    [Fact]
+    public void ModalNode_Dispose_CompletesObservables()
+    {
+        var modal = new ModalNode();
+        var invalidatedCompleted = false;
+        var dismissedCompleted = false;
+
+        modal.Invalidated.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => invalidatedCompleted = true);
+        modal.Dismissed.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => dismissedCompleted = true);
+
+        modal.Dispose();
+
+        Assert.True(invalidatedCompleted);
+        Assert.True(dismissedCompleted);
+    }
+
+    [Fact]
+    public void ModalNode_WidthConstraint_IsFillRemaining()
+    {
+        using var modal = new ModalNode();
+
+        Assert.IsType<SizeConstraint.Fill>(modal.WidthConstraint);
+    }
+
+    [Fact]
+    public void ModalNode_HeightConstraint_IsFillRemaining()
+    {
+        using var modal = new ModalNode();
+
+        Assert.IsType<SizeConstraint.Fill>(modal.HeightConstraint);
+    }
+
+    /// <summary>
+    /// Test implementation of IFocusable for testing input forwarding.
+    /// </summary>
+    private class FocusableTestContent : IFocusable
+    {
+        public ConsoleKeyInfo? LastHandledKey { get; private set; }
+
+        public SizeConstraint WidthConstraint => SizeConstraint.AutoSize();
+        public SizeConstraint HeightConstraint => SizeConstraint.AutoSize();
+        public bool CanFocus => true;
+        public bool HasFocus => false;
+        public int FocusPriority => 1;
+
+        public void OnFocused() { }
+        public void OnBlurred() { }
+
+        public bool HandleInput(ConsoleKeyInfo key)
+        {
+            LastHandledKey = key;
+            return true;
+        }
+
+        public Size Measure(Size available) => new(10, 1);
+        public void Render(IRenderContext context, Rect bounds) { }
+        public void Dispose() { }
+    }
+}

--- a/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
@@ -322,4 +322,133 @@ public class SelectionListNodeTests
     }
 
     private record TestItem(int Id, string Name);
+
+    [Fact]
+    public void SelectionListNode_SingleMode_EnterSelectsHighlightedItem()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithMode(SelectionMode.Single);
+        list.OnFocused();
+
+        var confirmed = new List<string>();
+        list.SelectionConfirmed.Subscribe(items => confirmed.AddRange(items));
+
+        // Move to B and press Enter without pressing Space first
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        // Should have selected B (the highlighted item)
+        Assert.Single(confirmed);
+        Assert.Equal("B", confirmed[0]);
+    }
+
+    [Fact]
+    public void SelectionListNode_SingleMode_EnterOverridesPreviousSelection()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithMode(SelectionMode.Single);
+        list.OnFocused();
+
+        var confirmed = new List<string>();
+        list.SelectionConfirmed.Subscribe(items => confirmed.AddRange(items));
+
+        // First select A with Space
+        var spaceKey = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+        list.HandleInput(spaceKey);
+        Assert.True(list.Items[0].IsSelected);
+
+        // Move to C and press Enter (not Space)
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+        list.HandleInput(downKey);
+
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        // Should have selected C (overriding A)
+        Assert.Single(confirmed);
+        Assert.Equal("C", confirmed[0]);
+        Assert.False(list.Items[0].IsSelected);
+        Assert.True(list.Items[2].IsSelected);
+    }
+
+    [Fact]
+    public void SelectionListNode_OtherOption_AutoStartsEditingOnNavigate()
+    {
+        using var list = Layouts.SelectionList("A", "B")
+            .WithOtherOption("Custom...");
+        list.OnFocused();
+
+        // Move to Other option - should auto-start editing
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+        list.HandleInput(downKey);
+
+        // Verify we're on the Other option
+        Assert.True(list.HighlightedItem?.IsOther);
+
+        // Should be able to type immediately without pressing Enter first
+        list.HandleInput(new ConsoleKeyInfo('T', ConsoleKey.T, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('e', ConsoleKey.E, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('s', ConsoleKey.S, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('t', ConsoleKey.T, false, false, false));
+
+        // This test verifies navigating to Other auto-starts text input mode
+    }
+
+    [Fact]
+    public void SelectionListNode_OtherOption_EmitsOtherSelectedOnConfirm()
+    {
+        using var list = Layouts.SelectionList("A", "B")
+            .WithOtherOption("Custom...");
+        list.OnFocused();
+
+        string? customValue = null;
+        list.OtherSelected.Subscribe(text => customValue = text);
+
+        // Navigate to Other - auto-starts editing
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+        list.HandleInput(downKey);
+
+        // Type "Hi" immediately (no Enter needed to start)
+        list.HandleInput(new ConsoleKeyInfo('H', ConsoleKey.H, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('i', ConsoleKey.I, false, false, false));
+
+        // Press Enter to confirm
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        Assert.Equal("Hi", customValue);
+    }
+
+    [Fact]
+    public void SelectionListNode_OtherOption_NumberKeyAutoStartsEditing()
+    {
+        using var list = Layouts.SelectionList("A", "B")
+            .WithOtherOption("Custom...");
+        list.OnFocused();
+
+        string? customValue = null;
+        list.OtherSelected.Subscribe(text => customValue = text);
+
+        // Press '3' to jump to Other option - should auto-start editing
+        var key3 = new ConsoleKeyInfo('3', ConsoleKey.D3, false, false, false);
+        list.HandleInput(key3);
+
+        // Type "Fast" immediately
+        list.HandleInput(new ConsoleKeyInfo('F', ConsoleKey.F, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('s', ConsoleKey.S, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('t', ConsoleKey.T, false, false, false));
+
+        // Press Enter to confirm
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        Assert.Equal("Fast", customValue);
+    }
 }

--- a/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
@@ -1,0 +1,325 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for the SelectionListNode component.
+/// </summary>
+public class SelectionListNodeTests
+{
+    [Fact]
+    public void SelectionListNode_CanBeCreatedWithItems()
+    {
+        var items = new[] { "Item 1", "Item 2", "Item 3" };
+        using var list = new SelectionListNode<string>(items, s => s);
+
+        Assert.NotNull(list);
+        Assert.Equal(3, list.Items.Count);
+    }
+
+    [Fact]
+    public void SelectionListNode_HasDefaultValues()
+    {
+        using var list = Layouts.SelectionList("A", "B");
+
+        Assert.True(list.CanFocus);
+        Assert.False(list.HasFocus);
+        Assert.Equal(10, list.FocusPriority);
+    }
+
+    [Fact]
+    public void SelectionListNode_FluentApi_ReturnsThis()
+    {
+        var items = new[] { "A", "B", "C" };
+        using var list = new SelectionListNode<string>(items, s => s);
+
+        var result = list
+            .WithMode(SelectionMode.Multi)
+            .WithHighlightColors(Color.Black, Color.White)
+            .WithForeground(Color.Gray)
+            .WithSelectedForeground(Color.Green)
+            .WithShowNumbers(true)
+            .WithVisibleRows(5);
+
+        Assert.Same(list, result);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithOtherOption_AddsOtherItem()
+    {
+        var items = new[] { "A", "B" };
+        using var list = new SelectionListNode<string>(items, s => s)
+            .WithOtherOption("Custom...");
+
+        Assert.Equal(3, list.Items.Count);
+        Assert.True(list.Items[2].IsOther);
+        Assert.Equal("Custom...", list.Items[2].DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_OnFocused_SetsHasFocus()
+    {
+        using var list = Layouts.SelectionList("A", "B");
+        Assert.False(list.HasFocus);
+
+        list.OnFocused();
+
+        Assert.True(list.HasFocus);
+    }
+
+    [Fact]
+    public void SelectionListNode_OnBlurred_ClearsHasFocus()
+    {
+        using var list = Layouts.SelectionList("A", "B");
+        list.OnFocused();
+
+        list.OnBlurred();
+
+        Assert.False(list.HasFocus);
+    }
+
+    [Fact]
+    public void SelectionListNode_HandleInput_DownArrow_MovesHighlight()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C");
+        list.OnFocused();
+
+        // Initial highlight should be at index 0
+        Assert.Equal("A", list.HighlightedItem?.DisplayText);
+
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+
+        Assert.Equal("B", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_HandleInput_UpArrow_MovesHighlight()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C");
+        list.OnFocused();
+
+        // Move down first
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+        Assert.Equal("B", list.HighlightedItem?.DisplayText);
+
+        // Then up
+        var upKey = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
+        list.HandleInput(upKey);
+
+        Assert.Equal("A", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_HandleInput_Home_MovesToFirst()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C");
+        list.OnFocused();
+
+        // Move to middle
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+        list.HandleInput(downKey);
+        Assert.Equal("C", list.HighlightedItem?.DisplayText);
+
+        // Press Home
+        var homeKey = new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false);
+        list.HandleInput(homeKey);
+
+        Assert.Equal("A", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_HandleInput_End_MovesToLast()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C");
+        list.OnFocused();
+
+        Assert.Equal("A", list.HighlightedItem?.DisplayText);
+
+        var endKey = new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false);
+        list.HandleInput(endKey);
+
+        Assert.Equal("C", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_HandleInput_Space_TogglesSelectionInMultiMode()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithMode(SelectionMode.Multi);
+        list.OnFocused();
+
+        Assert.False(list.Items[0].IsSelected);
+
+        var spaceKey = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+        list.HandleInput(spaceKey);
+
+        Assert.True(list.Items[0].IsSelected);
+
+        // Toggle off
+        list.HandleInput(spaceKey);
+        Assert.False(list.Items[0].IsSelected);
+    }
+
+    [Fact]
+    public void SelectionListNode_HandleInput_NumberKeys_SelectItem()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithShowNumbers(true)
+            .WithMode(SelectionMode.Multi);
+        list.OnFocused();
+
+        // Press '2' to select second item
+        var key2 = new ConsoleKeyInfo('2', ConsoleKey.D2, false, false, false);
+        list.HandleInput(key2);
+
+        Assert.True(list.Items[1].IsSelected);
+    }
+
+    [Fact]
+    public void SelectionListNode_HandleInput_Enter_EmitsSelectionConfirmed()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithMode(SelectionMode.Multi);
+        list.OnFocused();
+
+        var confirmed = new List<string>();
+        list.SelectionConfirmed.Subscribe(items => confirmed.AddRange(items));
+
+        // Select first item
+        var spaceKey = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+        list.HandleInput(spaceKey);
+
+        // Confirm
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        Assert.Single(confirmed);
+        Assert.Equal("A", confirmed[0]);
+    }
+
+    [Fact]
+    public void SelectionListNode_HandleInput_Escape_EmitsCancelled()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C");
+        list.OnFocused();
+
+        var cancelled = false;
+        list.Cancelled.Subscribe(_ => cancelled = true);
+
+        var escapeKey = new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false);
+        list.HandleInput(escapeKey);
+
+        Assert.True(cancelled);
+    }
+
+    [Fact]
+    public void SelectionListNode_SingleMode_ClearsOtherSelections()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithMode(SelectionMode.Single);
+        list.OnFocused();
+
+        // Select first item
+        var spaceKey = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+        list.HandleInput(spaceKey);
+        Assert.True(list.Items[0].IsSelected);
+
+        // Move down and select second
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+        list.HandleInput(spaceKey);
+
+        // First should be deselected, second selected
+        Assert.False(list.Items[0].IsSelected);
+        Assert.True(list.Items[1].IsSelected);
+    }
+
+    [Fact]
+    public void SelectionListNode_SelectedItems_ReturnsOnlySelected()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithMode(SelectionMode.Multi);
+        list.OnFocused();
+
+        // Select A and C
+        var spaceKey = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+
+        list.HandleInput(spaceKey); // Select A
+        list.HandleInput(downKey);  // Move to B
+        list.HandleInput(downKey);  // Move to C
+        list.HandleInput(spaceKey); // Select C
+
+        var selected = list.SelectedItems;
+        Assert.Equal(2, selected.Count);
+        Assert.Contains("A", selected);
+        Assert.Contains("C", selected);
+    }
+
+    [Fact]
+    public void SelectionListNode_Invalidated_EmitsOnChanges()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C");
+        var invalidationCount = 0;
+        list.Invalidated.Subscribe(_ => invalidationCount++);
+
+        list.OnFocused();
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+
+        Assert.True(invalidationCount > 0);
+    }
+
+    [Fact]
+    public void SelectionListNode_Dispose_CompletesObservables()
+    {
+        var list = Layouts.SelectionList("A", "B");
+        var completed = 0;
+
+        list.SelectionConfirmed.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => completed++);
+        list.OtherSelected.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => completed++);
+        list.Cancelled.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => completed++);
+        list.Invalidated.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => completed++);
+
+        list.Dispose();
+
+        Assert.Equal(4, completed);
+    }
+
+    [Fact]
+    public void SelectionListNode_TypedItems_WorksWithCustomTypes()
+    {
+        var items = new[]
+        {
+            new TestItem(1, "First"),
+            new TestItem(2, "Second"),
+            new TestItem(3, "Third")
+        };
+
+        using var list = new SelectionListNode<TestItem>(items, i => i.Name);
+
+        Assert.Equal(3, list.Items.Count);
+        Assert.Equal("First", list.Items[0].DisplayText);
+        Assert.Equal(1, list.Items[0].Value.Id);
+    }
+
+    private record TestItem(int Id, string Name);
+}

--- a/tests/Termina.Tests/ReactiveViewModelTests.cs
+++ b/tests/Termina.Tests/ReactiveViewModelTests.cs
@@ -2,6 +2,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Termina.Input;
+using Termina.Layout;
 using Termina.Reactive;
 
 namespace Termina.Tests;
@@ -42,7 +43,8 @@ public class ReactiveViewModelTests
             navigateWithParams: (_, _) => { },
             shutdown: () => { },
             requestRedraw: () => { },
-            input: Observable.Empty<IInputEvent>());
+            input: Observable.Empty<IInputEvent>(),
+            focusManager: new StubFocusManager());
 
         vm.TestNavigate("test-page");
 
@@ -60,7 +62,8 @@ public class ReactiveViewModelTests
             navigateWithParams: (_, _) => { },
             shutdown: () => shutdownCalled = true,
             requestRedraw: () => { },
-            input: Observable.Empty<IInputEvent>());
+            input: Observable.Empty<IInputEvent>(),
+            focusManager: new StubFocusManager());
 
         vm.TestShutdown();
 
@@ -79,7 +82,8 @@ public class ReactiveViewModelTests
             navigateWithParams: (_, _) => { },
             shutdown: () => { },
             requestRedraw: () => { },
-            input: inputSubject);
+            input: inputSubject,
+            focusManager: new StubFocusManager());
 
         vm.TestInput.OfType<KeyPressed>()
             .Subscribe(k => receivedKeys.Add(k.KeyInfo.Key))
@@ -97,7 +101,7 @@ public class ReactiveViewModelTests
     public void ReactiveViewModel_OnActivatedCalled()
     {
         var vm = new TestViewModel();
-        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => { }, Observable.Empty<IInputEvent>());
+        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => { }, Observable.Empty<IInputEvent>(), new StubFocusManager());
 
         Assert.False(vm.WasActivated);
 
@@ -110,7 +114,7 @@ public class ReactiveViewModelTests
     public void ReactiveViewModel_OnDeactivatingCalled()
     {
         var vm = new TestViewModel();
-        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => { }, Observable.Empty<IInputEvent>());
+        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => { }, Observable.Empty<IInputEvent>(), new StubFocusManager());
 
         Assert.False(vm.WasDeactivating);
 
@@ -248,4 +252,18 @@ public partial class TestReactiveViewModelWithCustomDispose : ReactiveViewModel
         DisposeReactiveFields();
         base.Dispose();
     }
+}
+
+/// <summary>
+/// Stub implementation of IFocusManager for testing.
+/// </summary>
+internal class StubFocusManager : IFocusManager
+{
+    public IObservable<IFocusable?> FocusChanged => Observable.Empty<IFocusable?>();
+    public IFocusable? CurrentFocus => null;
+    public void PushFocus(IFocusable focusable) { }
+    public void PopFocus() { }
+    public void SetFocus(IFocusable focusable) { }
+    public void ClearFocus() { }
+    public bool RouteInput(ConsoleKeyInfo key) => false;
 }


### PR DESCRIPTION
## Summary

Implements GitHub issue #43 - Modal/Overlay component for selection prompts.

This PR adds a complete focus management system and new interactive components:

- **Focus Management System**: Routes keyboard input to focused interactive components with a priority-based stack for nested modals
- **ModalNode**: Overlay component with configurable backdrop (transparent, dim, solid), positioning (center, top, bottom), and Escape dismissal
- **SelectionListNode**: Interactive list selection with single/multi-select modes, keyboard navigation, number keys for quick selection, and optional "Other" text input
- **DeferredNode**: Non-owning wrapper that prevents ObjectDisposedException when showing/hiding components in reactive layouts
- **TextInputNode IFocusable**: Text inputs now implement IFocusable for seamless modal integration

### Key Features

**ModalNode**:
- Configurable backdrop styles and colors
- Border styles matching PanelNode
- Forwards input to focusable content
- Observable-based dismissal handling

**SelectionListNode**:
- Single and multi-select modes
- Arrow keys, Home/End, Space (toggle), Enter (confirm)
- Number keys 1-9 for quick selection
- "Other" option with immediate inline text input
- Scrolling for long lists

**Focus Management**:
- `Focus.PushFocus(modal)` / `Focus.PopFocus()` API
- Priority-based input routing
- `IFocusable` interface for custom interactive components

## Test plan

- [x] All 516 existing tests pass
- [x] New FocusManager tests (245 lines)
- [x] New ModalNode tests (223 lines)
- [x] New SelectionListNode tests (454 lines)
- [x] Manual testing with TodoListPage demo
- [ ] Verify documentation renders correctly in VitePress

Closes #43