### PR TITLE
Add TERMINA002 analyzer and refactor MVVM architecture

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,11 @@
   <!-- Source generator dependencies -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+  </ItemGroup>
+  <!-- Analyzer testing dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -185,16 +185,27 @@ Shutdown();  // Exit the application
 
 ## Streaming Content
 
-For real-time content like LLM output:
+For real-time content like LLM output, Pages own `StreamingTextNode` and subscribe to ViewModel observables:
 
 ```csharp
-public StreamingTextNode Output { get; } = StreamingTextNode.Create();
+// In Page
+private StreamingTextNode _output = null!;
+
+protected override void OnBound()
+{
+    _output = StreamingTextNode.Create();
+    ViewModel.StreamOutput.Subscribe(chunk => _output.Append(chunk));
+}
+
+// In ViewModel
+public IObservable<string> StreamOutput => _streamOutput.AsObservable();
+private readonly Subject<string> _streamOutput = new();
 
 private async Task StreamResponse()
 {
     await foreach (var chunk in GetStreamingData())
     {
-        Output.Append(chunk);  // Character-level updates
+        _streamOutput.OnNext(chunk);  // Character-level updates
     }
 }
 ```

--- a/demos/Termina.Demo.RegionBased/CounterPage.cs
+++ b/demos/Termina.Demo.RegionBased/CounterPage.cs
@@ -12,7 +12,7 @@ namespace Termina.Demo.RegionBased;
 
 /// <summary>
 /// Page for the counter demo.
