### PR TITLE
Add inline animated text segments with tracked segment support

### DIFF
--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -34,30 +34,31 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
 
         // Subscribe to ViewModel chat output and update nodes
         ViewModel.ChatOutput
-            .Subscribe(segment =>
+            .Subscribe(message =>
             {
-                // Handle tracked segment append
-                if (segment.AppendTracked != null && segment.TrackedId.HasValue)
+                switch (message)
                 {
-                    _chatHistory.AppendTracked(segment.TrackedId.Value, segment.AppendTracked);
-                }
-                // Handle tracked segment replacement
-                else if (segment.ReplaceSegmentId.HasValue && segment.ReplaceWith != null)
-                {
-                    _chatHistory.Replace(segment.ReplaceSegmentId.Value, segment.ReplaceWith, segment.ReplaceKeepTracked);
-                }
-                // Handle tracked segment removal
-                else if (segment.RemoveSegmentId.HasValue)
-                {
-                    _chatHistory.Remove(segment.RemoveSegmentId.Value);
-                }
-                // Handle regular text append
-                else
-                {
-                    if (segment.IsNewLine)
-                        _chatHistory.AppendLine(segment.Text, segment.Foreground, null, segment.Decoration);
-                    else
-                        _chatHistory.Append(segment.Text, segment.Foreground, null, segment.Decoration);
+                    case AppendText text:
+                        if (text.IsNewLine)
+                            _chatHistory.AppendLine(text.Text, text.Foreground, null, text.Decoration);
+                        else
+                            _chatHistory.Append(text.Text, text.Foreground, null, text.Decoration);
+                        break;
+
+                    case AppendTrackedSegment tracked:
+                        _chatHistory.AppendTracked(tracked.Id, tracked.Segment);
+                        break;
+
+                    case RemoveTrackedSegment remove:
+                        _chatHistory.Remove(remove.Id);
+                        break;
+
+                    case ReplaceTrackedSegment replace:
+                        _chatHistory.Replace(replace.Id, replace.NewSegment, replace.KeepTracked);
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Unknown message type: {message.GetType()}");
                 }
             })
             .DisposeWith(Subscriptions);

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
 using System.Reactive.Linq;
+using Termina.Components.Streaming;
 using Termina.Extensions;
 using Termina.Input;
 using Termina.Layout;
@@ -35,10 +36,29 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
         ViewModel.ChatOutput
             .Subscribe(segment =>
             {
-                if (segment.IsNewLine)
-                    _chatHistory.AppendLine(segment.Text, segment.Foreground, null, segment.Decoration);
+                // Handle tracked segment append
+                if (segment.AppendTracked != null && segment.TrackedId.HasValue)
+                {
+                    _chatHistory.AppendTracked(segment.TrackedId.Value, segment.AppendTracked);
+                }
+                // Handle tracked segment replacement
+                else if (segment.ReplaceSegmentId.HasValue && segment.ReplaceWith != null)
+                {
+                    _chatHistory.Replace(segment.ReplaceSegmentId.Value, segment.ReplaceWith, segment.ReplaceKeepTracked);
+                }
+                // Handle tracked segment removal
+                else if (segment.RemoveSegmentId.HasValue)
+                {
+                    _chatHistory.Remove(segment.RemoveSegmentId.Value);
+                }
+                // Handle regular text append
                 else
-                    _chatHistory.Append(segment.Text, segment.Foreground, null, segment.Decoration);
+                {
+                    if (segment.IsNewLine)
+                        _chatHistory.AppendLine(segment.Text, segment.Foreground, null, segment.Decoration);
+                    else
+                        _chatHistory.Append(segment.Text, segment.Foreground, null, segment.Decoration);
+                }
             })
             .DisposeWith(Subscriptions);
 
@@ -131,25 +151,7 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                     .WithTitleColor(Color.Yellow)
                     .WithBorder(BorderStyle.Rounded)
                     .WithBorderColor(Color.Gray)
-                    .WithContent(
-                        Layouts.Vertical()
-                            .WithChild(_chatHistory.Fill())
-                            .WithChild(
-                                ViewModel.IsGeneratingChanged
-                                    .CombineLatest(ViewModel.HasReceivedTextChanged, (isGenerating, hasText) => (isGenerating, hasText))
-                                    .Select(state => state.isGenerating && !state.hasText
-                                        ? Layouts.Horizontal()
-                                            .WithChild(new TextNode("  🤖 ")
-                                                .WithForeground(Color.Yellow)
-                                                .Width(5))
-                                            .WithChild(new TextNode("Assistant: ")
-                                                .WithForeground(Color.Green)
-                                                .Bold())
-                                            .WithChild(new SpinnerNode(SpinnerStyle.Dots)
-                                                .WithSpinnerColor(Color.Red))
-                                            as ILayoutNode
-                                        : new EmptyNode())
-                                    .AsLayout()))
+                    .WithContent(_chatHistory.Fill())
                     .Fill())
             .WithChild(new EmptyNode().Height(1))
             // Input panel

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
@@ -15,20 +15,33 @@ using Termina.Terminal;
 namespace Termina.Demo.Streaming.Pages;
 
 /// <summary>
-/// Represents a styled text segment for chat display.
-/// Supports both regular text and tracked segment operations.
+/// Base interface for chat messages.
 /// </summary>
-public readonly record struct ChatTextSegment(
+public interface IChatMessage;
+
+/// <summary>
+/// Append regular text to the chat history.
+/// </summary>
+public sealed record AppendText(
     string Text,
     Color? Foreground = null,
     TextDecoration Decoration = TextDecoration.None,
-    bool IsNewLine = false,
-    ITextSegment? AppendTracked = null,        // If set, append this tracked segment with TrackedId
-    SegmentId? TrackedId = null,               // The ID to use when appending a tracked segment
-    SegmentId? RemoveSegmentId = null,         // If set, remove the tracked segment with this ID
-    ITextSegment? ReplaceWith = null,          // If set with ReplaceSegmentId, replace that segment with this
-    SegmentId? ReplaceSegmentId = null,        // The ID of the segment to replace
-    bool ReplaceKeepTracked = false);          // Whether the replaced segment should remain tracked
+    bool IsNewLine = false) : IChatMessage;
+
+/// <summary>
+/// Append a tracked text segment that can be manipulated later.
+/// </summary>
+public sealed record AppendTrackedSegment(SegmentId Id, ITextSegment Segment) : IChatMessage;
+
+/// <summary>
+/// Remove a tracked segment by ID.
+/// </summary>
+public sealed record RemoveTrackedSegment(SegmentId Id) : IChatMessage;
+
+/// <summary>
+/// Replace a tracked segment with new content.
+/// </summary>
+public sealed record ReplaceTrackedSegment(SegmentId Id, ITextSegment NewSegment, bool KeepTracked = false) : IChatMessage;
 
 /// <summary>
 /// ViewModel for the streaming chat demo.
@@ -48,14 +61,14 @@ public partial class StreamingChatViewModel : ReactiveViewModel
     private SpinnerSegment? _currentSpinner;
 
     // Subjects for chat output - Page subscribes to these
-    private readonly Subject<ChatTextSegment> _chatOutput = new();
+    private readonly Subject<IChatMessage> _chatOutput = new();
     private readonly Subject<string> _promptTextChanged = new();
 
     /// <summary>
-    /// Observable for chat history content.
-    /// Includes both regular text and tracked segment operations.
+    /// Observable for chat messages.
+    /// Includes text appends and tracked segment operations.
     /// </summary>
