### PR TITLE
Fix docs deployment and add quick install section

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,13 @@ name: Deploy Documentation
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - dev
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,29 @@ features:
     details: Custom terminal rendering with surgical region-based updates. No external dependencies for rendering.
 ---
 
+## Quick Install
+
+::: code-group
+
+```shell [.NET CLI]
+dotnet add package Termina
+```
+
+```xml [PackageReference]
+<PackageReference Include="Termina" Version="0.2.*" />
+```
+
+:::
+
+<div style="margin-top: 1rem;">
+  <a href="https://www.nuget.org/packages/Termina" target="_blank">
+    <img src="https://img.shields.io/nuget/v/Termina?style=flat-square&logo=nuget&label=NuGet" alt="NuGet" />
+  </a>
+  <a href="https://www.nuget.org/packages/Termina" target="_blank" style="margin-left: 0.5rem;">
+    <img src="https://img.shields.io/nuget/dt/Termina?style=flat-square&logo=nuget&label=Downloads" alt="Downloads" />
+  </a>
+</div>
+
 ## Quick Example
 
 ```csharp


### PR DESCRIPTION
## Summary
- Fix documentation deployment workflow that was failing due to GitHub Pages environment protection rules blocking tag-based deployments
- Add quick install section to documentation homepage with NuGet package info

## Changes

### Workflow Fix
The `docs.yml` workflow was triggering on tag pushes, but GitHub Pages environments have branch-based protection rules that don't allow deployments from tags. Changed triggers to:
- Push to `dev` branch (for docs changes)
- `release: [published]` event (fires when CI/CD creates the release)
- Manual dispatch

### Homepage Enhancement
Added a "Quick Install" section to the docs homepage featuring:
- Code group with .NET CLI and PackageReference options
- NuGet version and download badges linking to the package page

## Test plan
- [ ] Verify PR validation passes
- [ ] After merge, verify docs deployment triggers successfully
- [ ] Check homepage displays quick install section correctly