-/// Demonstrates the tree-based declarative layout API with reactive bindings.
+/// Demonstrates the declarative layout API with reactive bindings.
 /// </summary>
 public class CounterPage : ReactivePage<CounterViewModel>
 {

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -3,6 +3,7 @@
 
 using System.Reactive.Linq;
 using Termina.Extensions;
+using Termina.Input;
 using Termina.Layout;
 using Termina.Reactive;
 using Termina.Rendering;
@@ -12,10 +13,126 @@ namespace Termina.Demo.Streaming.Pages;
 
 /// <summary>
 /// Demo page showing streaming text components with LLM simulation.
-/// Uses the new declarative layout API.
+/// Handles all UI concerns including layout nodes, focus, and input routing.
 /// </summary>
 public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
 {
+    // Layout nodes owned by the Page
+    private StreamingTextNode _chatHistory = null!;
+    private StreamingTextNode _thinkingIndicator = null!;
+    private TextInputNode _promptInput = null!;
+
+    protected override void OnBound()
+    {
+        // Create layout nodes
+        _chatHistory = StreamingTextNode.Create()
+            .WithPrefix("  ", Color.Gray);
+
+        _thinkingIndicator = StreamingTextNode.CreateWindowed(windowSize: 3)
+            .WithPrefix("💭 ", Color.Yellow)
+            .WithForeground(Color.Gray);
+
+        _promptInput = new TextInputNode()
+            .WithPlaceholder("Enter your question...")
+            .WithForeground(Color.Cyan);
+
+        // Subscribe to ViewModel chat output and update nodes
+        ViewModel.ChatOutput
+            .Subscribe(segment =>
+            {
+                if (segment.IsNewLine)
+                    _chatHistory.AppendLine(segment.Text, segment.Foreground, null, segment.Decoration);
+                else
+                    _chatHistory.Append(segment.Text, segment.Foreground, null, segment.Decoration);
+            })
+            .DisposeWith(Subscriptions);
+
+        ViewModel.ThinkingOutput
+            .Subscribe(segment =>
+            {
+                if (segment.IsNewLine)
+                    _thinkingIndicator.AppendLine(segment.Text, segment.Foreground, null, segment.Decoration);
+                else
+                    _thinkingIndicator.Append(segment.Text, segment.Foreground, null, segment.Decoration);
+            })
+            .DisposeWith(Subscriptions);
+
+        ViewModel.ClearThinking
+            .Subscribe(_ => _thinkingIndicator.Clear())
+            .DisposeWith(Subscriptions);
+
+        ViewModel.PromptTextChanged
+            .Subscribe(text => _promptInput.Text = text)
+            .DisposeWith(Subscriptions);
+
+        // Subscribe to prompt input submission
+        _promptInput.Submitted
+            .Subscribe(text =>
+            {
+                ViewModel.HandleSubmit(text);
+                _promptInput.Clear();
+            })
+            .DisposeWith(Subscriptions);
+
+        // Handle keyboard input - Page routes to interactive layout nodes
+        ViewModel.Input.OfType<KeyPressed>()
+            .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+
+        // Emit welcome message
+        ViewModel.EmitWelcomeMessage();
+    }
+
+    private void HandleKeyPress(KeyPressed key)
+    {
+        var keyInfo = key.KeyInfo;
+
+        // Ctrl+Q always quits
+        if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            ViewModel.RequestShutdown();
+            return;
+        }
+
+        // Escape handling
+        if (keyInfo.Key == ConsoleKey.Escape)
+        {
+            if (ViewModel.IsGenerating)
+            {
+                ViewModel.CancelGeneration();
+            }
+            else
+            {
+                ViewModel.RequestShutdown();
+            }
+            return;
+        }
+
+        // Page Up/Down scroll chat history
+        if (_chatHistory.HandleInput(keyInfo, viewportHeight: 10, viewportWidth: 80))
+        {
+            return;
+        }
+
+        // When not generating, handle other input
+        if (!ViewModel.IsGenerating)
+        {
+            if (keyInfo.Key == ConsoleKey.UpArrow)
+            {
+                ViewModel.NavigateHistoryUp();
+                return;
+            }
+            if (keyInfo.Key == ConsoleKey.DownArrow)
+            {
+                ViewModel.NavigateHistoryDown();
+                return;
+            }
+
+            // Let the text input handle other keys
+            _promptInput.HandleInput(keyInfo);
+        }
+    }
+
     public override ILayoutNode BuildLayout()
     {
         return Layouts.Vertical()
@@ -33,26 +150,26 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                     .WithTitleColor(Color.Yellow)
                     .WithBorder(BorderStyle.Rounded)
                     .WithBorderColor(Color.Gray)
-                    .WithContent(ViewModel.ChatHistory)
+                    .WithContent(_chatHistory)
                     .Fill())
             // Thinking indicator - conditionally shown
             .WithChild(
                 ViewModel.IsGeneratingChanged
-                    .Select(isGenerating => isGenerating && ViewModel.ThinkingIndicator.Buffer.HasContent
+                    .Select(isGenerating => isGenerating && _thinkingIndicator.Buffer.HasContent
                         ? BuildThinkingPanel()
                         : (ILayoutNode)new EmptyNode())
                     .AsLayout())
             .WithChild(new EmptyNode().Height(1))
-            // Input panel - NOT reactive to avoid disposing the shared TextInputNode
+            // Input panel
             .WithChild(
                 new PanelNode()
                     .WithTitle("Your Prompt")
                     .WithTitleColor(Color.Cyan)
                     .WithBorder(BorderStyle.Rounded)
                     .WithBorderColor(Color.Cyan)
-                    .WithContent(ViewModel.PromptInput)
+                    .WithContent(_promptInput)
                     .Height(3))
-            // Status bar with dynamic hints
+            // Status bar
             .WithChild(
                 ViewModel.IsGeneratingChanged
                     .Select(isGenerating => new TextNode(
@@ -80,8 +197,7 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                     .WithTitleColor(Color.Yellow)
                     .WithBorder(BorderStyle.Rounded)
                     .WithBorderColor(Color.Yellow)
-                    .WithContent(ViewModel.ThinkingIndicator)
+                    .WithContent(_thinkingIndicator)
                     .Height(5));
     }
-
 }

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
@@ -1,21 +1,30 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using Akka.Actor;
 using Akka.Hosting;
 using Termina.Demo.Streaming.Actors;
-using Termina.Input;
-using Termina.Layout;
 using Termina.Reactive;
 using Termina.Terminal;
 
 namespace Termina.Demo.Streaming.Pages;
 
 /// <summary>
+/// Represents a styled text segment for chat display.
+/// </summary>
+public readonly record struct ChatTextSegment(
+    string Text,
+    Color? Foreground = null,
+    TextDecoration Decoration = TextDecoration.None,
+    bool IsNewLine = false);
+
+/// <summary>
 /// ViewModel for the streaming chat demo.
-/// Uses the new StreamingTextNode and TextInputNode for rendering.
-/// Uses IAsyncEnumerable from Akka Streams for token consumption.
+/// Contains only state and business logic - no UI concerns.
+/// Exposes observables for chat content that the Page subscribes to.
 /// </summary>
 public partial class StreamingChatViewModel : ReactiveViewModel
 {
@@ -25,25 +34,31 @@ public partial class StreamingChatViewModel : ReactiveViewModel
     private IActorRef? _llmActor;
     private CancellationTokenSource? _generationCts;
 
-    /// <summary>
-    /// Chat history component - renders all content with scrolling.
-    /// </summary>
-    public StreamingTextNode ChatHistory { get; } = StreamingTextNode.Create()
-        .WithPrefix("  ", Color.Gray);
+    // Subjects for chat output - Page subscribes to these
+    private readonly Subject<ChatTextSegment> _chatOutput = new();
+    private readonly Subject<ChatTextSegment> _thinkingOutput = new();
+    private readonly Subject<Unit> _clearThinking = new();
+    private readonly Subject<string> _promptTextChanged = new();
 
     /// <summary>
-    /// Thinking indicator component (windowed, rolling).
+    /// Observable for chat history content.
     /// </summary>
-    public StreamingTextNode ThinkingIndicator { get; } = StreamingTextNode.CreateWindowed(windowSize: 3)
-        .WithPrefix("💭 ", Color.Yellow)
-        .WithForeground(Color.Gray);
+    public IObservable<ChatTextSegment> ChatOutput => _chatOutput.AsObservable();
 
     /// <summary>
-    /// Text input component - handles its own keyboard input.
+    /// Observable for thinking indicator content.
     /// </summary>
-    public TextInputNode PromptInput { get; } = new TextInputNode()
-        .WithPlaceholder("Enter your question...")
-        .WithForeground(Color.Cyan);
+    public IObservable<ChatTextSegment> ThinkingOutput => _thinkingOutput.AsObservable();
+
+    /// <summary>
+    /// Observable that fires when thinking indicator should be cleared.
+    /// </summary>
+    public IObservable<Unit> ClearThinking => _clearThinking.AsObservable();
+
+    /// <summary>
+    /// Observable for prompt text changes (for history navigation).
+    /// </summary>
+    public IObservable<string> PromptTextChanged => _promptTextChanged.AsObservable();
 
     // Reactive properties for UI state
     [Reactive] private bool _isGenerating = false;
@@ -52,109 +67,34 @@ public partial class StreamingChatViewModel : ReactiveViewModel
     public StreamingChatViewModel(IRequiredActor<LlmSimulatorActor> llmActorProvider)
     {
         _llmActorProvider = llmActorProvider;
+    }
 
-        // Add initial welcome message with styled text
-        ChatHistory.Append("🤖 ", foreground: Color.Yellow);
-        ChatHistory.Append("Assistant: ", foreground: Color.Green, decoration: TextDecoration.Bold);
-        ChatHistory.AppendLine("Hello! I'm a simulated LLM demo.", foreground: Color.White);
-        ChatHistory.AppendLine("   Ask me anything and watch the streaming response!", foreground: Color.BrightBlack);
-        ChatHistory.AppendLine("");
-
-        // Wire up submit observable from the text input component
-        PromptInput.Submitted
-            .Subscribe(HandleSubmit)
-            .DisposeWith(Subscriptions);
+    /// <summary>
+    /// Emits the initial welcome message.
+    /// </summary>
+    public void EmitWelcomeMessage()
+    {
+        _chatOutput.OnNext(new ChatTextSegment("🤖 ", Color.Yellow));
+        _chatOutput.OnNext(new ChatTextSegment("Assistant: ", Color.Green, TextDecoration.Bold));
+        _chatOutput.OnNext(new ChatTextSegment("Hello! I'm a simulated LLM demo.", Color.White, IsNewLine: true));
+        _chatOutput.OnNext(new ChatTextSegment("   Ask me anything and watch the streaming response!", Color.BrightBlack, IsNewLine: true));
+        _chatOutput.OnNext(new ChatTextSegment("", IsNewLine: true));
     }
 
     public override void OnActivated()
     {
-        // Subscribe to component content changes to trigger UI redraws
-        // This is the marshalling mechanism for async backend updates to the UI
-        ChatHistory.ContentChanged
-            .Subscribe(_ => RequestRedraw())
-            .DisposeWith(Subscriptions);
-
-        ThinkingIndicator.ContentChanged
-            .Subscribe(_ => RequestRedraw())
-            .DisposeWith(Subscriptions);
-
-        // Wait for the actor to be available, then subscribe to input
         _ = InitializeAsync();
     }
 
     private async Task InitializeAsync()
     {
-        // Wait for the LLM actor to be registered by Akka.Hosting
         _llmActor = await _llmActorProvider.GetAsync();
-
-        // Subscribe to keyboard input
-        Input.OfType<KeyPressed>()
-            .Subscribe(HandleKeyPress)
-            .DisposeWith(Subscriptions);
     }
 
-    private void HandleKeyPress(KeyPressed key)
-    {
-        var keyInfo = key.KeyInfo;
-
-        // Ctrl+Q always quits
-        if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
-        {
-            Shutdown();
-            return;
-        }
-
-        // Escape handling
-        if (keyInfo.Key == ConsoleKey.Escape)
-        {
-            if (IsGenerating)
-            {
-                CancelGeneration();
-            }
-            else
-            {
-                // When not generating, Escape clears input or quits if input is empty
-                if (string.IsNullOrEmpty(PromptInput.Text))
-                {
-                    Shutdown();
-                }
-                else
-                {
-                    PromptInput.Text = "";
-                    StatusMessage = "Input cleared. Press Esc again to quit.";
-                }
-            }
-            return;
-        }
-
-        // Page Up/Down always scroll chat history (works during generation too)
-        // Use reasonable defaults for viewport (scrolls ~10 lines per page)
-        if (ChatHistory.HandleInput(keyInfo, viewportHeight: 10, viewportWidth: 80))
-        {
-            return;
-        }
-
-        // When not generating, handle input
-        if (!IsGenerating)
-        {
-            // Handle history navigation (Up/Down arrows)
-            if (keyInfo.Key == ConsoleKey.UpArrow)
-            {
-                NavigateHistoryUp();
-                return;
-            }
-            if (keyInfo.Key == ConsoleKey.DownArrow)
-            {
-                NavigateHistoryDown();
-                return;
-            }
-
-            // Let the text input handle other keys
-            PromptInput.HandleInput(keyInfo);
-        }
-    }
-
-    private void NavigateHistoryUp()
+    /// <summary>
+    /// Navigate up through prompt history.
+    /// </summary>
+    public void NavigateHistoryUp()
     {
         if (_promptHistory.Count == 0)
             return;
@@ -168,10 +108,13 @@ public partial class StreamingChatViewModel : ReactiveViewModel
             _historyIndex--;
         }
 
-        PromptInput.Text = _promptHistory[_historyIndex];
+        _promptTextChanged.OnNext(_promptHistory[_historyIndex]);
     }
 
-    private void NavigateHistoryDown()
+    /// <summary>
+    /// Navigate down through prompt history.
+    /// </summary>
+    public void NavigateHistoryDown()
     {
         if (_historyIndex < 0)
             return;
@@ -179,16 +122,30 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         if (_historyIndex < _promptHistory.Count - 1)
         {
             _historyIndex++;
-            PromptInput.Text = _promptHistory[_historyIndex];
+            _promptTextChanged.OnNext(_promptHistory[_historyIndex]);
         }
         else
         {
             _historyIndex = -1;
-            PromptInput.Text = "";
+            _promptTextChanged.OnNext("");
         }
     }
 
-    private void HandleSubmit(string prompt)
+    /// <summary>
+    /// Cancel the current generation.
+    /// </summary>
+    public void CancelGeneration()
+    {
+        _generationCts?.Cancel();
+        _chatOutput.OnNext(new ChatTextSegment(" [cancelled]", Color.Yellow, TextDecoration.Italic, IsNewLine: true));
+        CleanupGeneration();
+        StatusMessage = "Generation cancelled.";
+    }
+
+    /// <summary>
+    /// Handle prompt submission.
+    /// </summary>
+    public void HandleSubmit(string prompt)
     {
         prompt = prompt.Trim();
         if (string.IsNullOrEmpty(prompt))
@@ -198,22 +155,18 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         _promptHistory.Add(prompt);
         _historyIndex = -1;
 
-        // Clear the input
-        PromptInput.Clear();
-
-        // Add user message to chat with styled text
-        ChatHistory.Append("👤 ", foreground: Color.Cyan);
-        ChatHistory.Append("You: ", foreground: Color.Cyan, decoration: TextDecoration.Bold);
-        ChatHistory.AppendLine(prompt, foreground: Color.White);
-        ChatHistory.AppendLine("");
-        ChatHistory.Append("🤖 ", foreground: Color.Yellow);
-        ChatHistory.Append("Assistant: ", foreground: Color.Green, decoration: TextDecoration.Bold);
+        // Add user message to chat
+        _chatOutput.OnNext(new ChatTextSegment("👤 ", Color.Cyan));
+        _chatOutput.OnNext(new ChatTextSegment("You: ", Color.Cyan, TextDecoration.Bold));
+        _chatOutput.OnNext(new ChatTextSegment(prompt, Color.White, IsNewLine: true));
+        _chatOutput.OnNext(new ChatTextSegment("", IsNewLine: true));
+        _chatOutput.OnNext(new ChatTextSegment("🤖 ", Color.Yellow));
+        _chatOutput.OnNext(new ChatTextSegment("Assistant: ", Color.Green, TextDecoration.Bold));
 
         // Start generation
         IsGenerating = true;
         StatusMessage = "Generating response...";
 
-        // Request stream from actor and consume it
         _ = ConsumeResponseStreamAsync(prompt);
     }
 
@@ -229,29 +182,23 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         var completedNormally = false;
         try
         {
-            // Ask actor for the stream
             var response = await _llmActor.Ask<LlmMessages.GenerateResponse>(
                 new LlmMessages.GenerateRequest(prompt),
                 TimeSpan.FromSeconds(30));
 
             _generationCts = response.Cancellation;
 
-            // Consume the IAsyncEnumerable from the actor
             await foreach (var token in response.TokenStream.WithCancellation(_generationCts.Token))
             {
                 switch (token)
                 {
                     case LlmMessages.ThinkingToken thinking:
-                        ThinkingIndicator.AppendLine(thinking.Text, foreground: Color.BrightBlack, decoration: TextDecoration.Italic);
+                        _thinkingOutput.OnNext(new ChatTextSegment(thinking.Text, Color.BrightBlack, TextDecoration.Italic, IsNewLine: true));
                         break;
 
                     case LlmMessages.TextChunk chunk:
-                        // Clear thinking when text starts
-                        if (ThinkingIndicator.Buffer.HasContent)
-                        {
-                            ThinkingIndicator.Clear();
-                        }
-                        ChatHistory.Append(chunk.Text);
+                        _clearThinking.OnNext(Unit.Default);
+                        _chatOutput.OnNext(new ChatTextSegment(chunk.Text));
                         break;
 
                     case LlmMessages.GenerationComplete:
@@ -264,16 +211,18 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         }
         catch (OperationCanceledException)
         {
-            // Normal cancellation - already handled in CancelGeneration
+            // Normal cancellation
         }
         catch (Exception ex)
         {
-            CleanupGenerationWithError(ex.Message);
+            _chatOutput.OnNext(new ChatTextSegment(" [error: ", Color.Red));
+            _chatOutput.OnNext(new ChatTextSegment(ex.Message, Color.Red, TextDecoration.Bold));
+            _chatOutput.OnNext(new ChatTextSegment("]", Color.Red, IsNewLine: true));
+            CleanupGeneration();
             StatusMessage = $"Error: {ex.Message}";
         }
         finally
         {
-            // Ensure IsGenerating is always reset, even if stream ends unexpectedly
             if (!completedNormally && IsGenerating)
             {
                 CleanupGeneration();
@@ -282,30 +231,22 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         }
     }
 
-    private void CancelGeneration()
-    {
-        _generationCts?.Cancel();
-        ChatHistory.AppendLine(" [cancelled]", foreground: Color.Yellow, decoration: TextDecoration.Italic);
-        CleanupGeneration();
-        StatusMessage = "Generation cancelled.";
-    }
-
-    private void CleanupGenerationWithError(string errorMessage)
-    {
-        ChatHistory.Append(" [error: ", foreground: Color.Red);
-        ChatHistory.Append(errorMessage, foreground: Color.Red, decoration: TextDecoration.Bold);
-        ChatHistory.AppendLine("]", foreground: Color.Red);
-        CleanupGeneration();
-    }
-
     private void CleanupGeneration()
     {
-        ChatHistory.AppendLine("");
-
-        ThinkingIndicator.Clear();
+        _chatOutput.OnNext(new ChatTextSegment("", IsNewLine: true));
+        _clearThinking.OnNext(Unit.Default);
         IsGenerating = false;
-
         _generationCts?.Dispose();
         _generationCts = null;
+    }
+
+    public override void Dispose()
+    {
+        _chatOutput.Dispose();
+        _thinkingOutput.Dispose();
+        _clearThinking.Dispose();
+        _promptTextChanged.Dispose();
+        DisposeReactiveFields();
+        base.Dispose();
     }
 }

--- a/demos/Termina.Demo/Pages/TodoListPage.cs
+++ b/demos/Termina.Demo/Pages/TodoListPage.cs
@@ -12,10 +12,111 @@ namespace Termina.Demo.Pages;
 
 /// <summary>
 /// Page for the todo list demo.
-/// Demonstrates list components and state binding with modal dialogs.
+/// Handles all UI concerns including layout nodes and focus management.
+/// Reacts to ViewModel state changes.
 /// </summary>
 public class TodoListPage : ReactivePage<TodoListViewModel>
 {
+    // Layout nodes owned by the Page
+    private ModalNode _addModal = null!;
+    private ModalNode _priorityModal = null!;
+    private SelectionListNode<string> _priorityList = null!;
+    private TextInputNode _textInput = null!;
+
+    protected override void OnBound()
+    {
+        // Create the text input for the add modal
+        _textInput = new TextInputNode()
+            .WithPlaceholder("Enter task description...");
+
+        // Subscribe to text input submission
+        _textInput.Submitted
+            .Subscribe(text => ViewModel.OnTextInputSubmitted(text))
+            .DisposeWith(Subscriptions);
+
+        // Create priority selection list
+        _priorityList = Layouts.SelectionList("High", "Medium", "Low")
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Cyan)
+            .WithOtherOption("Custom priority...");
+
+        // Subscribe to priority selection events
+        _priorityList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                var priority = selected.FirstOrDefault() ?? "Normal";
+                ViewModel.OnPrioritySelected(priority);
+            })
+            .DisposeWith(Subscriptions);
+
+        _priorityList.OtherSelected
+            .Subscribe(customPriority => ViewModel.OnPrioritySelected(customPriority))
+            .DisposeWith(Subscriptions);
+
+        _priorityList.Cancelled
+            .Subscribe(_ => ViewModel.OnPriorityCancelled())
+            .DisposeWith(Subscriptions);
+
+        // Create modals
+        _addModal = Layouts.Modal()
+            .WithTitle("Add New Task")
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Color.Cyan)
+            .WithBackdrop(BackdropStyle.Dim)
+            .WithPosition(ModalPosition.Center)
+            .WithPadding(1)
+            .WithContent(_textInput)
+            .WithDismissOnEscape(true);
+
+        _addModal.Dismissed
+            .Subscribe(_ => ViewModel.OnAddModalDismissed())
+            .DisposeWith(Subscriptions);
+
+        _priorityModal = Layouts.Modal()
+            .WithTitle("Select Priority")
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Color.Yellow)
+            .WithBackdrop(BackdropStyle.Dim)
+            .WithPosition(ModalPosition.Center)
+            .WithPadding(1)
+            .WithContent(_priorityList)
+            .WithDismissOnEscape(true);
+
+        _priorityModal.Dismissed
+            .Subscribe(_ => ViewModel.OnPriorityModalDismissed())
+            .DisposeWith(Subscriptions);
+
+        // React to state changes for focus management
+        // When IsAddingItem becomes true (and not showing priority), focus add modal
+        ViewModel.IsAddingItemChanged
+            .CombineLatest(ViewModel.ShowPriorityModalChanged, (adding, showPriority) => (adding, showPriority))
+            .Subscribe(state =>
+            {
+                if (state.adding && !state.showPriority)
+                {
+                    _textInput.Clear();
+                    Focus.PushFocus(_addModal);
+                }
+                else if (!state.adding && !state.showPriority)
+                {
+                    Focus.ClearFocus();
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        // When ShowPriorityModal becomes true, switch focus to priority modal
+        ViewModel.ShowPriorityModalChanged
+            .Where(show => show)
+            .Subscribe(_ =>
+            {
+                Focus.PopFocus(); // Remove add modal focus
+                Focus.PushFocus(_priorityModal);
+                Focus.PushFocus(_priorityList);
+            })
+            .DisposeWith(Subscriptions);
+    }
+
     public override ILayoutNode BuildLayout()
     {
         // Build the main content
@@ -42,26 +143,20 @@ public class TodoListPage : ReactivePage<TodoListViewModel>
                     .Height(1));
 
         // Build the layer with modal overlays
-        // The stack layout renders children in order, with later children on top
-        //
-        // We use Layouts.Deferred() because modals are created in OnActivated (which runs
-        // after BuildLayout) and we don't want the modal to be disposed when hidden.
         return Layouts.Stack()
             .WithChild(mainContent)
             .WithChild(
-                // Show add modal when IsAddingItem is true and ShowPriorityModal is false
                 ViewModel.IsAddingItemChanged
                     .CombineLatest(ViewModel.ShowPriorityModalChanged, (adding, showPriority) => adding && !showPriority)
                     .Select(showModal => showModal
-                        ? Layouts.Deferred(() => ViewModel.AddModal)
-                        : (ILayoutNode)Layouts.Empty())
+                        ? (ILayoutNode)_addModal
+                        : Layouts.Empty())
                     .AsLayout())
             .WithChild(
-                // Show priority selection modal when ShowPriorityModal is true
                 ViewModel.ShowPriorityModalChanged
                     .Select(showPriority => showPriority
-                        ? Layouts.Deferred(() => ViewModel.PriorityModal)
-                        : (ILayoutNode)Layouts.Empty())
+                        ? (ILayoutNode)_priorityModal
+                        : Layouts.Empty())
                     .AsLayout());
     }
 