-    public IObservable<ChatTextSegment> ChatOutput => _chatOutput.AsObservable();
+    public IObservable<IChatMessage> ChatOutput => _chatOutput.AsObservable();
 
     /// <summary>
     /// Observable for prompt text changes (for history navigation).
@@ -77,11 +90,11 @@ public partial class StreamingChatViewModel : ReactiveViewModel
     /// </summary>
     public void EmitWelcomeMessage()
     {
-        _chatOutput.OnNext(new ChatTextSegment("🤖 ", Color.Yellow));
-        _chatOutput.OnNext(new ChatTextSegment("Assistant: ", Color.Green, TextDecoration.Bold));
-        _chatOutput.OnNext(new ChatTextSegment("Hello! I'm a simulated LLM demo.", Color.White, IsNewLine: true));
-        _chatOutput.OnNext(new ChatTextSegment("   Ask me anything and watch the streaming response!", Color.BrightBlack, IsNewLine: true));
-        _chatOutput.OnNext(new ChatTextSegment("", IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("🤖 ", Color.Yellow));
+        _chatOutput.OnNext(new AppendText("Assistant: ", Color.Green, TextDecoration.Bold));
+        _chatOutput.OnNext(new AppendText("Hello! I'm a simulated LLM demo.", Color.White, IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("   Ask me anything and watch the streaming response!", Color.BrightBlack, IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("", IsNewLine: true));
     }
 
     public override void OnActivated()
@@ -140,7 +153,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
     public void CancelGeneration()
     {
         _generationCts?.Cancel();
-        _chatOutput.OnNext(new ChatTextSegment(" [cancelled]", Color.Yellow, TextDecoration.Italic, IsNewLine: true));
+        _chatOutput.OnNext(new AppendText(" [cancelled]", Color.Yellow, TextDecoration.Italic, IsNewLine: true));
         CleanupGeneration();
         StatusMessage = "Generation cancelled.";
     }
@@ -159,20 +172,18 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         _historyIndex = -1;
 
         // Add user message to chat
-        _chatOutput.OnNext(new ChatTextSegment("👤 ", Color.Cyan));
-        _chatOutput.OnNext(new ChatTextSegment("You: ", Color.Cyan, TextDecoration.Bold));
-        _chatOutput.OnNext(new ChatTextSegment(prompt, Color.White, IsNewLine: true));
-        _chatOutput.OnNext(new ChatTextSegment("", IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("👤 ", Color.Cyan));
+        _chatOutput.OnNext(new AppendText("You: ", Color.Cyan, TextDecoration.Bold));
+        _chatOutput.OnNext(new AppendText(prompt, Color.White, IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("", IsNewLine: true));
 
         // Add Assistant prefix and append animated spinner
-        _chatOutput.OnNext(new ChatTextSegment("🤖 ", Color.Yellow));
-        _chatOutput.OnNext(new ChatTextSegment("Assistant: ", Color.Green, TextDecoration.Bold));
+        _chatOutput.OnNext(new AppendText("🤖 ", Color.Yellow));
+        _chatOutput.OnNext(new AppendText("Assistant: ", Color.Green, TextDecoration.Bold));
 
-        // Append tracked spinner - will be removed when first text arrives
+        // Append tracked spinner - will be replaced when first text arrives
         _currentSpinner = new SpinnerSegment(Components.Streaming.SpinnerStyle.Dots, Color.Red);
-        _chatOutput.OnNext(new ChatTextSegment("",
-            AppendTracked: _currentSpinner,
-            TrackedId: ThinkingSpinnerId));
+        _chatOutput.OnNext(new AppendTrackedSegment(ThinkingSpinnerId, _currentSpinner));
 
         // Start generation
         IsGenerating = true;
@@ -212,16 +223,16 @@ public partial class StreamingChatViewModel : ReactiveViewModel
                         // On first text chunk, replace the spinner with static empty segment
                         if (!HasReceivedText)
                         {
-                            _chatOutput.OnNext(new ChatTextSegment("",
-                                ReplaceWith: new StaticTextSegment("", TextStyle.Default),
-                                ReplaceSegmentId: ThinkingSpinnerId,
-                                ReplaceKeepTracked: false));
+                            _chatOutput.OnNext(new ReplaceTrackedSegment(
+                                ThinkingSpinnerId,
+                                new StaticTextSegment("", TextStyle.Default),
+                                KeepTracked: false));
                             _currentSpinner?.Dispose();
                             _currentSpinner = null;
                             HasReceivedText = true;
                         }
 
-                        _chatOutput.OnNext(new ChatTextSegment(chunk.Text));
+                        _chatOutput.OnNext(new AppendText(chunk.Text));
                         break;
 
                     case LlmMessages.GenerationComplete:
@@ -238,9 +249,9 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         }
         catch (Exception ex)
         {
-            _chatOutput.OnNext(new ChatTextSegment(" [error: ", Color.Red));
-            _chatOutput.OnNext(new ChatTextSegment(ex.Message, Color.Red, TextDecoration.Bold));
-            _chatOutput.OnNext(new ChatTextSegment("]", Color.Red, IsNewLine: true));
+            _chatOutput.OnNext(new AppendText(" [error: ", Color.Red));
+            _chatOutput.OnNext(new AppendText(ex.Message, Color.Red, TextDecoration.Bold));
+            _chatOutput.OnNext(new AppendText("]", Color.Red, IsNewLine: true));
             CleanupGeneration();
             StatusMessage = $"Error: {ex.Message}";
         }
@@ -256,8 +267,8 @@ public partial class StreamingChatViewModel : ReactiveViewModel
 
     private void CleanupGeneration()
     {
-        _chatOutput.OnNext(new ChatTextSegment("", IsNewLine: true));
-        _chatOutput.OnNext(new ChatTextSegment("", IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("", IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("", IsNewLine: true));
         IsGenerating = false;
         _generationCts?.Dispose();
         _generationCts = null;

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
@@ -6,7 +6,9 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Akka.Actor;
 using Akka.Hosting;
+using Termina.Components.Streaming;
 using Termina.Demo.Streaming.Actors;
+using Termina.Layout;
 using Termina.Reactive;
 using Termina.Terminal;
 
@@ -14,12 +16,19 @@ namespace Termina.Demo.Streaming.Pages;
 
 /// <summary>
 /// Represents a styled text segment for chat display.
+/// Supports both regular text and tracked segment operations.
 /// </summary>
 public readonly record struct ChatTextSegment(
     string Text,
     Color? Foreground = null,
     TextDecoration Decoration = TextDecoration.None,
-    bool IsNewLine = false);
+    bool IsNewLine = false,
+    ITextSegment? AppendTracked = null,        // If set, append this tracked segment with TrackedId
+    SegmentId? TrackedId = null,               // The ID to use when appending a tracked segment
+    SegmentId? RemoveSegmentId = null,         // If set, remove the tracked segment with this ID
+    ITextSegment? ReplaceWith = null,          // If set with ReplaceSegmentId, replace that segment with this
+    SegmentId? ReplaceSegmentId = null,        // The ID of the segment to replace
+    bool ReplaceKeepTracked = false);          // Whether the replaced segment should remain tracked
 
 /// <summary>
 /// ViewModel for the streaming chat demo.
@@ -28,11 +37,15 @@ public readonly record struct ChatTextSegment(
 /// </summary>
 public partial class StreamingChatViewModel : ReactiveViewModel
 {
+    // Predefined segment IDs for tracked elements
+    private static readonly SegmentId ThinkingSpinnerId = new(1);
+
     private readonly IRequiredActor<LlmSimulatorActor> _llmActorProvider;
     private readonly List<string> _promptHistory = new();
     private int _historyIndex = -1;
     private IActorRef? _llmActor;
     private CancellationTokenSource? _generationCts;
+    private SpinnerSegment? _currentSpinner;
 
     // Subjects for chat output - Page subscribes to these
     private readonly Subject<ChatTextSegment> _chatOutput = new();
@@ -40,6 +53,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
 
     /// <summary>
     /// Observable for chat history content.
+    /// Includes both regular text and tracked segment operations.
     /// </summary>
     public IObservable<ChatTextSegment> ChatOutput => _chatOutput.AsObservable();
 
@@ -150,7 +164,17 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         _chatOutput.OnNext(new ChatTextSegment(prompt, Color.White, IsNewLine: true));
         _chatOutput.OnNext(new ChatTextSegment("", IsNewLine: true));
 
-        // Start generation - don't emit Assistant prefix yet, let the reactive layout show spinner
+        // Add Assistant prefix and append animated spinner
+        _chatOutput.OnNext(new ChatTextSegment("🤖 ", Color.Yellow));
+        _chatOutput.OnNext(new ChatTextSegment("Assistant: ", Color.Green, TextDecoration.Bold));
+
+        // Append tracked spinner - will be removed when first text arrives
+        _currentSpinner = new SpinnerSegment(Components.Streaming.SpinnerStyle.Dots, Color.Red);
+        _chatOutput.OnNext(new ChatTextSegment("",
+            AppendTracked: _currentSpinner,
+            TrackedId: ThinkingSpinnerId));
+
+        // Start generation
         IsGenerating = true;
         HasReceivedText = false;
         StatusMessage = "Generating response...";
@@ -185,11 +209,15 @@ public partial class StreamingChatViewModel : ReactiveViewModel
                         break;
 
                     case LlmMessages.TextChunk chunk:
-                        // On first text chunk, emit the Assistant prefix
+                        // On first text chunk, replace the spinner with static empty segment
                         if (!HasReceivedText)
                         {
-                            _chatOutput.OnNext(new ChatTextSegment("🤖 ", Color.Yellow));
-                            _chatOutput.OnNext(new ChatTextSegment("Assistant: ", Color.Green, TextDecoration.Bold));
+                            _chatOutput.OnNext(new ChatTextSegment("",
+                                ReplaceWith: new StaticTextSegment("", TextStyle.Default),
+                                ReplaceSegmentId: ThinkingSpinnerId,
+                                ReplaceKeepTracked: false));
+                            _currentSpinner?.Dispose();
+                            _currentSpinner = null;
                             HasReceivedText = true;
                         }
 
@@ -237,6 +265,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
 
     public override void Dispose()
     {
+        _currentSpinner?.Dispose();
         _chatOutput.Dispose();
         _promptTextChanged.Dispose();
         DisposeReactiveFields();

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -44,19 +44,49 @@ export default defineConfig({
       ],
       '/components/': [
         { text: 'Component Library', link: '/components/' },
-        { text: 'TextNode', link: '/components/text-node' },
-        { text: 'PanelNode', link: '/components/panel-node' },
-        { text: 'TextInputNode', link: '/components/text-input-node' },
-        { text: 'SelectionListNode', link: '/components/selection-list-node' },
-        { text: 'SpinnerNode', link: '/components/spinner-node' },
-        { text: 'StreamingTextNode', link: '/components/streaming-text-node' },
-        { text: 'ScrollableContainerNode', link: '/components/scrollable-container' },
-        { text: 'StackLayout', link: '/components/stack-layout' },
-        { text: 'ModalNode', link: '/components/modal-node' },
-        { text: 'ReactiveLayoutNode', link: '/components/reactive-layout' },
-        { text: 'ConditionalNode', link: '/components/conditional-node' },
-        { text: 'EmptyNode', link: '/components/empty-node' },
-        { text: 'DeferredNode', link: '/components/deferred-node' }
+        {
+          text: 'Display Components',
+          collapsed: false,
+          items: [
+            { text: 'TextNode', link: '/components/text-node' },
+            { text: 'StreamingTextNode', link: '/components/streaming-text-node' },
+            { text: 'PanelNode', link: '/components/panel-node' },
+            { text: 'SpinnerNode', link: '/components/spinner-node' }
+          ]
+        },
+        {
+          text: 'Input Components',
+          collapsed: false,
+          items: [
+            { text: 'TextInputNode', link: '/components/text-input-node' },
+            { text: 'SelectionListNode', link: '/components/selection-list-node' }
+          ]
+        },
+        {
+          text: 'Container Components',
+          collapsed: false,
+          items: [
+            { text: 'ScrollableContainer', link: '/components/scrollable-container' },
+            { text: 'StackLayout', link: '/components/stack-layout' },
+            { text: 'ModalNode', link: '/components/modal-node' }
+          ]
+        },
+        {
+          text: 'Reactive Components',
+          collapsed: false,
+          items: [
+            { text: 'ReactiveLayoutNode', link: '/components/reactive-layout' },
+            { text: 'ConditionalNode', link: '/components/conditional-node' }
+          ]
+        },
+        {
+          text: 'Utility Components',
+          collapsed: false,
+          items: [
+            { text: 'EmptyNode', link: '/components/empty-node' },
+            { text: 'DeferredNode', link: '/components/deferred-node' }
+          ]
+        }
       ],
       '/styling/': [
         { text: 'Styling Guide', link: '/styling/' },

--- a/docs/components/streaming-text-node.md
+++ b/docs/components/streaming-text-node.md
@@ -187,6 +187,255 @@ stream.Append(
 );
 ```
 
+## Text Composition and Tracked Segments
+
+StreamingTextNode supports **tracked segments** - text elements that can be independently animated and later removed or replaced. This enables inline animations like spinners, progress bars, timers, and other dynamic content that appears alongside static text.
+
+### Concepts
+
+**Untracked vs Tracked Content:**
+- **Untracked** (default): Regular `Append()` and `AppendLine()` calls create immutable content with zero overhead
+- **Tracked**: `AppendTracked()` creates mutable segments that can be animated, removed, or replaced
+
+**Segment Types:**
+
+| Type | Interface | Purpose |
+|------|-----------|---------|
+| `StaticTextSegment` | `ITextSegment` | Static trackable text that can be removed/replaced |
+| `SpinnerSegment` | `IAnimatedTextSegment` | Animated spinner with multiple styles |
+| Custom implementations | `ITextSegment` or `IAnimatedTextSegment` | Your own tracked segments |
+
+### Caller-Provided IDs
+
+Like HTML elements with `id` attributes, tracked segments use caller-provided IDs. You choose the ID upfront:
+
+```csharp
+// Define your segment IDs
+private static readonly SegmentId SpinnerId = new(1);
+private static readonly SegmentId TimerId = new(2);
+private static readonly SegmentId ProgressId = new(3);
+
+// Use them for tracking
+stream.AppendTracked(SpinnerId, new SpinnerSegment());
+```
+
+This eliminates the need to capture and track returned IDs - you control the identifiers.
+
+### Static Tracked Segments
+
+Use `StaticTextSegment` when you need to track non-animated text for later removal or replacement:
+
+```csharp
+var stream = StreamingTextNode.Create();
+
+// Append tracked static text
+var placeholder = new StaticTextSegment("[loading...]", Color.Gray);
+stream.AppendTracked(new SegmentId(1), placeholder);
+
+// Later, replace with actual content
+stream.Replace(
+    new SegmentId(1),
+    new StaticTextSegment("Operation complete!"),
+    keepTracked: false  // Convert to untracked
+);
+```
+
+### Animated Segments
+
+`SpinnerSegment` provides inline animated spinners with 6 styles:
+
+```csharp
+using Termina.Components.Streaming;
+
+var stream = StreamingTextNode.Create();
+
+// Append "Thinking: " followed by animated spinner
+stream.Append("Thinking: ");
+var spinner = new SpinnerSegment(
+    SpinnerStyle.Dots,  // ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏
+    Color.Yellow,
+    intervalMs: 80
+);
+stream.AppendTracked(new SegmentId(1), spinner);
+```
+
+**Available Spinner Styles:**
+
+| Style | Animation Frames |
+|-------|-----------------|
+| `SpinnerStyle.Dots` | ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏ |
+| `SpinnerStyle.Line` | - \\ \| / |
+| `SpinnerStyle.Arrow` | ← ↖ ↑ ↗ → ↘ ↓ ↙ |
+| `SpinnerStyle.Bounce` | ⠁ ⠂ ⠄ ⠂ |
+| `SpinnerStyle.Box` | ▖ ▘ ▝ ▗ |
+| `SpinnerStyle.Circle` | ◐ ◓ ◑ ◒ |
+
+### Operations on Tracked Segments
+
+```csharp
+var stream = StreamingTextNode.Create();
+var spinnerId = new SegmentId(1);
+
+// 1. Append a tracked segment
+var spinner = new SpinnerSegment(SpinnerStyle.Dots, Color.Red);
+stream.AppendTracked(spinnerId, spinner);
+
+// 2. Remove the tracked segment
+stream.Remove(spinnerId);
+
+// 3. Replace with another tracked segment (stays tracked)
+stream.Replace(spinnerId, new SpinnerSegment(SpinnerStyle.Arrow), keepTracked: true);
+
+// 4. Replace with untracked content (stops tracking, frees ID)
+stream.Replace(
+    spinnerId,
+    new StaticTextSegment("Done!"),
+    keepTracked: false
+);
+```
+
+### ID Reuse
+
+When `keepTracked: false`, the segment ID is freed and can be reused:
+
+```csharp
+private static readonly SegmentId ThinkingSpinnerId = new(1);
+
+// First use
+stream.AppendTracked(ThinkingSpinnerId, new SpinnerSegment(...));
+// ... later ...
+stream.Replace(ThinkingSpinnerId, new StaticTextSegment(""), keepTracked: false);
+
+// ID is now free, can reuse for next operation
+stream.AppendTracked(ThinkingSpinnerId, new SpinnerSegment(...));
+```
+
+### Real-World Example: Chat with Thinking Indicator
+
+A complete example showing a spinner that appears while waiting for an LLM response:
+
+```csharp
+public class ChatViewModel : ReactiveViewModel
+{
+    private static readonly SegmentId ThinkingSpinnerId = new(1);
+    private SpinnerSegment? _currentSpinner;
+
+    public void HandleUserMessage(string message)
+    {
+        // Show user message
+        ChatHistory.Append("You: ", Color.Cyan, decoration: TextDecoration.Bold);
+        ChatHistory.AppendLine(message);
+        ChatHistory.AppendLine("");
+
+        // Show "Assistant: " with inline spinner
+        ChatHistory.Append("Assistant: ", Color.Green, decoration: TextDecoration.Bold);
+        _currentSpinner = new SpinnerSegment(SpinnerStyle.Dots, Color.Red);
+        ChatHistory.AppendTracked(ThinkingSpinnerId, _currentSpinner);
+
+        // Start async response
+        _ = StreamResponseAsync();
+    }
+
+    private async Task StreamResponseAsync()
+    {
+        var firstChunk = true;
+
+        await foreach (var token in GetLlmResponse())
+        {
+            // On first text, replace spinner with empty content
+            if (firstChunk)
+            {
+                ChatHistory.Replace(
+                    ThinkingSpinnerId,
+                    new StaticTextSegment(""),
+                    keepTracked: false
+                );
+                _currentSpinner?.Dispose();
+                _currentSpinner = null;
+                firstChunk = false;
+            }
+
+            // Append LLM text
+            ChatHistory.Append(token);
+        }
+
+        ChatHistory.AppendLine("");
+        ChatHistory.AppendLine("");
+    }
+}
+```
+
+### Custom Animated Segments
+
+Implement `IAnimatedTextSegment` to create custom animations:
+
+```csharp
+public class BlinkSegment : IAnimatedTextSegment
+{
+    private readonly Timer _timer;
+    private readonly Subject<Unit> _invalidated = new();
+    private bool _visible = true;
+    private readonly string _text;
+    private readonly TextStyle _style;
+
+    public BlinkSegment(string text, Color color, int intervalMs = 500)
+    {
+        _text = text;
+        _style = new TextStyle(color, Color.Default, TextDecoration.None);
+        _timer = new Timer(intervalMs);
+        _timer.Elapsed += (_, _) =>
+        {
+            _visible = !_visible;
+            _invalidated.OnNext(Unit.Default);
+        };
+        Start();
+    }
+
+    public IObservable<Unit> Invalidated => _invalidated;
+    public bool IsAnimating => _timer.Enabled;
+
+    public StyledSegment GetCurrentSegment()
+    {
+        return _visible
+            ? new StyledSegment(_text, _style)
+            : new StyledSegment(new string(' ', _text.Length), _style);
+    }
+
+    public void Start() => _timer.Start();
+    public void Stop() => _timer.Stop();
+
+    public void Dispose()
+    {
+        Stop();
+        _timer.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+    }
+}
+
+// Usage
+var blink = new BlinkSegment("URGENT", Color.Red);
+stream.AppendTracked(new SegmentId(1), blink);
+```
+
+### Performance Considerations
+
+- **Untracked appends**: O(1), zero overhead
+- **Tracked appends**: O(1), minimal tracking overhead
+- **Remove/Replace**: O(n) buffer rebuild, but only when mutating
+- **Animation frames**: No rebuild, just invalidation for redraw
+
+Most content should be untracked. Only use tracked segments for dynamic elements that need mutation.
+
+### Use Cases
+
+- **Spinners**: Loading indicators while waiting for async operations
+- **Timers**: Countdown or elapsed time displays
+- **Progress bars**: Text-based progress indicators
+- **Blinking text**: Attention-grabbing alerts
+- **Status indicators**: Live updating connection status, typing indicators
+- **Placeholders**: Temporary content replaced when data loads
+
 ## Scrolling API
 
 For persisted buffers:
@@ -266,6 +515,8 @@ StreamingTextNode.CreateWindowed(windowSize: 100)
 
 ### Methods
 
+#### Untracked Content
+
 | Method | Description |
 |--------|-------------|
 | `.Append(string)` | Append plain text |
@@ -273,11 +524,29 @@ StreamingTextNode.CreateWindowed(windowSize: 100)
 | `.Append(StyledSegment)` | Append a styled segment |
 | `.AppendLine(string)` | Append plain text line |
 | `.AppendLine(string, foreground?, background?, decoration?)` | Append styled line |
-| `.Clear()` | Clear all content |
+| `.Clear()` | Clear all content (tracked and untracked) |
+
+#### Tracked Segments
+
+| Method | Description |
+|--------|-------------|
+| `.AppendTracked(SegmentId, ITextSegment)` | Append tracked segment with caller-provided ID |
+| `.Remove(SegmentId)` | Remove tracked segment by ID |
+| `.Replace(SegmentId, ITextSegment, keepTracked)` | Replace segment; `keepTracked: false` converts to untracked |
+
+#### Scrolling
+
+| Method | Description |
+|--------|-------------|
 | `.ScrollUp(lines, width)` | Scroll up |
 | `.ScrollDown(lines)` | Scroll down |
 | `.ScrollToBottom()` | Jump to bottom |
 | `.HandleInput(key, height, width)` | Handle scroll keys |
+
+#### Configuration
+
+| Method | Description |
+|--------|-------------|
 | `.WithForeground(Color)` | Set default text color |
 | `.WithBackground(Color)` | Set default background color |
 | `.WithPrefix(string, Color?)` | Set line prefix |

--- a/src/Termina/Components/Streaming/IAnimatedTextSegment.cs
+++ b/src/Termina/Components/Streaming/IAnimatedTextSegment.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+
+namespace Termina.Components.Streaming;
+
+/// <summary>
+/// Represents a text segment that can animate over time (spinner, blink, timer, etc).
+/// Extends ITextSegment with animation lifecycle and invalidation events.
+/// </summary>
+public interface IAnimatedTextSegment : ITextSegment
+{
+    /// <summary>
+    /// Observable that fires when the segment's display text changes and needs re-rendering.
+    /// Subscribe to this to trigger redraws when animation frames change.
+    /// </summary>
+    IObservable<Unit> Invalidated { get; }
+
+    /// <summary>
+    /// Start the animation.
+    /// </summary>
+    void Start();
+
+    /// <summary>
+    /// Stop the animation.
+    /// </summary>
+    void Stop();
+
+    /// <summary>
+    /// Gets whether the animation is currently running.
+    /// </summary>
+    bool IsAnimating { get; }
+}

--- a/src/Termina/Components/Streaming/ICompositeTextSegment.cs
+++ b/src/Termina/Components/Streaming/ICompositeTextSegment.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Components.Streaming;
+
+/// <summary>
+/// Represents a group of text segments composed together.
+/// Enables grouping multiple segments (static or animated) as a single trackable unit.
+/// </summary>
+/// <remarks>
+/// Composition pattern for combining segments. Example: "[🔄 Processing...]" could be:
+/// - CompositeSegment([, SpinnerSegment, " Processing..."])
+/// </remarks>
+public interface ICompositeTextSegment : ITextSegment
+{
+    /// <summary>
+    /// Gets the child segments that make up this composite.
+    /// </summary>
+    IReadOnlyList<ITextSegment> Children { get; }
+}

--- a/src/Termina/Components/Streaming/ITextSegment.cs
+++ b/src/Termina/Components/Streaming/ITextSegment.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Terminal;
+
+namespace Termina.Components.Streaming;
+
+/// <summary>
+/// Base interface for any text segment (static or animated) that can be rendered.
+/// All tracked segments must implement this interface to provide their current display content.
+/// </summary>
+public interface ITextSegment : IDisposable
+{
+    /// <summary>
+    /// Gets the current styled segment to display.
+    /// For static segments, this always returns the same content.
+    /// For animated segments, this returns different content based on the current animation frame.
+    /// </summary>
+    StyledSegment GetCurrentSegment();
+}

--- a/src/Termina/Components/Streaming/SpinnerSegment.cs
+++ b/src/Termina/Components/Streaming/SpinnerSegment.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Timers;
+using Termina.Terminal;
+using Timer = System.Timers.Timer;
+
+namespace Termina.Components.Streaming;
+
+/// <summary>
+/// Available spinner animation styles.
+/// </summary>
+public enum SpinnerStyle
+{
+    /// <summary>Braille dots spinner: ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏</summary>
+    Dots,
+
+    /// <summary>Line spinner: - \ | /</summary>
+    Line,
+
+    /// <summary>Arrow spinner: ← ↖ ↑ ↗ → ↘ ↓ ↙</summary>
+    Arrow,
+
+    /// <summary>Bounce spinner: ⠁ ⠂ ⠄ ⠂</summary>
+    Bounce,
+
+    /// <summary>Box spinner: ▖ ▘ ▝ ▗</summary>
+    Box,
+
+    /// <summary>Circle spinner: ◐ ◓ ◑ ◒</summary>
+    Circle
+}
+
+/// <summary>
+/// Animated spinner segment that cycles through animation frames.
+/// Emits invalidation events when frames change to trigger redraws.
+/// </summary>
+public sealed class SpinnerSegment : IAnimatedTextSegment
+{
+    private static readonly Dictionary<SpinnerStyle, string[]> Frames = new()
+    {
+        [SpinnerStyle.Dots] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+        [SpinnerStyle.Line] = ["-", "\\", "|", "/"],
+        [SpinnerStyle.Arrow] = ["←", "↖", "↑", "↗", "→", "↘", "↓", "↙"],
+        [SpinnerStyle.Bounce] = ["⠁", "⠂", "⠄", "⠂"],
+        [SpinnerStyle.Box] = ["▖", "▘", "▝", "▗"],
+        [SpinnerStyle.Circle] = ["◐", "◓", "◑", "◒"]
+    };
+
+    private readonly Timer _timer;
+    private readonly string[] _frames;
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly TextStyle _style;
+    private int _currentFrame;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a new spinner segment with the specified style and appearance.
+    /// </summary>
+    /// <param name="style">The spinner animation style.</param>
+    /// <param name="color">The color of the spinner (defaults to terminal default).</param>
+    /// <param name="intervalMs">The interval between frame updates in milliseconds (default: 80ms).</param>
+    public SpinnerSegment(SpinnerStyle style = SpinnerStyle.Dots, Color? color = null, int intervalMs = 80)
+    {
+        _frames = Frames[style];
+        _style = new TextStyle(color ?? Color.Default, Color.Default, TextDecoration.None);
+        _timer = new Timer(intervalMs);
+        _timer.Elapsed += OnTimerTick;
+        _timer.AutoReset = true;
+        Start();
+    }
+
+    /// <inheritdoc />
+    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+
+    /// <inheritdoc />
+    public bool IsAnimating => _timer.Enabled;
+
+    /// <inheritdoc />
+    public StyledSegment GetCurrentSegment()
+    {
+        return new StyledSegment(_frames[_currentFrame], _style);
+    }
+
+    /// <inheritdoc />
+    public void Start()
+    {
+        if (!_disposed)
+        {
+            _timer.Start();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Stop()
+    {
+        _timer.Stop();
+    }
+
+    private void OnTimerTick(object? sender, ElapsedEventArgs e)
+    {
+        _currentFrame = (_currentFrame + 1) % _frames.Length;
+        _invalidated.OnNext(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        Stop();
+        _timer.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+    }
+}

--- a/src/Termina/Components/Streaming/StaticTextSegment.cs
+++ b/src/Termina/Components/Streaming/StaticTextSegment.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Terminal;
+
+namespace Termina.Components.Streaming;
+
+/// <summary>
+/// Represents a static (non-animated) text segment that can be tracked for removal/replacement.
+/// Wraps a StyledSegment to enable tracking without animation overhead.
+/// </summary>
+public sealed class StaticTextSegment : ITextSegment
+{
+    private readonly StyledSegment _segment;
+
+    /// <summary>
+    /// Creates a static text segment from a styled segment.
+    /// </summary>
+    public StaticTextSegment(StyledSegment segment)
+    {
+        _segment = segment;
+    }
+
+    /// <summary>
+    /// Creates a static text segment from text and optional style.
+    /// </summary>
+    public StaticTextSegment(string text, TextStyle? style = null)
+    {
+        _segment = new StyledSegment(text, style ?? TextStyle.Default);
+    }
+
+    /// <summary>
+    /// Creates a static text segment with explicit colors.
+    /// </summary>
+    public StaticTextSegment(string text, Color? foreground = null, Color? background = null,
+        TextDecoration decoration = TextDecoration.None)
+    {
+        var style = new TextStyle(
+            foreground ?? Color.Default,
+            background ?? Color.Default,
+            decoration);
+        _segment = new StyledSegment(text, style);
+    }
+
+    /// <inheritdoc />
+    public StyledSegment GetCurrentSegment() => _segment;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // No resources to dispose for static segments
+    }
+}

--- a/src/Termina/Layout/SegmentId.cs
+++ b/src/Termina/Layout/SegmentId.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Unique identifier for a tracked segment in a streaming text buffer.
+/// Uses lightweight integer instead of GUID for performance during rapid segment insertion.
+/// </summary>
+public readonly record struct SegmentId(int Value)
+{
+    /// <summary>
+    /// Represents an invalid or unassigned segment ID.
+    /// </summary>
+    public static readonly SegmentId None = new(0);
+}

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -21,6 +21,17 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
     private readonly IStreamingTextBuffer _buffer;
     private readonly Subject<Unit> _invalidated = new();
 
+    // Tracked segment infrastructure
+    private readonly List<ContentElement> _content = new();  // Ordered list of all content
+    private readonly Dictionary<SegmentId, int> _segmentIndices = new();  // ID -> index in _content
+    private readonly Dictionary<SegmentId, IDisposable> _subscriptions = new();  // Animation subscriptions
+    private readonly object _contentLock = new();  // Thread safety for content mutations
+
+    // Content element types for tracking
+    private abstract record ContentElement;
+    private record StaticElement(StyledSegment Segment) : ContentElement;  // Untracked text
+    private record TrackedElement(SegmentId Id, ITextSegment Segment) : ContentElement;  // Tracked segment
+
     /// <inheritdoc />
     public IObservable<Unit> Invalidated => _invalidated;
 
@@ -84,15 +95,22 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
 
     /// <summary>
     /// Appends text to the buffer and triggers a redraw.
+    /// Untracked - cannot be removed or replaced later.
     /// </summary>
     public void Append(string text)
     {
-        _buffer.Append(text);
+        lock (_contentLock)
+        {
+            var segment = new StyledSegment(text, TextStyle.Default);
+            _content.Add(new StaticElement(segment));
+            _buffer.Append(text);
+        }
         NotifyChanged();
     }
 
     /// <summary>
     /// Appends styled text to the buffer and triggers a redraw.
+    /// Untracked - cannot be removed or replaced later.
     /// </summary>
     /// <param name="text">The text to append.</param>
     /// <param name="foreground">The foreground color (optional).</param>
@@ -105,31 +123,49 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
             foreground ?? Color.Default,
             background ?? Color.Default,
             decoration);
-        _buffer.Append(text, style);
+        var segment = new StyledSegment(text, style);
+
+        lock (_contentLock)
+        {
+            _content.Add(new StaticElement(segment));
+            _buffer.Append(segment);
+        }
         NotifyChanged();
     }
 
     /// <summary>
     /// Appends a styled segment to the buffer and triggers a redraw.
+    /// Untracked - cannot be removed or replaced later.
     /// </summary>
     /// <param name="segment">The styled segment to append.</param>
     public void Append(StyledSegment segment)
     {
-        _buffer.Append(segment);
+        lock (_contentLock)
+        {
+            _content.Add(new StaticElement(segment));
+            _buffer.Append(segment);
+        }
         NotifyChanged();
     }
 
     /// <summary>
     /// Appends a line to the buffer and triggers a redraw.
+    /// Untracked - cannot be removed or replaced later.
     /// </summary>
     public void AppendLine(string line)
     {
-        _buffer.AppendLine(line);
+        lock (_contentLock)
+        {
+            var segment = new StyledSegment(line + "\n", TextStyle.Default);
+            _content.Add(new StaticElement(segment));
+            _buffer.AppendLine(line);
+        }
         NotifyChanged();
     }
 
     /// <summary>
     /// Appends a styled line to the buffer and triggers a redraw.
+    /// Untracked - cannot be removed or replaced later.
     /// </summary>
     /// <param name="line">The line to append.</param>
     /// <param name="foreground">The foreground color (optional).</param>
@@ -142,16 +178,219 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
             foreground ?? Color.Default,
             background ?? Color.Default,
             decoration);
-        _buffer.AppendLine(line, style);
+        var segment = new StyledSegment(line + "\n", style);
+
+        lock (_contentLock)
+        {
+            _content.Add(new StaticElement(segment));
+            _buffer.AppendLine(line, style);
+        }
         NotifyChanged();
     }
 
     /// <summary>
-    /// Clears all content from the buffer.
+    /// Appends a tracked text segment that can be removed or replaced later.
+    /// The caller provides the ID to reference this segment.
+    /// </summary>
+    /// <param name="id">The unique identifier for this segment (provided by caller).</param>
+    /// <param name="segment">The text segment to append.</param>
+    /// <exception cref="ArgumentException">Thrown if the ID is already in use.</exception>
+    public void AppendTracked(SegmentId id, ITextSegment segment)
+    {
+        lock (_contentLock)
+        {
+            if (id == SegmentId.None)
+                throw new ArgumentException("SegmentId.None cannot be used for tracked segments", nameof(id));
+
+            if (_segmentIndices.ContainsKey(id))
+                throw new ArgumentException($"SegmentId {id.Value} is already in use", nameof(id));
+
+            var element = new TrackedElement(id, segment);
+            var index = _content.Count;
+
+            _content.Add(element);
+            _segmentIndices[id] = index;
+            _buffer.Append(segment.GetCurrentSegment());
+
+            // Subscribe to animation invalidation if this is an animated segment
+            if (segment is IAnimatedTextSegment animated)
+            {
+                var subscription = animated.Invalidated.Subscribe(_ =>
+                {
+                    // On animation frame change, rebuild buffer to show new frame
+                    RebuildBuffer();
+                    NotifyChanged();
+                });
+                _subscriptions[id] = subscription;
+            }
+
+            NotifyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Removes a tracked segment by ID and rebuilds the buffer.
+    /// </summary>
+    /// <param name="id">The segment ID to remove.</param>
+    /// <returns>True if the segment was found and removed, false otherwise.</returns>
+    public bool Remove(SegmentId id)
+    {
+        lock (_contentLock)
+        {
+            if (!_segmentIndices.TryGetValue(id, out var index))
+                return false;
+
+            // Dispose animation subscription if present
+            if (_subscriptions.TryGetValue(id, out var subscription))
+            {
+                subscription.Dispose();
+                _subscriptions.Remove(id);
+            }
+
+            // Dispose the segment itself
+            if (_content[index] is TrackedElement { Segment: var segment })
+            {
+                segment.Dispose();
+            }
+
+            // Remove from content list
+            _content.RemoveAt(index);
+            _segmentIndices.Remove(id);
+
+            // Update indices for all segments after this one
+            for (var i = index; i < _content.Count; i++)
+            {
+                if (_content[i] is TrackedElement { Id: var otherId })
+                {
+                    _segmentIndices[otherId] = i;
+                }
+            }
+
+            // Rebuild buffer from remaining content
+            RebuildBuffer();
+            NotifyChanged();
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Replaces a tracked segment with a new segment.
+    /// </summary>
+    /// <param name="id">The segment ID to replace.</param>
+    /// <param name="newSegment">The new segment to replace it with.</param>
+    /// <param name="keepTracked">If true, keeps the segment tracked with the same ID. If false, converts to untracked static content.</param>
+    /// <returns>True if the segment was found and replaced, false otherwise.</returns>
+    public bool Replace(SegmentId id, ITextSegment newSegment, bool keepTracked = true)
+    {
+        lock (_contentLock)
+        {
+            if (!_segmentIndices.TryGetValue(id, out var index))
+                return false;
+
+            // Dispose old animation subscription if present
+            if (_subscriptions.TryGetValue(id, out var oldSubscription))
+            {
+                oldSubscription.Dispose();
+                _subscriptions.Remove(id);
+            }
+
+            // Dispose old segment
+            if (_content[index] is TrackedElement { Segment: var oldSegment })
+            {
+                oldSegment.Dispose();
+            }
+
+            if (keepTracked)
+            {
+                // Replace with new tracked segment
+                _content[index] = new TrackedElement(id, newSegment);
+
+                // Subscribe to new animation if applicable
+                if (newSegment is IAnimatedTextSegment animated)
+                {
+                    var subscription = animated.Invalidated.Subscribe(_ =>
+                    {
+                        RebuildBuffer();
+                        NotifyChanged();
+                    });
+                    _subscriptions[id] = subscription;
+                }
+            }
+            else
+            {
+                // Replace with static element (no longer tracked)
+                var staticSegment = newSegment.GetCurrentSegment();
+                _content[index] = new StaticElement(staticSegment);
+                _segmentIndices.Remove(id);
+
+                // Dispose the new segment since we only needed its current content
+                newSegment.Dispose();
+
+                // Update indices for all segments after this one
+                for (var i = index + 1; i < _content.Count; i++)
+                {
+                    if (_content[i] is TrackedElement { Id: var otherId })
+                    {
+                        _segmentIndices[otherId] = i;
+                    }
+                }
+            }
+
+            // Rebuild buffer with new content
+            RebuildBuffer();
+            NotifyChanged();
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds the buffer from the content list.
+    /// Called when tracked segments are added, removed, or replaced.
+    /// </summary>
+    private void RebuildBuffer()
+    {
+        _buffer.Clear();
+
+        foreach (var element in _content)
+        {
+            var segment = element switch
+            {
+                StaticElement s => s.Segment,
+                TrackedElement t => t.Segment.GetCurrentSegment(),
+                _ => throw new InvalidOperationException($"Unknown content element type: {element.GetType()}")
+            };
+
+            _buffer.Append(segment);
+        }
+    }
+
+    /// <summary>
+    /// Clears all content from the buffer, including tracked segments.
     /// </summary>
     public void Clear()
     {
-        _buffer.Clear();
+        lock (_contentLock)
+        {
+            // Dispose all subscriptions
+            foreach (var subscription in _subscriptions.Values)
+            {
+                subscription.Dispose();
+            }
+            _subscriptions.Clear();
+
+            // Dispose all tracked segments
+            foreach (var element in _content)
+            {
+                if (element is TrackedElement { Segment: var segment })
+                {
+                    segment.Dispose();
+                }
+            }
+
+            _content.Clear();
+            _segmentIndices.Clear();
+            _buffer.Clear();
+        }
         NotifyChanged();
     }
 
@@ -353,6 +592,28 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
     /// <inheritdoc />
     public override void Dispose()
     {
+        lock (_contentLock)
+        {
+            // Dispose all subscriptions
+            foreach (var subscription in _subscriptions.Values)
+            {
+                subscription.Dispose();
+            }
+            _subscriptions.Clear();
+
+            // Dispose all tracked segments
+            foreach (var element in _content)
+            {
+                if (element is TrackedElement { Segment: var segment })
+                {
+                    segment.Dispose();
+                }
+            }
+
+            _content.Clear();
+            _segmentIndices.Clear();
+        }
+
         _invalidated.OnCompleted();
         _invalidated.Dispose();
         base.Dispose();

--- a/tests/Termina.Tests/Layout/StreamingTextNodeTrackedSegmentTests.cs
+++ b/tests/Termina.Tests/Layout/StreamingTextNodeTrackedSegmentTests.cs
@@ -1,0 +1,306 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Components.Streaming;
+using Termina.Layout;
+using Termina.Terminal;
+using SpinnerStyle = Termina.Components.Streaming.SpinnerStyle;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for tracked segment functionality in StreamingTextNode.
+/// </summary>
+public class StreamingTextNodeTrackedSegmentTests
+{
+    [Fact]
+    public void AppendTracked_WithStaticSegment_AddsToBuffer()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+        var segment = new StaticTextSegment("tracked", TextStyle.Default);
+
+        node.AppendTracked(id, segment);
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Single(lines);
+        Assert.Equal("tracked", lines[0].Segments[0].Text);
+    }
+
+    [Fact]
+    public void AppendTracked_WithNoneId_ThrowsArgumentException()
+    {
+        var node = StreamingTextNode.Create();
+        var segment = new StaticTextSegment("test", TextStyle.Default);
+
+        var ex = Assert.Throws<ArgumentException>(() => node.AppendTracked(SegmentId.None, segment));
+        Assert.Contains("SegmentId.None cannot be used", ex.Message);
+    }
+
+    [Fact]
+    public void AppendTracked_WithDuplicateId_ThrowsArgumentException()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+
+        node.AppendTracked(id, new StaticTextSegment("first", TextStyle.Default));
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            node.AppendTracked(id, new StaticTextSegment("second", TextStyle.Default)));
+        Assert.Contains("already in use", ex.Message);
+    }
+
+    [Fact]
+    public void Remove_ExistingSegment_RemovesFromBuffer()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+
+        node.Append("Before ");
+        node.AppendTracked(id, new StaticTextSegment("tracked", TextStyle.Default));
+        node.Append(" After");
+
+        var result = node.Remove(id);
+
+        Assert.True(result);
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Single(lines);
+        Assert.Equal("Before  After", lines[0].Segments[0].Text);
+    }
+
+    [Fact]
+    public void Remove_NonExistentSegment_ReturnsFalse()
+    {
+        var node = StreamingTextNode.Create();
+        var result = node.Remove(new SegmentId(999));
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Remove_DisposesSegment()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+        var segment = new SpinnerSegment(SpinnerStyle.Dots);
+
+        node.AppendTracked(id, segment);
+        Assert.True(segment.IsAnimating);
+
+        node.Remove(id);
+
+        // Spinner should be disposed and stopped
+        Assert.False(segment.IsAnimating);
+    }
+
+    [Fact]
+    public void Replace_WithTrackedSegment_ReplacesContent()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+
+        node.AppendTracked(id, new StaticTextSegment("original", TextStyle.Default));
+
+        var result = node.Replace(id, new StaticTextSegment("replaced", TextStyle.Default), keepTracked: true);
+
+        Assert.True(result);
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal("replaced", lines[0].Segments[0].Text);
+    }
+
+    [Fact]
+    public void Replace_WithUntrackedSegment_ConvertsToStatic()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+
+        node.AppendTracked(id, new StaticTextSegment("tracked", TextStyle.Default));
+
+        // Replace with untracked
+        var result = node.Replace(id, new StaticTextSegment("untracked", TextStyle.Default), keepTracked: false);
+
+        Assert.True(result);
+
+        // ID should now be free for reuse
+        node.AppendTracked(id, new StaticTextSegment("reused", TextStyle.Default));
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal("untrackedreused", lines[0].Segments[0].Text);
+    }
+
+    [Fact]
+    public void Replace_NonExistentSegment_ReturnsFalse()
+    {
+        var node = StreamingTextNode.Create();
+        var result = node.Replace(new SegmentId(999), new StaticTextSegment("test", TextStyle.Default));
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Replace_DisposesOldSegment()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+        var oldSpinner = new SpinnerSegment(SpinnerStyle.Dots);
+
+        node.AppendTracked(id, oldSpinner);
+        Assert.True(oldSpinner.IsAnimating);
+
+        node.Replace(id, new StaticTextSegment("static", TextStyle.Default));
+
+        Assert.False(oldSpinner.IsAnimating);
+    }
+
+    [Fact]
+    public void AppendTracked_MixedWithUntracked_MaintainsOrder()
+    {
+        var node = StreamingTextNode.Create();
+
+        node.Append("A");
+        node.AppendTracked(new SegmentId(1), new StaticTextSegment("B", TextStyle.Default));
+        node.Append("C");
+        node.AppendTracked(new SegmentId(2), new StaticTextSegment("D", TextStyle.Default));
+        node.Append("E");
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal("ABCDE", lines[0].Segments[0].Text);
+    }
+
+    [Fact]
+    public void Remove_UpdatesIndicesCorrectly()
+    {
+        var node = StreamingTextNode.Create();
+
+        node.AppendTracked(new SegmentId(1), new StaticTextSegment("A", TextStyle.Default));
+        node.AppendTracked(new SegmentId(2), new StaticTextSegment("B", TextStyle.Default));
+        node.AppendTracked(new SegmentId(3), new StaticTextSegment("C", TextStyle.Default));
+
+        // Remove middle element
+        node.Remove(new SegmentId(2));
+
+        // Should be able to remove element 3 (indices were updated)
+        var result = node.Remove(new SegmentId(3));
+        Assert.True(result);
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal("A", lines[0].Segments[0].Text);
+    }
+
+    [Fact]
+    public void SpinnerSegment_AnimationFramesChange()
+    {
+        var spinner = new SpinnerSegment(SpinnerStyle.Line, Color.Yellow, intervalMs: 10);
+
+        // Get initial frame
+        var frame1 = spinner.GetCurrentSegment().Text;
+
+        // Wait for animation to tick
+        Thread.Sleep(50);
+
+        var frame2 = spinner.GetCurrentSegment().Text;
+
+        // Frames should differ (animation progressed)
+        Assert.NotEqual(frame1, frame2);
+
+        spinner.Dispose();
+    }
+
+    [Fact]
+    public void SpinnerSegment_InvalidatedEventFires()
+    {
+        var spinner = new SpinnerSegment(SpinnerStyle.Dots, intervalMs: 10);
+        var eventFired = false;
+
+        spinner.Invalidated.Subscribe(_ => eventFired = true);
+
+        // Wait for at least one timer tick
+        Thread.Sleep(50);
+
+        Assert.True(eventFired);
+        spinner.Dispose();
+    }
+
+    [Fact]
+    public void SpinnerSegment_StopPausesAnimation()
+    {
+        var spinner = new SpinnerSegment(SpinnerStyle.Dots);
+
+        Assert.True(spinner.IsAnimating);
+
+        spinner.Stop();
+
+        Assert.False(spinner.IsAnimating);
+
+        spinner.Dispose();
+    }
+
+    [Fact]
+    public void StaticTextSegment_WithStyle_RendersCorrectly()
+    {
+        var segment = new StaticTextSegment("styled", Color.Red, Color.Blue, TextDecoration.Bold);
+
+        var styled = segment.GetCurrentSegment();
+
+        Assert.Equal("styled", styled.Text);
+        Assert.Equal(Color.Red, styled.Style.Foreground);
+        Assert.Equal(Color.Blue, styled.Style.Background);
+        Assert.Equal(TextDecoration.Bold, styled.Style.Decoration);
+    }
+
+    [Fact]
+    public void Clear_RemovesAllTrackedSegments()
+    {
+        var node = StreamingTextNode.Create();
+        var spinner = new SpinnerSegment(SpinnerStyle.Dots);
+
+        node.AppendTracked(new SegmentId(1), spinner);
+        node.Append("text");
+        node.AppendTracked(new SegmentId(2), new StaticTextSegment("tracked", TextStyle.Default));
+
+        node.Clear();
+
+        // Buffer should be empty
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Empty(lines);
+
+        // Spinner should be disposed
+        Assert.False(spinner.IsAnimating);
+    }
+
+    [Fact]
+    public void Dispose_DisposesAllTrackedSegments()
+    {
+        var node = StreamingTextNode.Create();
+        var spinner1 = new SpinnerSegment(SpinnerStyle.Dots);
+        var spinner2 = new SpinnerSegment(SpinnerStyle.Line);
+
+        node.AppendTracked(new SegmentId(1), spinner1);
+        node.AppendTracked(new SegmentId(2), spinner2);
+
+        node.Dispose();
+
+        Assert.False(spinner1.IsAnimating);
+        Assert.False(spinner2.IsAnimating);
+    }
+
+    [Fact]
+    public void Replace_KeepTracked_SubscribesToNewAnimation()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+
+        node.AppendTracked(id, new StaticTextSegment("static", TextStyle.Default));
+
+        // Replace with animated segment
+        var newSpinner = new SpinnerSegment(SpinnerStyle.Dots, intervalMs: 10);
+        node.Replace(id, newSpinner, keepTracked: true);
+
+        var eventFired = false;
+        // Give animation time to invalidate
+        var subscription = node.ContentChanged.Subscribe(_ => eventFired = true);
+
+        Thread.Sleep(50);
+
+        Assert.True(eventFired);
+        subscription.Dispose();
+        newSpinner.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for independently animated text elements (spinners, timers, etc.) that appear inline in streaming text and can be replaced or removed later. Implements opt-in tracked segment system with caller-provided IDs.

## Key Features

- **Caller-provided IDs**: Like HTML div IDs, callers choose segment IDs upfront
- **Opt-in tracking**: Regular appends remain untracked (zero overhead), explicit tracked appends enable mutation
- **Replace with untracked**: Convert tracked segments to static content and free IDs for reuse
- **Animation support**: Spinner segments with 6 styles, custom animated segments via IAnimatedTextSegment
- **Message protocol**: Interface-based chat messages for clean separation between ViewModel and Page

## Implementation

### New Types
- `SegmentId` - Integer-based value object for segment identifiers
- `ITextSegment` - Base interface for all text segments
- `IAnimatedTextSegment` - Interface for animated segments with invalidation events
- `StaticTextSegment` - Wrapper for static trackable text
- `SpinnerSegment` - Animated spinner with 6 styles (Dots, Line, Arrow, Bounce, Box, Circle)

### Modified Components
- `StreamingTextNode` - Enhanced with tracked segment support
  - `AppendTracked(SegmentId, ITextSegment)` - Append tracked segment
  - `Remove(SegmentId)` - Remove tracked segment
  - `Replace(SegmentId, ITextSegment, bool keepTracked)` - Replace segment

### Demo Updates
- Streaming chat demo refactored to use message protocol
- Shows inline spinner while waiting for LLM response
- Spinner replaced with response text when first chunk arrives

## Documentation

- Added comprehensive "Text Composition and Tracked Segments" section to StreamingTextNode docs
- Reorganized component sidebar into functional categories (Display, Input, Container, Reactive, Utility)
- Included real-world chat examples and custom animation implementation guide

## Testing

- 19 new tests for tracked segment functionality
- All 616 existing tests pass
- Coverage for AppendTracked, Remove, Replace, disposal, animation, mixed content