### PR TITLE
Add footer to all doc pages and fix docs deployment trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,9 @@
 name: Deploy Documentation
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
         { text: 'SelectionListNode', link: '/components/selection-list-node' },
         { text: 'SpinnerNode', link: '/components/spinner-node' },
         { text: 'StreamingTextNode', link: '/components/streaming-text-node' },
-        { text: 'ScrollableContainer', link: '/components/scrollable-container' },
+        { text: 'ScrollableContainerNode', link: '/components/scrollable-container' },
         { text: 'StackLayout', link: '/components/stack-layout' },
         { text: 'ModalNode', link: '/components/modal-node' },
         { text: 'ReactiveLayoutNode', link: '/components/reactive-layout' },

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import DefaultTheme from 'vitepress/theme'
+import { useData } from 'vitepress'
+
+const { Layout } = DefaultTheme
+const { theme } = useData()
+</script>
+
+<template>
+  <Layout>
+    <template #doc-after>
+      <div class="custom-footer" v-if="theme.footer">
+        <p class="message" v-if="theme.footer.message" v-html="theme.footer.message"></p>
+        <p class="copyright" v-if="theme.footer.copyright" v-html="theme.footer.copyright"></p>
+      </div>
+    </template>
+  </Layout>
+</template>
+
+<style scoped>
+.custom-footer {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--vp-c-divider);
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--vp-c-text-2);
+}
+
+.custom-footer .message {
+  margin-bottom: 0.5rem;
+}
+
+.custom-footer .copyright {
+  margin: 0;
+}
+
+.custom-footer :deep(a) {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+
+.custom-footer :deep(a:hover) {
+  text-decoration: underline;
+}
+</style>

--- a/docs/.vitepress/theme/index.mts
+++ b/docs/.vitepress/theme/index.mts
@@ -1,3 +1,7 @@
 import DefaultTheme from 'vitepress/theme'
+import Layout from './Layout.vue'
 
-export default DefaultTheme
+export default {
+  extends: DefaultTheme,
+  Layout
+}

--- a/docs/layout/vertical-horizontal.md
+++ b/docs/layout/vertical-horizontal.md
@@ -227,3 +227,16 @@ Layouts.Vertical()
 | Status bar sections | Horizontal |
 | Stacked panels | Vertical |
 | Tab bar | Horizontal |
+
+## Need Z-Axis Layering?
+
+`VerticalLayout` and `HorizontalLayout` arrange children along a single axis. For **overlapping content** where children render on top of each other (like modals, tooltips, or floating panels), use [StackLayout](/components/stack-layout).
+
+```csharp
+// Children render in order - later children appear on top
+new StackLayout()
+    .WithChild(backgroundContent)
+    .WithChild(floatingPanel);
+```
+
+See [StackLayout](/components/stack-layout) for details on z-axis composition.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -172,7 +172,6 @@
       "integrity": "sha512-22SHEEVNjZfFWkFks3P6HilkR3rS7a6GjnCIqR22Zz4HNxdfT0FG+RE7efTcFVfLUkTTMQQybvaUcwMrHXYa7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.46.0",
         "@algolia/requester-browser-xhr": "5.46.0",
@@ -1525,7 +1524,6 @@
       "integrity": "sha512-7ML6fa2K93FIfifG3GMWhDEwT5qQzPTmoHKCTvhzGEwdbQ4n0yYUWZlLYT75WllTGJCJtNUI0C1ybN4BCegqvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.12.0",
         "@algolia/client-abtesting": "5.46.0",
@@ -1719,7 +1717,6 @@
       "integrity": "sha512-v/Z8bvMCajtx4mEXmOo7QEsIzlIOqRXTIwgUfsFOF9gEsespdbD0AkPIka1bSXZ8Y8oZ+2IVDQZePkTfEHZl7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.3.0"
       }
@@ -2338,7 +2335,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2441,7 +2437,6 @@
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",


### PR DESCRIPTION
## Summary
- Add copyright footer to all documentation pages (not just home page)
- Fix docs deployment workflow to trigger on tag push

## Changes

### Custom VitePress Layout
Created `docs/.vitepress/theme/Layout.vue` that extends the default theme and adds the footer to all doc pages using the `#doc-footer-before` slot.

### Workflow Fix
Changed `docs.yml` trigger from `release: types: [published]` to `push: tags: ['*']`.

**Why?** When the `publish_nuget` workflow creates a GitHub release using `GITHUB_TOKEN`, it doesn't trigger other workflows that listen for release events (GitHub's anti-cascade protection). By triggering on tag push instead, both workflows run in parallel when a tag is pushed.

## Test Plan
- [x] VitePress build succeeds locally
- [ ] Footer appears on documentation pages (not just home)
- [ ] Docs deploy when tag is pushed