--- a/demos/Termina.Demo/Pages/TodoListViewModel.cs
+++ b/demos/Termina.Demo/Pages/TodoListViewModel.cs
@@ -1,14 +1,12 @@
 using System.Reactive.Linq;
 using Termina.Input;
-using Termina.Layout;
 using Termina.Reactive;
-using Termina.Rendering;
 
 namespace Termina.Demo.Pages;
 
 /// <summary>
 /// ViewModel for a todo list demo.
-/// Demonstrates list selection and state management with modal dialogs.
+/// Contains only state and business logic - no UI concerns.
 /// </summary>
 public partial class TodoListViewModel : ReactiveViewModel
 {
@@ -23,15 +21,8 @@ public partial class TodoListViewModel : ReactiveViewModel
     [Reactive] private int _selectedIndex;
     [Reactive] private string _statusMessage = "Navigate with ↑/↓, Space to toggle, C for counter, Q to quit";
     [Reactive] private bool _isAddingItem;
-    [Reactive] private string _newItemText = "";
     [Reactive] private bool _showPriorityModal;
     [Reactive] private string _pendingTaskText = "";
-
-    // Modal and selection list instances (created once, reused)
-    private ModalNode? _addModal;
-    private ModalNode? _priorityModal;
-    private SelectionListNode<string>? _priorityList;
-    private TextInputNode? _textInput;
 
     public override void OnActivated()
     {
@@ -39,113 +30,74 @@ public partial class TodoListViewModel : ReactiveViewModel
         Input.OfType<KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
-
-        // Create the text input for the add modal
-        _textInput = new TextInputNode()
-            .WithPlaceholder("Enter task description...");
-
-        // Subscribe to text input submission
-        _textInput.Submitted
-            .Subscribe(text =>
-            {
-                if (!string.IsNullOrWhiteSpace(text))
-                {
-                    PendingTaskText = text.Trim();
-                    ShowPrioritySelection();
-                }
-                else
-                {
-                    CancelAddItem();
-                }
-            })
-            .DisposeWith(Subscriptions);
-
-        // Create priority selection list
-        _priorityList = Layouts.SelectionList("High", "Medium", "Low")
-            .WithMode(SelectionMode.Single)
-            .WithShowNumbers(true)
-            .WithHighlightColors(Terminal.Color.Black, Terminal.Color.Cyan)
-            .WithOtherOption("Custom priority...");
-
-        // Subscribe to priority selection
-        _priorityList.SelectionConfirmed
-            .Subscribe(selected =>
-            {
-                var priority = selected.FirstOrDefault() ?? "Normal";
-                AddNewItem(PendingTaskText, priority);
-            })
-            .DisposeWith(Subscriptions);
-
-        _priorityList.OtherSelected
-            .Subscribe(customPriority =>
-            {
-                AddNewItem(PendingTaskText, customPriority);
-            })
-            .DisposeWith(Subscriptions);
-
-        _priorityList.Cancelled
-            .Subscribe(_ =>
-            {
-                // Go back to text input
-                ShowPriorityModal = false;
-                Focus.PopFocus();
-            })
-            .DisposeWith(Subscriptions);
-
-        // Create modals
-        _addModal = Layouts.Modal()
-            .WithTitle("Add New Task")
-            .WithBorder(BorderStyle.Rounded)
-            .WithBorderColor(Terminal.Color.Cyan)
-            .WithBackdrop(BackdropStyle.Dim)
-            .WithPosition(ModalPosition.Center)
-            .WithPadding(1)
-            .WithContent(_textInput)
-            .WithDismissOnEscape(true);
-
-        _addModal.Dismissed
-            .Subscribe(_ => CancelAddItem())
-            .DisposeWith(Subscriptions);
-
-        _priorityModal = Layouts.Modal()
-            .WithTitle("Select Priority")
-            .WithBorder(BorderStyle.Rounded)
-            .WithBorderColor(Terminal.Color.Yellow)
-            .WithBackdrop(BackdropStyle.Dim)
-            .WithPosition(ModalPosition.Center)
-            .WithPadding(1)
-            .WithContent(_priorityList)
-            .WithDismissOnEscape(true);
-
-        _priorityModal.Dismissed
-            .Subscribe(_ =>
-            {
-                ShowPriorityModal = false;
-                IsAddingItem = false;
-                Focus.PopFocus();
-                StatusMessage = "Cancelled adding item";
-            })
-            .DisposeWith(Subscriptions);
     }
 
     /// <summary>
-    /// Gets the modal for adding items (used by the Page).
+    /// Called by Page when text input is submitted.
     /// </summary>
-    public ModalNode? AddModal => _addModal;
+    public void OnTextInputSubmitted(string text)
+    {
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            PendingTaskText = text.Trim();
+            ShowPriorityModal = true;
+            StatusMessage = "Select priority with ↑/↓ or number keys, Enter to confirm";
+        }
+        else
+        {
+            CancelAddItem();
+        }
+    }
 
     /// <summary>
-    /// Gets the modal for priority selection (used by the Page).
+    /// Called by Page when priority is selected.
     /// </summary>
-    public ModalNode? PriorityModal => _priorityModal;
+    public void OnPrioritySelected(string priority)
+    {
+        var newItems = Items.ToList();
+        var displayText = priority != "Normal" ? $"[{priority}] {PendingTaskText}" : PendingTaskText;
+        newItems.Add(new TodoItem(displayText, false));
+        Items = newItems;
+        SelectedIndex = Items.Count - 1;
+        StatusMessage = $"Added: {displayText}";
+
+        // Clean up state
+        ShowPriorityModal = false;
+        IsAddingItem = false;
+        PendingTaskText = "";
+    }
+
+    /// <summary>
+    /// Called by Page when priority selection is cancelled.
+    /// </summary>
+    public void OnPriorityCancelled()
+    {
+        ShowPriorityModal = false;
+    }
+
+    /// <summary>
+    /// Called by Page when add modal is dismissed.
+    /// </summary>
+    public void OnAddModalDismissed()
+    {
+        CancelAddItem();
+    }
+
+    /// <summary>
+    /// Called by Page when priority modal is dismissed.
+    /// </summary>
+    public void OnPriorityModalDismissed()
+    {
+        ShowPriorityModal = false;
+        IsAddingItem = false;
+        StatusMessage = "Cancelled adding item";
+    }
 
     private void HandleKeyPress(KeyPressed key)
     {
-        // Handle input differently when in text entry mode
-        if (IsAddingItem)
-        {
-            HandleTextEntryKeyPress(key);
+        // Don't handle keys when in modal mode - let the modals handle input
+        if (IsAddingItem || ShowPriorityModal)
             return;
-        }
 
         switch (key.KeyInfo.Key)
         {
@@ -187,106 +139,19 @@ public partial class TodoListViewModel : ReactiveViewModel
         }
     }
 
