### PR TITLE
Fix terminal state cleanup on application exit

### DIFF
--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -346,9 +346,15 @@ public sealed class TerminaApplication
         }
         finally
         {
-            // Restore terminal
+            // Restore terminal state fully to avoid artifacts
+            _terminal.DisableMouse();
             _terminal.SetCursorVisible(true);
+            _terminal.ResetColors();
             _terminal.ExitAlternateScreen();
+            _terminal.Flush();
+
+            // Clear any partial line artifacts
+            Console.WriteLine();
 
             // Complete the input subject
             _inputSubject.OnCompleted();


### PR DESCRIPTION
## Summary

Fixes #44 - Terminal state not fully cleaned up on application exit.

Ensure terminal is fully restored when Termina application exits by adding missing cleanup steps to `RunAsync()` finally block:

- `DisableMouse()` - turn off mouse tracking if enabled
- `ResetColors()` - emit `\x1b[0m` to reset text attributes  
- `Flush()` - actually send buffered ANSI commands to terminal
- `Console.WriteLine()` - clear any partial line artifacts

## Before

Users had to manually reset terminal state after Termina shutdown:
```csharp
Console.Write("\x1b[?25h\x1b[0m");
Console.WriteLine();
Console.ResetColor();
```

## After

Terminal state is automatically restored - no manual cleanup needed.

## Test plan

- [x] All 561 existing tests pass
- [ ] Manual test: Run demo app, exit with Ctrl+Q, verify no artifacts
- [ ] Manual test: Run demo app, exit with Ctrl+C, verify no artifacts