### PR TITLE
Add changelog page with version badge in navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,7 +19,8 @@ export default defineConfig({
       { text: 'Components', link: '/components/' },
       { text: 'Styling', link: '/styling/' },
       { text: 'Concepts', link: '/concepts/' },
-      { text: 'Advanced', link: '/advanced/' }
+      { text: 'Advanced', link: '/advanced/' },
+      { text: 'Changelog', link: '/changelog' }
     ],
 
     sidebar: {

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,15 +1,30 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import DefaultTheme from 'vitepress/theme'
-import { useData } from 'vitepress'
+import { useData, useRoute } from 'vitepress'
+import VersionBadge from './VersionBadge.vue'
 
 const { Layout } = DefaultTheme
-const { theme } = useData()
+const { theme, frontmatter } = useData()
+const route = useRoute()
+
+// Show footer on doc pages, but not on changelog (it has its own) or home
+const showFooter = computed(() => {
+  const layout = frontmatter.value.layout
+  const path = route.path
+  return theme.value.footer &&
+         layout !== 'home' &&
+         !path.includes('/changelog')
+})
 </script>
 
 <template>
   <Layout>
+    <template #nav-bar-content-after>
+      <VersionBadge />
+    </template>
     <template #doc-after>
-      <div class="custom-footer" v-if="theme.footer">
+      <div class="custom-footer" v-if="showFooter">
         <p class="message" v-if="theme.footer.message" v-html="theme.footer.message"></p>
         <p class="copyright" v-if="theme.footer.copyright" v-html="theme.footer.copyright"></p>
       </div>

--- a/docs/.vitepress/theme/VersionBadge.vue
+++ b/docs/.vitepress/theme/VersionBadge.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { data } from '../../releases.data'
+</script>
+
+<template>
+  <a
+    v-if="data.latest !== '0.0.0'"
+    href="/Termina/changelog"
+    class="version-badge"
+    title="View changelog"
+  >
+    v{{ data.latest }}
+  </a>
+</template>
+
+<style scoped>
+.version-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 10px;
+  height: 28px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  border-radius: 14px;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s;
+  margin-left: 8px;
+}
+
+.version-badge:hover {
+  background: var(--vp-c-brand-1);
+  color: var(--vp-c-white);
+}
+</style>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,113 @@
+---
+outline: deep
+---
+
+<script setup>
+import { data } from './releases.data'
+</script>
+
+# Changelog
+
+All notable releases of Termina.
+
+<div class="releases">
+  <div v-for="release in data.releases" :key="release.version" class="release">
+    <h2 :id="release.version">
+      <a :href="'#' + release.version" class="header-anchor">#</a>
+      {{ release.name }}
+      <span v-if="release.isPrerelease" class="prerelease-badge">pre-release</span>
+    </h2>
+    <p class="release-meta">
+      <span class="release-date">{{ release.date }}</span>
+      <a :href="release.url" target="_blank" class="github-link">View full release notes on GitHub →</a>
+    </p>
+    <ul class="release-highlights">
+      <li v-for="(item, index) in getHighlights(release.summary)" :key="index">{{ item }}</li>
+    </ul>
+  </div>
+</div>
+
+<div v-if="data.releases.length === 0" class="no-releases">
+  <p>No releases found. Check the <a href="https://github.com/Aaronontheweb/Termina/releases">GitHub releases page</a>.</p>
+</div>
+
+<script>
+export default {
+  methods: {
+    getHighlights(text) {
+      // Extract bullet points as plain text highlights
+      return text
+        .split('\n')
+        .filter(line => line.startsWith('- ') || line.startsWith('* '))
+        .map(line => line.slice(2).replace(/`/g, '').replace(/\*\*/g, ''))
+        .slice(0, 5)
+    }
+  }
+}
+</script>
+
+<style scoped>
+.releases {
+  margin-top: 2rem;
+}
+
+.release {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.release:last-child {
+  border-bottom: none;
+}
+
+.release h2 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.prerelease-badge {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  background: var(--vp-c-warning-soft);
+  color: var(--vp-c-warning-1);
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.release-meta {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  color: var(--vp-c-text-2);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.github-link {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+
+.github-link:hover {
+  text-decoration: underline;
+}
+
+.release-highlights {
+  color: var(--vp-c-text-1);
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.release-highlights li {
+  margin: 0.4rem 0;
+}
+
+.no-releases {
+  text-align: center;
+  color: var(--vp-c-text-2);
+  padding: 2rem;
+}
+</style>

--- a/docs/releases.data.ts
+++ b/docs/releases.data.ts
@@ -1,0 +1,69 @@
+// VitePress data loader - fetches GitHub releases at build time
+export interface Release {
+  version: string
+  name: string
+  date: string
+  url: string
+  summary: string
+  isPrerelease: boolean
+}
+
+export interface ReleasesData {
+  latest: string
+  releases: Release[]
+}
+
+declare const data: ReleasesData
+export { data }
+
+export default {
+  async load(): Promise<ReleasesData> {
+    const response = await fetch(
+      'https://api.github.com/repos/Aaronontheweb/Termina/releases?per_page=10'
+    )
+
+    if (!response.ok) {
+      console.warn('Failed to fetch releases:', response.status)
+      return { latest: '0.0.0', releases: [] }
+    }
+
+    const releases = await response.json()
+
+    const parsed: Release[] = releases.map((r: any) => ({
+      version: r.tag_name,
+      name: r.name || r.tag_name,
+      date: new Date(r.published_at).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      }),
+      url: r.html_url,
+      summary: extractSummary(r.body || ''),
+      isPrerelease: r.prerelease
+    }))
+
+    return {
+      latest: parsed[0]?.version || '0.0.0',
+      releases: parsed
+    }
+  }
+}
+
+function extractSummary(body: string): string {
+  // Get first meaningful paragraph (skip headers, blank lines)
+  const lines = body.split('\n')
+  const summaryLines: string[] = []
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    // Skip empty lines, headers, and bullet points at start
+    if (!trimmed || trimmed.startsWith('#')) continue
+    // Stop at a header or after getting enough content
+    if (summaryLines.length > 0 && trimmed.startsWith('#')) break
+    // Collect bullet points and text
+    summaryLines.push(trimmed)
+    if (summaryLines.length >= 5) break
+  }
+
+  return summaryLines.join('\n')
+}


### PR DESCRIPTION
## Summary
- Add auto-updating changelog page that fetches releases from GitHub API at build time
- Display latest version number in the navigation bar
- Add "Changelog" link in nav

## Features

### Changelog Page (`/changelog`)
- Fetches latest 10 releases from GitHub API during VitePress build
- Displays release name, date, and key highlights
- Links to full release notes on GitHub
- Supports pre-release badge

### Version Badge
- Shows current version (e.g., `v0.2.0`) in nav bar
- Clickable link to changelog page
- Auto-updates on each docs deployment

### Footer Fix
- Footer now shows on all doc pages
- Excludes changelog page (uses VitePress's built-in footer there) to prevent duplicates

## Test Plan
- [x] Changelog page loads with release data
- [x] Version badge appears in nav
- [x] No duplicate footers
- [x] Footer shows on regular doc pages