-    private void HandleTextEntryKeyPress(KeyPressed key)
-    {
-        switch (key.KeyInfo.Key)
-        {
-            case ConsoleKey.Enter:
-                ConfirmAddItem();
-                break;
-            case ConsoleKey.Escape:
-                CancelAddItem();
-                break;
-            case ConsoleKey.Backspace:
-                if (NewItemText.Length > 0)
-                {
-                    NewItemText = NewItemText[..^1];
-                }
-                break;
-            default:
-                // Add printable characters
-                if (key.KeyInfo.KeyChar != '\0' && !char.IsControl(key.KeyInfo.KeyChar))
-                {
-                    NewItemText += key.KeyInfo.KeyChar;
-                }
-                break;
-        }
-    }
-
     private void StartAddingItem()
     {
         IsAddingItem = true;
         ShowPriorityModal = false;
-        NewItemText = "";
         PendingTaskText = "";
-        _textInput?.Clear();
         StatusMessage = "Enter task name and press Enter, or Escape to cancel";
-
-        // Push focus to the modal for keyboard input
-        if (_addModal != null)
-        {
-            Focus.PushFocus(_addModal);
-        }
-    }
-
-    private void ShowPrioritySelection()
-    {
-        ShowPriorityModal = true;
-
-        // Switch focus from text input modal to priority modal
-        Focus.PopFocus(); // Remove add modal focus
-
-        if (_priorityModal != null && _priorityList != null)
-        {
-            Focus.PushFocus(_priorityModal);
-            Focus.PushFocus(_priorityList); // Selection list needs focus for keyboard input
-        }
-
-        StatusMessage = "Select priority with ↑/↓ or number keys, Enter to confirm";
-    }
-
-    private void AddNewItem(string description, string priority)
-    {
-        var newItems = Items.ToList();
-        var displayText = priority != "Normal" ? $"[{priority}] {description}" : description;
-        newItems.Add(new TodoItem(displayText, false));
-        Items = newItems;
-        SelectedIndex = Items.Count - 1;
-        StatusMessage = $"Added: {displayText}";
-
-        // Clean up modal state
-        ShowPriorityModal = false;
-        IsAddingItem = false;
-        PendingTaskText = "";
-        Focus.ClearFocus();
-    }
-
-    private void ConfirmAddItem()
-    {
-        if (!string.IsNullOrWhiteSpace(NewItemText))
-        {
-            var newItems = Items.ToList();
-            newItems.Add(new TodoItem(NewItemText.Trim(), false));
-            Items = newItems;
-            SelectedIndex = Items.Count - 1;
-            StatusMessage = $"Added: {NewItemText.Trim()}";
-        }
-        else
-        {
-            StatusMessage = "Cancelled - empty task name";
-        }
-
-        IsAddingItem = false;
-        NewItemText = "";
     }
 
     private void CancelAddItem()
     {
         IsAddingItem = false;
         ShowPriorityModal = false;
-        NewItemText = "";
         PendingTaskText = "";
-        Focus.ClearFocus();
         StatusMessage = "Cancelled adding item";
     }
 
@@ -297,7 +162,6 @@ public partial class TodoListViewModel : ReactiveViewModel
         var item = Items[SelectedIndex];
         var newItem = item with { IsCompleted = !item.IsCompleted };
 
-        // Create new list with updated item
         var newItems = Items.ToList();
         newItems[SelectedIndex] = newItem;
         Items = newItems;
@@ -316,7 +180,6 @@ public partial class TodoListViewModel : ReactiveViewModel
         newItems.RemoveAt(SelectedIndex);
         Items = newItems;
 
