### PR TITLE
Update docs base URL to lowercase after repo rename

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,8 +91,8 @@
   <!-- NuGet .nupkg options -->
   <PropertyGroup>
     <PackageTags>tui;terminal;console;ansi;reactive;mvvm;cli;dotnet</PackageTags>
-    <PackageProjectUrl>https://aaronstannard.com/Termina/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Aaronontheweb/Termina</RepositoryUrl>
+    <PackageProjectUrl>https://aaronstannard.com/termina/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Aaronontheweb/termina</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>termina-icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Termina
 
-![Termina Logo](https://raw.githubusercontent.com/Aaronontheweb/Termina/refs/heads/dev/assets/termina-icon.png)
+![Termina Logo](https://raw.githubusercontent.com/Aaronontheweb/termina/refs/heads/dev/assets/termina-icon.png)
 
-[![NuGet Downloads](https://img.shields.io/nuget/dt/Termina)](https://www.nuget.org/packages/Termina) ![GitHub License](https://img.shields.io/github/license/Aaronontheweb/Termina) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Aaronontheweb/Termina/pr_validation.yml) ![GitHub Release](https://img.shields.io/github/v/release/Aaronontheweb/Termina)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/Termina)](https://www.nuget.org/packages/Termina) ![GitHub License](https://img.shields.io/github/license/Aaronontheweb/termina) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Aaronontheweb/termina/pr_validation.yml) ![GitHub Release](https://img.shields.io/github/v/release/Aaronontheweb/termina)
 
 **Termina** is a reactive terminal UI (TUI) framework for .NET with declarative layouts and surgical region-based rendering. It provides an MVVM architecture with source-generated reactive properties, ASP.NET Core-style routing, and seamless integration with Microsoft.Extensions.Hosting.
 
 ## Documentation
 
-**[Full Documentation](https://aaronontheweb.github.io/Termina/)**
+**[Full Documentation](https://aaronontheweb.github.io/termina/)**
 
-- [Getting Started Guide](https://aaronontheweb.github.io/Termina/guide/getting-started)
-- [Tutorials](https://aaronontheweb.github.io/Termina/tutorials/)
-- [Component Reference](https://aaronontheweb.github.io/Termina/components/)
-- [Architecture](https://aaronontheweb.github.io/Termina/concepts/architecture)
+- [Getting Started Guide](https://aaronontheweb.github.io/termina/guide/getting-started)
+- [Tutorials](https://aaronontheweb.github.io/termina/tutorials/)
+- [Component Reference](https://aaronontheweb.github.io/termina/components/)
+- [Architecture](https://aaronontheweb.github.io/termina/concepts/architecture)
 
 ## Features
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: 'Termina',
   description: 'Reactive Terminal UI Framework for .NET',
-  base: '/Termina/',
+  base: '/termina/',
 
   head: [
-    ['link', { rel: 'icon', href: '/Termina/termina-icon.png' }]
+    ['link', { rel: 'icon', href: '/termina/termina-icon.png' }]
   ],
 
   themeConfig: {

--- a/docs/.vitepress/theme/VersionBadge.vue
+++ b/docs/.vitepress/theme/VersionBadge.vue
@@ -5,7 +5,7 @@ import { data } from '../../releases.data'
 <template>
   <a
     v-if="data.latest !== '0.0.0'"
-    href="/Termina/changelog"
+    href="/termina/changelog"
     class="version-badge"
     title="View changelog"
   >


### PR DESCRIPTION
## Summary
Update documentation URLs after repo rename from `Termina` to `termina`.

## Changes
- `base: '/Termina/'` → `base: '/termina/'`
- Favicon href updated to lowercase
- Version badge link updated to lowercase
- Git remote URL updated locally

The docs will now be served at `aaronontheweb.github.io/termina/` instead of `/Termina/`.