### PR TITLE
Document tag naming convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,13 @@ All layout nodes use fluent builder pattern with `With*` methods that return `th
 ### Constraint-Based Layout
 
 Use `SizeConstraint` (Fixed, Fill, Auto, Percent) for sizing rather than hardcoded values.
+
+## Release Process
+
+### Tag Naming Convention
+
+**Do NOT use the `v` prefix for release tags.** Tags should be numeric version only.
+
+**Correct:** `0.2.0`, `1.0.0`, `2.1.3`
+
+**Incorrect:** `v0.2.0`, `v1.0.0`, `v2.1.3`


### PR DESCRIPTION
## Summary
- Add release process section to CLAUDE.md
- Document that tags should NOT use the `v` prefix (e.g., `0.2.0` not `v0.2.0`)

## Test Plan
- [x] Documentation only change