-        // Adjust selected index if needed
         if (SelectedIndex >= Items.Count && Items.Count > 0)
         {
             SelectedIndex = Items.Count - 1;

--- a/docs/components/modal-node.md
+++ b/docs/components/modal-node.md
@@ -102,34 +102,58 @@ Focus.PushFocus(modal);
 
 ## Complete Example
 
-Here's a real-world example from a todo list application:
+Here's the recommended pattern where the **Page owns layout nodes** (including modals) and **manages Focus**, while the **ViewModel handles state**:
+
+**ViewModel** - State and business logic only:
 
 ```csharp
 public partial class MyViewModel : ReactiveViewModel
 {
-    private ModalNode? _confirmModal;
-    private TextInputNode? _textInput;
+    [Reactive] private bool _isShowingModal;
 
-    public ModalNode? ConfirmModal => _confirmModal;
+    // Called by Page when text is submitted
+    public void OnTextSubmitted(string text)
+    {
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            AddTask(text);
+        }
+        IsShowingModal = false;
+    }
 
-    public override void OnActivated()
+    // Called by Page when modal is dismissed
+    public void OnModalDismissed()
+    {
+        IsShowingModal = false;
+    }
+
+    private void ShowAddModal()
+    {
+        IsShowingModal = true;
+    }
+}
+```
+
+**Page** - Owns modals and manages Focus:
+
+```csharp
+public class MyPage : ReactivePage<MyViewModel>
+{
+    private ModalNode _modal = null!;
+    private TextInputNode _textInput = null!;
+
+    protected override void OnBound()
     {
         // Create text input
         _textInput = new TextInputNode()
             .WithPlaceholder("Enter task description...");
 
         _textInput.Submitted
-            .Subscribe(text => {
-                if (!string.IsNullOrWhiteSpace(text))
-                {
-                    AddTask(text);
-                }
-                HideModal();
-            })
+            .Subscribe(text => ViewModel.OnTextSubmitted(text))
             .DisposeWith(Subscriptions);
 
         // Create modal
-        _confirmModal = Layouts.Modal()
+        _modal = Layouts.Modal()
             .WithTitle("Add New Task")
             .WithBorder(BorderStyle.Rounded)
             .WithBorderColor(Color.Cyan)
@@ -138,39 +162,37 @@ public partial class MyViewModel : ReactiveViewModel
             .WithContent(_textInput)
             .WithDismissOnEscape(true);
 
-        _confirmModal.Dismissed
-            .Subscribe(_ => HideModal())
+        _modal.Dismissed
+            .Subscribe(_ => ViewModel.OnModalDismissed())
+            .DisposeWith(Subscriptions);
+
+        // React to ViewModel state to manage Focus
+        ViewModel.IsShowingModalChanged
+            .Subscribe(show => {
+                if (show)
+                {
+                    _textInput.Clear();
+                    Focus.PushFocus(_modal);
+                }
+                else
+                {
+                    Focus.PopFocus();
+                }
+            })
             .DisposeWith(Subscriptions);
     }
 
-    private void ShowModal()
+    public override ILayoutNode BuildLayout()
     {
-        IsShowingModal = true;
-        _textInput?.Clear();
-        Focus.PushFocus(_confirmModal!);
+        return Layouts.Stack()
+            .WithChild(mainContent)
+            .WithChild(
+                ViewModel.IsShowingModalChanged
+                    .Select(show => show
+                        ? (ILayoutNode)_modal
+                        : Layouts.Empty())
+                    .AsLayout());
     }
-
-    private void HideModal()
-    {
-        IsShowingModal = false;
-        Focus.PopFocus();
-    }
-}
-```
-
-In your page, use `Layouts.Deferred()` to prevent modal disposal when hidden:
-
-```csharp
-public override ILayoutNode BuildLayout()
-{
-    return Layouts.Stack()
-        .WithChild(mainContent)
-        .WithChild(
-            ViewModel.IsShowingModalChanged
-                .Select(show => show
-                    ? Layouts.Deferred(() => ViewModel.ConfirmModal)
-                    : (ILayoutNode)Layouts.Empty())
-                .AsLayout());
 }
 ```
 

--- a/docs/components/selection-list-node.md
+++ b/docs/components/selection-list-node.md
@@ -128,57 +128,100 @@ list.SelectionConfirmed.Subscribe(selected => {
 
 ## Inside a Modal
 
-SelectionListNode works seamlessly with ModalNode:
+SelectionListNode works seamlessly with ModalNode. The **Page owns both nodes** and **manages Focus**:
 
 ```csharp
-// Create selection list
-var priorityList = Layouts.SelectionList("High", "Medium", "Low")
-    .WithMode(SelectionMode.Single)
-    .WithShowNumbers(true)
-    .WithHighlightColors(Color.Black, Color.Cyan)
-    .WithOtherOption("Custom...");
+public class MyPage : ReactivePage<MyViewModel>
+{
+    private SelectionListNode<string> _priorityList = null!;
+    private ModalNode _priorityModal = null!;
 
-// Create modal with selection list
-var modal = Layouts.Modal()
-    .WithTitle("Select Priority")
-    .WithBorder(BorderStyle.Rounded)
-    .WithBorderColor(Color.Yellow)
-    .WithBackdrop(BackdropStyle.Dim)
-    .WithContent(priorityList);
+    protected override void OnBound()
+    {
+        _priorityList = Layouts.SelectionList("High", "Medium", "Low")
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Cyan)
+            .WithOtherOption("Custom...");
 
-// Handle selections
-priorityList.SelectionConfirmed.Subscribe(selected => {
-    HandleSelection(selected.First());
-    Focus.PopFocus();
-});
+        _priorityModal = Layouts.Modal()
+            .WithTitle("Select Priority")
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Color.Yellow)
+            .WithBackdrop(BackdropStyle.Dim)
+            .WithContent(_priorityList);
 
-priorityList.OtherSelected.Subscribe(custom => {
-    HandleSelection(custom);
-    Focus.PopFocus();
-});
+        // Handle selections - call ViewModel methods
+        _priorityList.SelectionConfirmed.Subscribe(selected =>
+            ViewModel.OnPrioritySelected(selected.First()))
+            .DisposeWith(Subscriptions);
 
-priorityList.Cancelled.Subscribe(_ => {
-    Focus.PopFocus();
-});
+        _priorityList.OtherSelected.Subscribe(custom =>
+            ViewModel.OnPrioritySelected(custom))
+            .DisposeWith(Subscriptions);
 
-// Show modal
-Focus.PushFocus(modal);
-Focus.PushFocus(priorityList);  // List needs focus for keyboard input
+        _priorityList.Cancelled.Subscribe(_ =>
+            ViewModel.OnPriorityCancelled())
+            .DisposeWith(Subscriptions);
+
+        // React to ViewModel state to manage Focus
+        ViewModel.ShowPriorityModalChanged
+            .Subscribe(show => {
+                if (show)
+                {
+                    Focus.PushFocus(_priorityModal);
+                    Focus.PushFocus(_priorityList);
+                }
+                else
+                {
+                    Focus.ClearFocus();
+                }
+            })
+            .DisposeWith(Subscriptions);
+    }
+}
 ```
 
 ## Complete Example
+
+Here's the recommended pattern where **ViewModel handles state** and **Page owns layout nodes and Focus**:
+
+**ViewModel** - State and business logic:
 
 ```csharp
 public partial class SettingsViewModel : ReactiveViewModel
 {
     [Reactive] private bool _showThemeSelector;
+    [Reactive] private string _currentTheme = "System Default";
 
-    private SelectionListNode<string>? _themeList;
-    private ModalNode? _themeModal;
+    public void OnThemeSelected(string theme)
+    {
+        CurrentTheme = theme;
+        ApplyTheme(theme);
+        ShowThemeSelector = false;
+    }
 
-    public ModalNode? ThemeModal => _themeModal;
+    public void OnThemeSelectorCancelled()
+    {
+        ShowThemeSelector = false;
+    }
 
-    public override void OnActivated()
+    public void OpenThemeSelector()
+    {
+        ShowThemeSelector = true;
+    }
+}
+```
+
+**Page** - Owns nodes and manages Focus:
+
+```csharp
+public class SettingsPage : ReactivePage<SettingsViewModel>
+{
+    private SelectionListNode<string> _themeList = null!;
+    private ModalNode _themeModal = null!;
+
+    protected override void OnBound()
     {
         _themeList = Layouts.SelectionList("Light", "Dark", "System Default")
             .WithMode(SelectionMode.Single)
@@ -186,14 +229,11 @@ public partial class SettingsViewModel : ReactiveViewModel
             .WithHighlightColors(Color.Black, Color.White);
 
         _themeList.SelectionConfirmed
-            .Subscribe(selected => {
-                ApplyTheme(selected.First());
-                HideThemeSelector();
-            })
+            .Subscribe(selected => ViewModel.OnThemeSelected(selected.First()))
             .DisposeWith(Subscriptions);
 
         _themeList.Cancelled
-            .Subscribe(_ => HideThemeSelector())
+            .Subscribe(_ => ViewModel.OnThemeSelectorCancelled())
             .DisposeWith(Subscriptions);
 
         _themeModal = Layouts.Modal()
@@ -202,21 +242,33 @@ public partial class SettingsViewModel : ReactiveViewModel
             .WithContent(_themeList);
 
         _themeModal.Dismissed
-            .Subscribe(_ => HideThemeSelector())
+            .Subscribe(_ => ViewModel.OnThemeSelectorCancelled())
+            .DisposeWith(Subscriptions);
+
+        // React to ViewModel state to manage Focus
+        ViewModel.ShowThemeSelectorChanged
+            .Subscribe(show => {
+                if (show)
+                {
+                    Focus.PushFocus(_themeModal);
+                    Focus.PushFocus(_themeList);
+                }
+                else
+                {
+                    Focus.ClearFocus();
+                }
+            })
             .DisposeWith(Subscriptions);
     }
 
-    private void ShowThemeSelector()
+    public override ILayoutNode BuildLayout()
     {
-        ShowThemeSelector = true;
-        Focus.PushFocus(_themeModal!);
-        Focus.PushFocus(_themeList!);
-    }
-
-    private void HideThemeSelector()
-    {
-        ShowThemeSelector = false;
-        Focus.ClearFocus();
+        return Layouts.Stack()
+            .WithChild(mainContent)
+            .WithChild(
+                ViewModel.ShowThemeSelectorChanged
+                    .Select(show => show ? (ILayoutNode)_themeModal : Layouts.Empty())
+                    .AsLayout());
     }
 }
 ```

--- a/docs/components/text-input-node.md
+++ b/docs/components/text-input-node.md
@@ -67,31 +67,61 @@ new TextInputNode()
 
 ## Handling Input
 
-TextInputNode exposes observables and the `HandleInput` method for integration with your ViewModel:
+TextInputNode is a layout node that should be **owned by the Page**. There are two patterns for input handling:
+
+### Pattern 1: Inside a Modal (Recommended)
+
+When TextInputNode is inside a Modal, Focus automatically routes input:
 
 ```csharp
-public partial class MyViewModel : ReactiveViewModel
+public class MyPage : ReactivePage<MyViewModel>
 {
-    public TextInputNode PromptInput { get; } = new TextInputNode()
-        .WithPlaceholder("Enter command...");
+    private TextInputNode _textInput = null!;
+    private ModalNode _modal = null!;
 
-    public override void OnActivated()
+    protected override void OnBound()
     {
-        // Handle keyboard input
-        Input.OfType<KeyPressed>()
-            .Subscribe(key => PromptInput.HandleInput(key.KeyInfo))
+        _textInput = new TextInputNode().WithPlaceholder("Enter command...");
+        _modal = Layouts.Modal().WithContent(_textInput);
+
+        _textInput.Submitted
+            .Subscribe(text => ViewModel.OnTextSubmitted(text))
+            .DisposeWith(Subscriptions);
+
+        // When showing modal, Focus handles input routing automatically
+        ViewModel.IsShowingModalChanged
+            .Where(show => show)
+            .Subscribe(_ => Focus.PushFocus(_modal))
+            .DisposeWith(Subscriptions);
+    }
+}
+```
+
+### Pattern 2: Always-Visible Input
+
+For always-visible text inputs, route input via `ViewModel.Input`:
+
+```csharp
+public class MyPage : ReactivePage<MyViewModel>
+{
+    private TextInputNode _promptInput = null!;
+
+    protected override void OnBound()
+    {
+        _promptInput = new TextInputNode().WithPlaceholder("Enter command...");
+
+        // Route input from ViewModel to the text input
+        ViewModel.Input.OfType<KeyPressed>()
+            .Subscribe(key => _promptInput.HandleInput(key.KeyInfo))
             .DisposeWith(Subscriptions);
 
         // Handle submission
-        PromptInput.Submitted
-            .Subscribe(OnSubmitted)
+        _promptInput.Submitted
+            .Subscribe(text => {
+                ViewModel.OnTextSubmitted(text);
+                _promptInput.Clear();
+            })
             .DisposeWith(Subscriptions);
-    }
-
-    private void OnSubmitted(string text)
-    {
-        // Process submitted text
-        PromptInput.Clear();
     }
 }
 ```

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -10,14 +10,14 @@ Termina uses a reactive MVVM architecture with declarative layouts and surgical 
 ├─────────────────────────────────────────────────────────────┤
 │  ┌─────────────┐    ┌──────────────┐    ┌───────────────┐  │
 │  │  ViewModel  │───▶│    Page      │───▶│  Layout Tree  │  │
-│  │  [Reactive] │    │ BuildLayout()│    │  (ILayoutNode)│  │
+│  │ Input,State │    │ Focus,Layout │    │  (ILayoutNode)│  │
 │  └─────────────┘    └──────────────┘    └───────────────┘  │
-│         ▲                                       │          │
-│         │                                       ▼          │
-│  ┌─────────────┐                        ┌───────────────┐  │
-│  │    Input    │                        │   Renderer    │  │
-│  │   Handler   │                        │  (ANSI out)   │  │
-│  └─────────────┘                        └───────────────┘  │
+│         ▲                  │                    │          │
+│         │                  ▼                    ▼          │
+│  ┌─────────────┐    ┌──────────────┐    ┌───────────────┐  │
+│  │   Keyboard  │    │    Focus     │    │   Renderer    │  │
+│  │    Input    │    │   Manager    │    │  (ANSI out)   │  │
+│  └─────────────┘    └──────────────┘    └───────────────┘  │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -25,9 +25,9 @@ Termina uses a reactive MVVM architecture with declarative layouts and surgical 
 
 ### 1. Separation of Concerns
 
-- **ViewModels** own state and handle input
-- **Pages** build layouts from state
-- **Layout Nodes** render to terminal
+- **ViewModels** own state, handle keyboard input, and expose observable properties
+- **Pages** own focus management, build layouts from ViewModel state, and manage interactive layout nodes (modals, text inputs)
+- **Layout Nodes** render to terminal and may handle routed input when focused
 
 ### 2. Reactive by Default
 
@@ -74,12 +74,13 @@ Only changed regions are re-rendered, not the entire screen. This provides:
 
 ### On Input
 
-1. Key press captured
-2. Input event sent to current ViewModel
-3. ViewModel updates state
-4. Reactive bindings emit new values
-5. Affected layout nodes invalidate
-6. Changed regions re-render
+1. Key press captured by application
+2. Input event sent to ViewModel's `Input` observable
+3. ViewModel subscribes and handles input (updates state, navigates, etc.)
+4. For focused interactive nodes (modals, text inputs), Page can route input via `Focus.RouteInput()`
+5. Reactive bindings emit new values from state changes
+6. Affected layout nodes invalidate
+7. Changed regions re-render
 
 ### On Navigation
 

--- a/docs/concepts/input-handling.md
+++ b/docs/concepts/input-handling.md
@@ -2,6 +2,31 @@
 
 Termina provides an observable stream of input events for keyboard, mouse, and terminal resize handling.
 
+## Input Ownership
+
+The `Input` observable is owned by the **ViewModel** and is public, allowing both ViewModels and Pages to subscribe:
+
+- **ViewModels** handle input to update state and business logic (most common)
+- **Pages** can access `ViewModel.Input` to route input to interactive layout nodes (TextInputNode, scrollable content)
+
+```csharp
+// In ViewModel - handle input for state changes
+public override void OnActivated()
+{
+    Input.OfType<KeyPressed>()
+        .Subscribe(HandleKey)
+        .DisposeWith(Subscriptions);
+}
+
+// In Page - route input to interactive layout nodes
+protected override void OnBound()
+{
+    ViewModel.Input.OfType<KeyPressed>()
+        .Subscribe(key => _textInput.HandleInput(key.KeyInfo))
+        .DisposeWith(Subscriptions);
+}
+```
+
 ## Input Events
 
 All input events implement `IInputEvent`. The framework provides:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -22,9 +22,9 @@ dotnet add package Termina
 
 Termina uses an MVVM pattern with three key pieces:
 
-1. **ViewModel** - Manages state with `[Reactive]` properties
-2. **Page** - Builds the UI layout from state
-3. **Host** - Wires everything together with routing
+1. **ViewModel** - Manages state with `[Reactive]` properties, handles keyboard input, and provides navigation/shutdown actions
+2. **Page** - Builds the UI layout from state, manages focus for modals and interactive controls
+3. **Host** - Wires everything together with routing and dependency injection
 
 ## Example: Counter Demo
 

--- a/docs/tutorials/streaming-chat.md
+++ b/docs/tutorials/streaming-chat.md
@@ -38,47 +38,30 @@ The ViewModel manages chat state and coordinates with Akka actors.
 
 ### Key Points
 
-**Streaming Components**
+**Streaming Output via Observables**
+
+The ViewModel exposes observables for chat content that the Page subscribes to:
 
 ```csharp
-public StreamingTextNode ChatHistory { get; } = StreamingTextNode.Create()
-    .WithPrefix("  ", Color.Gray);
+// ViewModel exposes output streams
+public IObservable<ChatTextSegment> ChatOutput => _chatOutput.AsObservable();
+public IObservable<ChatTextSegment> ThinkingOutput => _thinkingOutput.AsObservable();
+public IObservable<Unit> ClearThinking => _clearThinking.AsObservable();
 
-public StreamingTextNode ThinkingIndicator { get; } = StreamingTextNode.CreateWindowed(3)
-    .WithPrefix("💭 ", Color.Yellow);
+// Emit chat content
+_chatOutput.OnNext(new ChatTextSegment("Hello!", Color.White, IsNewLine: true));
 ```
 
-`StreamingTextNode` handles character-by-character updates efficiently:
-- `Create()` - Full scrolling buffer
-- `CreateWindowed(n)` - Rolling window of last n lines
+**Text Input Coordination**
 
-**Text Input Component**
+The ViewModel exposes an observable for prompt text changes (for history navigation):
 
 ```csharp
-public TextInputNode PromptInput { get; } = new TextInputNode()
-    .WithPlaceholder("Enter your question...")
-    .WithForeground(Color.Cyan);
+public IObservable<string> PromptTextChanged => _promptTextChanged.AsObservable();
 
-// Wire up submit observable
-PromptInput.Submitted
-    .Subscribe(HandleSubmit)
-    .DisposeWith(Subscriptions);
+// Navigate history
+_promptTextChanged.OnNext(_promptHistory[_historyIndex]);
 ```
-
-`TextInputNode` provides full text editing with cursor, selection, and history.
-
-**Content Change Notifications**
-
-```csharp
-public override void OnActivated()
-{
-    ChatHistory.ContentChanged
-        .Subscribe(_ => RequestRedraw())
-        .DisposeWith(Subscriptions);
-}
-```
-
-Subscribe to `ContentChanged` and call `RequestRedraw()` to trigger UI updates for streaming content.
 
 **Async Stream Consumption**
 
@@ -106,41 +89,56 @@ The Page renders the chat interface.
 
 ### Key Points
 
-**Shared Components**
+**Page Owns Layout Nodes**
+
+The Page creates and owns interactive layout nodes:
 
 ```csharp
-.WithChild(
-    new PanelNode()
-        .WithContent(ViewModel.ChatHistory)  // Shared instance
-        .Fill())
+private StreamingTextNode _chatHistory = null!;
+private TextInputNode _promptInput = null!;
+
+protected override void OnBound()
+{
+    _chatHistory = StreamingTextNode.Create().WithPrefix("  ", Color.Gray);
+    _promptInput = new TextInputNode().WithPlaceholder("Enter your question...");
+
+    // Subscribe to ViewModel's output streams
+    ViewModel.ChatOutput.Subscribe(segment => _chatHistory.Append(segment.Text));
+}
 ```
 
-Pass component instances directly - they manage their own state.
+**Input Routing via ViewModel.Input**
+
+The Page accesses `ViewModel.Input` to route input to interactive layout nodes:
+
+```csharp
+// Page subscribes to ViewModel's input for routing to layout nodes
+ViewModel.Input.OfType<KeyPressed>()
+    .Subscribe(HandleKeyPress)
+    .DisposeWith(Subscriptions);
+
+private void HandleKeyPress(KeyPressed key)
+{
+    // Route to scrollable chat history
+    if (_chatHistory.HandleInput(key.KeyInfo, viewportHeight: 10, viewportWidth: 80))
+        return;
+
+    // Route to text input
+    _promptInput.HandleInput(key.KeyInfo);
+}
+```
 
 **Conditional Panels**
 
 ```csharp
 ViewModel.IsGeneratingChanged
-    .Select(isGenerating => isGenerating && ViewModel.ThinkingIndicator.HasContent
+    .Select(isGenerating => isGenerating && _thinkingIndicator.Buffer.HasContent
         ? BuildThinkingPanel()
         : new EmptyNode())
     .AsLayout()
 ```
 
 Show/hide panels based on state.
-
-**Dynamic Status Bar**
-
-```csharp
-ViewModel.IsGeneratingChanged
-    .Select(isGenerating => new TextNode(
-        isGenerating
-            ? "[Esc] Cancel [PgUp/PgDn] Scroll"
-            : "[Enter] Send [↑/↓] History [Esc] Quit"))
-    .AsLayout()
-```
-
-Change help text based on current state.
 
 ## Step 3: Create the Actor
 
@@ -252,18 +250,18 @@ private void CancelGeneration()
 }
 ```
 
-### Input Component Observables
+### Page-ViewModel Communication
 
 ```csharp
-PromptInput.Submitted
-    .Subscribe(HandleSubmit)
+// Page subscribes to TextInputNode events and calls ViewModel methods
+_promptInput.Submitted
+    .Subscribe(text => ViewModel.HandleSubmit(text))
     .DisposeWith(Subscriptions);
 
-// In input handling:
-if (ChatHistory.HandleInput(keyInfo, viewportHeight: 10, viewportWidth: 80))
-{
-    return;  // Component handled the input
-}
+// Page routes input to layout nodes via ViewModel.Input
+ViewModel.Input.OfType<KeyPressed>()
+    .Subscribe(key => _chatHistory.HandleInput(key.KeyInfo, 10, 80))
+    .DisposeWith(Subscriptions);
 ```
 
 ### State-Based UI Updates

--- a/src/Termina.Generators/LayoutNodeInViewModelAnalyzer.cs
+++ b/src/Termina.Generators/LayoutNodeInViewModelAnalyzer.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Termina.Generators;
+
+/// <summary>
+/// Analyzer that detects when layout node types (ILayoutNode implementations)
+/// are declared as fields or properties in ReactiveViewModel-derived classes.
+///
+/// This is an anti-pattern because:
+/// - ViewModels should contain application STATE, not UI components
+/// - Layout nodes belong in Page/View classes (BuildLayout method)
+/// - Mixing UI components in ViewModels breaks the MVVM separation
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class LayoutNodeInViewModelAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// Diagnostic ID for layout nodes in ViewModel fields/properties.
+    /// </summary>
+    public const string DiagnosticId = "TERMINA002";
+
+    private const string Category = "Termina.Architecture";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Layout nodes should not be declared in ViewModels",
+        messageFormat: "'{0}' of type '{1}' is a layout node. Layout nodes should be created in the Page's BuildLayout() method, not stored in ViewModels. ViewModels should only contain application state ([Reactive] properties) and business logic.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "ViewModels in the MVVM pattern should contain application state and business logic, not UI components. Layout nodes (ILayoutNode implementations) should be created in the Page class's BuildLayout() method. This separation ensures proper testability and maintains a clear boundary between UI and application logic.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // Use CompilationStartAction to cache symbol lookups once per compilation
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var terminaContext = new TerminaContext(compilationContext.Compilation);
+
+            // Only run analysis if Termina types are available
+            if (!terminaContext.HasTerminaInstalled)
+                return;
+
+            // Register for both property and field declarations
+            compilationContext.RegisterSyntaxNodeAction(
+                ctx => AnalyzeProperty(ctx, terminaContext),
+                SyntaxKind.PropertyDeclaration);
+
+            compilationContext.RegisterSyntaxNodeAction(
+                ctx => AnalyzeField(ctx, terminaContext),
+                SyntaxKind.FieldDeclaration);
+        });
+    }
+
+    private static void AnalyzeProperty(SyntaxNodeAnalysisContext context, TerminaContext terminaContext)
+    {
+        var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
+
+        // Get the property symbol
+        var propertySymbol = context.SemanticModel.GetDeclaredSymbol(propertyDeclaration);
+        if (propertySymbol is null)
+            return;
+
+        // Check if containing type inherits from ReactiveViewModel
+        var containingType = propertySymbol.ContainingType;
+        if (!terminaContext.InheritsFromReactiveViewModel(containingType))
+            return;
+
+        // Check if property type implements ILayoutNode
+        var propertyType = propertySymbol.Type;
+        if (!terminaContext.ImplementsILayoutNode(propertyType))
+            return;
+
+        // Report the diagnostic
+        var diagnostic = Diagnostic.Create(
+            Rule,
+            propertyDeclaration.GetLocation(),
+            propertySymbol.Name,
+            propertyType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    private static void AnalyzeField(SyntaxNodeAnalysisContext context, TerminaContext terminaContext)
+    {
+        var fieldDeclaration = (FieldDeclarationSyntax)context.Node;
+
+        // Get the containing type
+        if (fieldDeclaration.Parent is not TypeDeclarationSyntax)
+            return;
+
+        // Process each variable in the field declaration
+        foreach (var variable in fieldDeclaration.Declaration.Variables)
+        {
+            var fieldSymbol = context.SemanticModel.GetDeclaredSymbol(variable) as IFieldSymbol;
+            if (fieldSymbol is null)
+                continue;
+
+            // Skip fields with [Reactive] attribute - these are handled by the source generator
+            if (HasReactiveAttribute(fieldSymbol))
+                continue;
+
+            // Check if containing type inherits from ReactiveViewModel
+            var containingType = fieldSymbol.ContainingType;
+            if (!terminaContext.InheritsFromReactiveViewModel(containingType))
+                continue;
+
+            // Check if field type implements ILayoutNode
+            var fieldType = fieldSymbol.Type;
+            if (!terminaContext.ImplementsILayoutNode(fieldType))
+                continue;
+
+            // Report the diagnostic on the full field declaration for consistency with properties
+            var diagnostic = Diagnostic.Create(
+                Rule,
+                fieldDeclaration.GetLocation(),
+                fieldSymbol.Name,
+                fieldType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    /// <summary>
+    /// Checks if a field has the [Reactive] attribute.
+    /// </summary>
+    private static bool HasReactiveAttribute(IFieldSymbol fieldSymbol)
+    {
+        foreach (var attribute in fieldSymbol.GetAttributes())
+        {
+            var attrClass = attribute.AttributeClass;
+            if (attrClass?.Name == "ReactiveAttribute" &&
+                attrClass.ContainingNamespace?.ToDisplayString() == "Termina.Reactive")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Caches Termina symbols for efficient lookup during analysis.
+    /// </summary>
+    private sealed class TerminaContext
+    {
+        private readonly INamedTypeSymbol? _reactiveViewModelType;
+        private readonly INamedTypeSymbol? _layoutNodeInterface;
+
+        public TerminaContext(Compilation compilation)
+        {
+            _reactiveViewModelType = compilation.GetTypeByMetadataName("Termina.Reactive.ReactiveViewModel");
+            _layoutNodeInterface = compilation.GetTypeByMetadataName("Termina.Layout.ILayoutNode");
+        }
+
+        /// <summary>
+        /// Returns true if Termina types are available in this compilation.
+        /// </summary>
+        public bool HasTerminaInstalled => _reactiveViewModelType is not null && _layoutNodeInterface is not null;
+
+        /// <summary>
+        /// Checks if a type inherits from ReactiveViewModel using symbol equality.
+        /// </summary>
+        public bool InheritsFromReactiveViewModel(INamedTypeSymbol? type)
+        {
+            if (_reactiveViewModelType is null || type is null)
+                return false;
+
+            var current = type.BaseType;
+            while (current is not null)
+            {
+                if (SymbolEqualityComparer.Default.Equals(current, _reactiveViewModelType))
+                    return true;
+                current = current.BaseType;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if a type implements ILayoutNode interface using symbol equality.
+        /// </summary>
+        public bool ImplementsILayoutNode(ITypeSymbol type)
+        {
+            if (_layoutNodeInterface is null)
+                return false;
+
+            // Handle nullable reference types
+            if (type.NullableAnnotation == NullableAnnotation.Annotated &&
+                type is INamedTypeSymbol namedType)
+            {
+                type = namedType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+            }
+
+            // Direct check for ILayoutNode
+            if (SymbolEqualityComparer.Default.Equals(type, _layoutNodeInterface))
+                return true;
+
+            // Check all interfaces (including inherited)
+            foreach (var iface in type.AllInterfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(iface, _layoutNodeInterface))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Termina/Pages/IPage.cs
+++ b/src/Termina/Pages/IPage.cs
@@ -43,6 +43,12 @@ internal interface IBindablePage : IPage
     void BindViewModel(ReactiveViewModel viewModel);
 
     /// <summary>
+    /// Wires up focus management to this page.
+    /// </summary>
+    /// <param name="focusManager">The focus manager.</param>
+    void WireUpFocus(Input.IFocusManager focusManager);
+
+    /// <summary>
     /// Gets the current cached layout root, if any.
     /// </summary>
     ILayoutNode? LayoutRoot { get; }

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
 using System.Reactive.Disposables;
+using Termina.Input;
 using Termina.Layout;
 using Termina.Pages;
 
@@ -54,6 +55,12 @@ public abstract class ReactivePage<TViewModel> : IBindablePage
     protected CompositeDisposable Subscriptions => _subscriptions;
 
     /// <summary>
+    /// Focus manager for this page.
+    /// Use this to manage focus for modals and interactive controls.
+    /// </summary>
+    protected IFocusManager Focus { get; private set; } = null!;
+
+    /// <summary>
     /// Build the layout tree for this page.
     /// Override this to compose your page's UI declaratively.
     /// </summary>
@@ -74,6 +81,14 @@ public abstract class ReactivePage<TViewModel> : IBindablePage
     void IBindablePage.BindViewModel(ReactiveViewModel viewModel)
     {
         Bind((TViewModel)viewModel);
+    }
+
+    /// <summary>
+    /// Wires up focus management to this page.
+    /// </summary>
+    void IBindablePage.WireUpFocus(IFocusManager focusManager)
+    {
+        Focus = focusManager;
     }
 
     /// <summary>

--- a/src/Termina/Reactive/ReactiveViewModel.cs
+++ b/src/Termina/Reactive/ReactiveViewModel.cs
@@ -102,15 +102,21 @@ public abstract class ReactiveViewModel : IDisposable
 
     /// <summary>
     /// Observable stream of input events from the application.
-    /// Subscribe to this to handle keyboard input in the ViewModel.
+    /// Subscribe to this in the ViewModel to handle keyboard input,
+    /// or access from the Page to route input to interactive layout nodes.
     /// </summary>
-    protected IObservable<IInputEvent> Input { get; private set; } = null!;
+    public IObservable<IInputEvent> Input { get; private set; } = null!;
 
     /// <summary>
-    /// The focus manager for managing keyboard focus between interactive components.
-    /// Use this to push/pop focus for modals or set focus to specific controls.
+    /// Request graceful application shutdown.
+    /// Called by Pages in response to user input (e.g., Ctrl+Q, Escape).
     /// </summary>
-    protected IFocusManager Focus { get; private set; } = null!;
+    /// <remarks>
+    /// Override this method to add custom shutdown behavior such as
+    /// confirmation dialogs, saving state, or cleanup operations.
+    /// The default implementation calls <see cref="Shutdown"/> directly.
+    /// </remarks>
+    public virtual void RequestShutdown() => Shutdown();
 
     /// <summary>
     /// Called when the page becomes active (navigated to).
@@ -148,7 +154,7 @@ public abstract class ReactiveViewModel : IDisposable
     }
 
     /// <summary>
-    /// Wires up the navigation, shutdown actions, input observable, and focus manager.
+    /// Wires up the navigation, shutdown actions, and input observable.
     /// Called by the framework when binding to a page.
     /// </summary>
     internal void WireUp(
@@ -156,14 +162,12 @@ public abstract class ReactiveViewModel : IDisposable
         Action<string, object?> navigateWithParams,
         Action shutdown,
         Action requestRedraw,
-        IObservable<IInputEvent> input,
-        IFocusManager focusManager)
+        IObservable<IInputEvent> input)
     {
         Navigate = navigate;
         NavigateWithParams = navigateWithParams;
         Shutdown = shutdown;
         RequestRedraw = requestRedraw;
         Input = input;
-        Focus = focusManager;
     }
 }

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -238,11 +238,12 @@ public sealed class TerminaApplication
                 receiver.SetRouteParameters(parameters);
             }
 
-            // Wire up ViewModel with navigation, shutdown, redraw, and focus manager
-            _currentViewModel.WireUp(NavigateTo, (t, v) => NavigateTo(t, v), Shutdown, RequestRedraw, Input, _focusManager);
+            // Wire up ViewModel with navigation, shutdown, redraw, and input
+            _currentViewModel.WireUp(NavigateTo, (t, v) => NavigateTo(t, v), Shutdown, RequestRedraw, Input);
 
-            // Bind page to ViewModel
+            // Bind page to ViewModel and wire up focus
             BindPageToViewModel(_currentPage, _currentViewModel);
+            WireUpPageFocus(_currentPage);
 
             // Cache if PreserveState
             if (registration.Behavior == NavigationBehavior.PreserveState)
@@ -268,6 +269,17 @@ public sealed class TerminaApplication
         if (page is IBindablePage bindablePage)
         {
             bindablePage.BindViewModel(viewModel);
+        }
+    }
+
+    /// <summary>
+    /// Wires up focus management to the page.
+    /// </summary>
+    private void WireUpPageFocus(IPage page)
+    {
+        if (page is IBindablePage bindablePage)
+        {
+            bindablePage.WireUpFocus(_focusManager);
         }
     }
 

--- a/tests/Termina.Tests/Analyzers/LayoutNodeInViewModelAnalyzerTests.cs
+++ b/tests/Termina.Tests/Analyzers/LayoutNodeInViewModelAnalyzerTests.cs
@@ -1,0 +1,413 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Termina.Generators;
+using Termina.Tests.Utility;
+
+namespace Termina.Tests.Analyzers;
+
+using Verify = TerminaVerifier<LayoutNodeInViewModelAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="LayoutNodeInViewModelAnalyzer"/>.
+/// Verifies that layout nodes declared in ViewModels are flagged as errors.
+/// </summary>
+public class LayoutNodeInViewModelAnalyzerTests
+{
+    // Common source code for ReactiveViewModel and ILayoutNode that all tests need
+    private const string TerminaFrameworkSource = """
+        namespace Termina.Reactive
+        {
+            public abstract class ReactiveViewModel : System.IDisposable
+            {
+                public virtual void Dispose() { }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Field)]
+            public class ReactiveAttribute : System.Attribute { }
+        }
+
+        namespace Termina.Layout
+        {
+            public interface ILayoutNode { }
+
+            public abstract class LayoutNode : ILayoutNode { }
+
+            public abstract class ContainerNode : LayoutNode { }
+
+            public sealed class TextNode : LayoutNode
+            {
+                public TextNode(string text) { }
+            }
+
+            public sealed class StreamingTextNode : LayoutNode
+            {
+                public static StreamingTextNode Create() => new();
+            }
+
+            public sealed class TextInputNode : LayoutNode { }
+
+            public sealed class SpinnerNode : LayoutNode { }
+
+            public sealed class ModalNode : ILayoutNode { }
+
+            public sealed class PanelNode : LayoutNode { }
+
+            public sealed class HorizontalLayout : ContainerNode { }
+
+            public sealed class VerticalLayout : ContainerNode { }
+
+            public sealed class SelectionListNode<T> : ILayoutNode { }
+
+            public sealed class ScrollableContainerNode : LayoutNode { }
+
+            public sealed class ConditionalNode : LayoutNode { }
+
+            public sealed class EmptyNode : LayoutNode { }
+        }
+        """;
+
+    #region Test Data
+
+    /// <summary>
+    /// Test cases that should NOT produce any diagnostics (valid code).
+    /// </summary>
+    public static readonly TheoryData<string> SuccessCases = new()
+    {
+        // Reactive properties are fine
+        """
+        using Termina.Reactive;
+
+        public partial class TestViewModel : ReactiveViewModel
+        {
+            [Reactive] private string _message = "";
+            [Reactive] private int _count;
+        }
+        """,
+
+        // Primitive properties are fine
+        """
+        using Termina.Reactive;
+        using System.Collections.Generic;
+
+        public partial class TestViewModel : ReactiveViewModel
+        {
+            public string Name { get; }
+            public int Count { get; }
+            public List<string> Items { get; }
+        }
+        """,
+
+        // Layout nodes in non-ViewModel classes are fine
+        """
+        using Termina.Layout;
+
+        public class RegularClass
+        {
+            public TextNode MyText { get; }
+        }
+        """,
+
+        // Layout nodes in Page classes are fine
+        """
+        using Termina.Layout;
+
+        public class TestPage
+        {
+            private TextNode _title;
+            public ILayoutNode BuildLayout() => _title;
+        }
+        """,
+
+        // Non-ILayoutNode types with "Node" suffix are fine
+        """
+        using Termina.Reactive;
+
+        public class TreeNode { }
+
+        public partial class TestViewModel : ReactiveViewModel
+        {
+            public TreeNode MyTree { get; }
+        }
+        """,
+
+        // Nested class inside ViewModel that isn't a ViewModel itself is fine
+        """
+        using Termina.Reactive;
+        using Termina.Layout;
+
+        public partial class OuterViewModel : ReactiveViewModel
+        {
+            public class Inner
+            {
+                public TextNode InnerNode { get; }
+            }
+        }
+        """,
+
+        // Local variables in ViewModel methods are fine
+        """
+        using Termina.Reactive;
+        using Termina.Layout;
+
+        public partial class TestViewModel : ReactiveViewModel
+        {
+            public void SomeMethod()
+            {
+                var text = new TextNode("Hello");
+            }
+        }
+        """
+    };
+
+    /// <summary>
+    /// Test cases that SHOULD produce diagnostics (invalid code).
+    /// Each tuple contains: (testCode, expectedPropertyName, expectedTypeName, expectedLine)
+    /// </summary>
+    public static TheoryData<string, string, string, int> FailureCases
+    {
+        get
+        {
+            var data = new TheoryData<string, string, string, int>();
+
+            // TextNode property
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public partial class TestViewModel : ReactiveViewModel
+                {
+                    public TextNode MyText { get; }
+                }
+                """,
+                "MyText",
+                "TextNode",
+                6);
+
+            // StreamingTextNode property with initializer
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public partial class ChatViewModel : ReactiveViewModel
+                {
+                    public StreamingTextNode ChatHistory { get; } = StreamingTextNode.Create();
+                }
+                """,
+                "ChatHistory",
+                "StreamingTextNode",
+                6);
+
+            // TextInputNode property
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public partial class InputViewModel : ReactiveViewModel
+                {
+                    public TextInputNode PromptInput { get; }
+                }
+                """,
+                "PromptInput",
+                "TextInputNode",
+                6);
+
+            // Generic SelectionListNode property
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public partial class ListViewModel : ReactiveViewModel
+                {
+                    public SelectionListNode<string> Items { get; }
+                }
+                """,
+                "Items",
+                "SelectionListNode<string>",
+                6);
+
+            // Nullable ModalNode property
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public partial class TestViewModel : ReactiveViewModel
+                {
+                    public ModalNode? Dialog { get; set; }
+                }
+                """,
+                "Dialog",
+                "ModalNode?",
+                6);
+
+            // HorizontalLayout (container) property
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public partial class TestViewModel : ReactiveViewModel
+                {
+                    public HorizontalLayout Layout { get; }
+                }
+                """,
+                "Layout",
+                "HorizontalLayout",
+                6);
+
+            // Derived ViewModel with TextNode (property on line 8 due to extra BaseViewModel class)
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public abstract class BaseViewModel : ReactiveViewModel { }
+
+                public partial class DerivedViewModel : BaseViewModel
+                {
+                    public TextNode Text { get; }
+                }
+                """,
+                "Text",
+                "TextNode",
+                8);
+
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// Test cases for fields that SHOULD produce diagnostics.
+    /// Each tuple contains: (testCode, expectedFieldName, expectedTypeName, expectedLine)
+    /// </summary>
+    public static TheoryData<string, string, string, int> FieldFailureCases
+    {
+        get
+        {
+            var data = new TheoryData<string, string, string, int>();
+
+            // Nullable ModalNode field
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public partial class TestViewModel : ReactiveViewModel
+                {
+                    private ModalNode? _modal;
+                }
+                """,
+                "_modal",
+                "ModalNode?",
+                6);
+
+            // TextNode field with initializer
+            data.Add(
+                """
+                using Termina.Reactive;
+                using Termina.Layout;
+
+                public partial class TestViewModel : ReactiveViewModel
+                {
+                    private readonly TextNode _title = new TextNode("Title");
+                }
+                """,
+                "_title",
+                "TextNode",
+                6);
+
+            return data;
+        }
+    }
+
+    #endregion
+
+    #region Success Tests
+
+    [Theory]
+    [MemberData(nameof(SuccessCases))]
+    public async Task SuccessCase_NoErrorReported(string testCode)
+    {
+        // These should produce no diagnostics
+        await Verify.VerifyAnalyzer([TerminaFrameworkSource, testCode]);
+    }
+
+    #endregion
+
+    #region Property Failure Tests
+
+    [Theory]
+    [MemberData(nameof(FailureCases))]
+    public async Task PropertyFailureCase_ErrorReported(string testCode, string expectedName, string expectedType, int expectedLine)
+    {
+        // Test1.cs because TerminaFrameworkSource is Test0.cs
+        var expected = Verify.Diagnostic()
+            .WithLocation("/0/Test1.cs", expectedLine, 5)
+            .WithArguments(expectedName, expectedType)
+            .WithSeverity(DiagnosticSeverity.Error);
+
+        await Verify.VerifyAnalyzer([TerminaFrameworkSource, testCode], expected);
+    }
+
+    #endregion
+
+    #region Field Failure Tests
+
+    [Theory]
+    [MemberData(nameof(FieldFailureCases))]
+    public async Task FieldFailureCase_ErrorReported(string testCode, string expectedName, string expectedType, int expectedLine)
+    {
+        // Test1.cs because TerminaFrameworkSource is Test0.cs
+        var expected = Verify.Diagnostic()
+            .WithLocation("/0/Test1.cs", expectedLine, 5)
+            .WithArguments(expectedName, expectedType)
+            .WithSeverity(DiagnosticSeverity.Error);
+
+        await Verify.VerifyAnalyzer([TerminaFrameworkSource, testCode], expected);
+    }
+
+    #endregion
+
+    #region Multiple Diagnostics Test
+
+    [Fact]
+    public async Task MultipleLayoutNodeProperties_ReportsMultipleErrors()
+    {
+        const string testCode = """
+            using Termina.Reactive;
+            using Termina.Layout;
+
+            public partial class TestViewModel : ReactiveViewModel
+            {
+                public TextNode Title { get; }
+                public StreamingTextNode Content { get; }
+                public SpinnerNode Loader { get; }
+            }
+            """;
+
+        var expected1 = Verify.Diagnostic()
+            .WithLocation("/0/Test1.cs", 6, 5)
+            .WithArguments("Title", "TextNode")
+            .WithSeverity(DiagnosticSeverity.Error);
+
+        var expected2 = Verify.Diagnostic()
+            .WithLocation("/0/Test1.cs", 7, 5)
+            .WithArguments("Content", "StreamingTextNode")
+            .WithSeverity(DiagnosticSeverity.Error);
+
+        var expected3 = Verify.Diagnostic()
+            .WithLocation("/0/Test1.cs", 8, 5)
+            .WithArguments("Loader", "SpinnerNode")
+            .WithSeverity(DiagnosticSeverity.Error);
+
+        await Verify.VerifyAnalyzer([TerminaFrameworkSource, testCode], expected1, expected2, expected3);
+    }
+
+    #endregion
+}

--- a/tests/Termina.Tests/ReactiveViewModelTests.cs
+++ b/tests/Termina.Tests/ReactiveViewModelTests.cs
@@ -2,7 +2,6 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Termina.Input;
-using Termina.Layout;
 using Termina.Reactive;
 
 namespace Termina.Tests;
@@ -43,8 +42,7 @@ public class ReactiveViewModelTests
             navigateWithParams: (_, _) => { },
             shutdown: () => { },
             requestRedraw: () => { },
-            input: Observable.Empty<IInputEvent>(),
-            focusManager: new StubFocusManager());
+            input: Observable.Empty<IInputEvent>());
 
         vm.TestNavigate("test-page");
 
@@ -62,8 +60,7 @@ public class ReactiveViewModelTests
             navigateWithParams: (_, _) => { },
             shutdown: () => shutdownCalled = true,
             requestRedraw: () => { },
-            input: Observable.Empty<IInputEvent>(),
-            focusManager: new StubFocusManager());
+            input: Observable.Empty<IInputEvent>());
 
         vm.TestShutdown();
 
@@ -82,8 +79,7 @@ public class ReactiveViewModelTests
             navigateWithParams: (_, _) => { },
             shutdown: () => { },
             requestRedraw: () => { },
-            input: inputSubject,
-            focusManager: new StubFocusManager());
+            input: inputSubject);
 
         vm.TestInput.OfType<KeyPressed>()
             .Subscribe(k => receivedKeys.Add(k.KeyInfo.Key))
@@ -101,7 +97,7 @@ public class ReactiveViewModelTests
     public void ReactiveViewModel_OnActivatedCalled()
     {
         var vm = new TestViewModel();
-        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => { }, Observable.Empty<IInputEvent>(), new StubFocusManager());
+        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => { }, Observable.Empty<IInputEvent>());
 
         Assert.False(vm.WasActivated);
 
@@ -114,7 +110,7 @@ public class ReactiveViewModelTests
     public void ReactiveViewModel_OnDeactivatingCalled()
     {
         var vm = new TestViewModel();
-        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => { }, Observable.Empty<IInputEvent>(), new StubFocusManager());
+        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => { }, Observable.Empty<IInputEvent>());
 
         Assert.False(vm.WasDeactivating);
 
@@ -254,16 +250,3 @@ public partial class TestReactiveViewModelWithCustomDispose : ReactiveViewModel
     }
 }
 
-/// <summary>
-/// Stub implementation of IFocusManager for testing.
-/// </summary>
-internal class StubFocusManager : IFocusManager
-{
-    public IObservable<IFocusable?> FocusChanged => Observable.Empty<IFocusable?>();
-    public IFocusable? CurrentFocus => null;
-    public void PushFocus(IFocusable focusable) { }
-    public void PopFocus() { }
-    public void SetFocus(IFocusable focusable) { }
-    public void ClearFocus() { }
-    public bool RouteInput(ConsoleKeyInfo key) => false;
-}

--- a/tests/Termina.Tests/Termina.Tests.csproj
+++ b/tests/Termina.Tests/Termina.Tests.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,9 +22,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Termina\Termina.csproj" />
+    <!-- Reference as analyzer for source generation in test code -->
     <ProjectReference Include="..\..\src\Termina.Generators\Termina.Generators.csproj"
                       OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="true" />
   </ItemGroup>
 
 </Project>

--- a/tests/Termina.Tests/Utility/TerminaVerifier.cs
+++ b/tests/Termina.Tests/Utility/TerminaVerifier.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Termina.Tests.Utility;
+
+/// <summary>
+/// Test verifier for Termina analyzers.
+/// Inspired by xunit.analyzers and Akka.Analyzers patterns.
+/// </summary>
+[SuppressMessage("Design", "CA1000:Do not declare static members on generic types")]
+public sealed class TerminaVerifier<TAnalyzer> where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    /// <summary>
+    /// Creates a diagnostic result for the diagnostic referenced in the analyzer.
+    /// </summary>
+    public static DiagnosticResult Diagnostic()
+    {
+        return CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic();
+    }
+
+    /// <summary>
+    /// Creates a diagnostic result for the specified diagnostic ID.
+    /// </summary>
+    public static DiagnosticResult Diagnostic(string id)
+    {
+        return CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(id);
+    }
+
+    /// <summary>
+    /// Verifies that the analyzer produces the expected diagnostics for the given source.
+    /// </summary>
+    public static Task VerifyAnalyzer(string source, params DiagnosticResult[] diagnostics)
+    {
+        return VerifyAnalyzer([source], diagnostics);
+    }
+
+    /// <summary>
+    /// Verifies that the analyzer produces the expected diagnostics for the given sources.
+    /// </summary>
+    public static Task VerifyAnalyzer(string[] sources, params DiagnosticResult[] diagnostics)
+    {
+        var test = new TerminaTest();
+
+        foreach (var source in sources)
+            test.TestState.Sources.Add(source);
+
+        test.ExpectedDiagnostics.AddRange(diagnostics);
+        return test.RunAsync();
+    }
+
+    private sealed class TerminaTest : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
+    {
+        public TerminaTest()
+        {
+            // Use .NET 8.0 reference assemblies (stable, widely available)
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+
+            // Diagnostics are reported in both normal and generated code
+            TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
+
+            // Tests should run independent of current system culture
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds TERMINA002 Roslyn analyzer to detect layout nodes stored as fields/properties in ViewModels (violates MVVM separation of concerns)
- Refactors MVVM architecture for cleaner separation:
  - **ViewModel**: Owns Input (public), state, and business logic
  - **Page**: Owns Focus for modal/interactive control management
- Refactors demo applications to follow the new pattern

## Architecture Decision

After experimenting with different approaches, we settled on:
- ViewModels handle keyboard input directly (business logic concern)
- Pages manage Focus (layout node concern)
- `ViewModel.Input` is public so Pages can access it when routing to interactive layout nodes (e.g., TextInputNode with scrolling)
- The TERMINA002 analyzer catches the real problem: layout nodes stored in ViewModels

This minimizes ceremony while maintaining proper separation of concerns.

## Test plan

- [x] All 578 existing tests pass
- [x] New analyzer tests verify TERMINA002 detection of layout nodes in ViewModels
- [x] Demo applications build and work correctly