### PR TITLE
Add formalized diagnostic tracing system

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,10 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
+  <!-- Benchmark dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
   <!-- SourceLink support -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Termina.slnx
+++ b/Termina.slnx
@@ -18,4 +18,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/Termina.Tests/Termina.Tests.csproj" />
   </Folder>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Termina.Benchmarks/Termina.Benchmarks.csproj" />
+  </Folder>
 </Solution>

--- a/benchmarks/Termina.Benchmarks/Program.cs
+++ b/benchmarks/Termina.Benchmarks/Program.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Running;
+
+// Run all benchmarks in the assembly
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/Termina.Benchmarks/Termina.Benchmarks.csproj
+++ b/benchmarks/Termina.Benchmarks/Termina.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Termina\Termina.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Termina.Benchmarks/TracingBenchmarks.cs
+++ b/benchmarks/Termina.Benchmarks/TracingBenchmarks.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Termina.Diagnostics;
+
+namespace Termina.Benchmarks;
+
+/// <summary>
+/// Benchmarks for tracing when DISABLED - should show near-zero overhead.
+/// </summary>
+/// <remarks>
+/// This is the critical benchmark: when tracing is disabled, there should be
+/// no allocations and minimal CPU overhead (just an inlined boolean check).
+/// </remarks>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class TracingDisabledBenchmarks
+{
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Ensure tracing is disabled
+        TerminaTrace.Disable();
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("NoArgs")]
+    public void Disabled_NoArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message");
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("OneArg")]
+    public void Disabled_OneArg()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}", 42);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("TwoArgs")]
+    public void Disabled_TwoArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}, {1}", 42, "hello");
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("ThreeArgs")]
+    public void Disabled_ThreeArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}, {1}, {2}", 42, "hello", true);
+    }
+}
+
+/// <summary>
+/// Benchmarks for tracing when ENABLED with a null listener (no I/O).
+/// </summary>
+/// <remarks>
+/// This measures the overhead of creating TraceEvent structs without
+/// any actual formatting or I/O.
+/// </remarks>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class TracingEnabledNullListenerBenchmarks
+{
+    private NullTraceListener _listener = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _listener = new NullTraceListener();
+        TerminaTrace.Configure(_listener, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        TerminaTrace.Disable();
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("NoArgs")]
+    public void NullListener_NoArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message");
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("OneArg")]
+    public void NullListener_OneArg()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}", 42);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("TwoArgs")]
+    public void NullListener_TwoArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}, {1}", 42, "hello");
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("ThreeArgs")]
+    public void NullListener_ThreeArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}, {1}, {2}", 42, "hello", true);
+    }
+}
+
+/// <summary>
+/// Benchmarks for tracing when ENABLED with a listener that formats messages.
+/// </summary>
+/// <remarks>
+/// This measures the full cost of tracing including string formatting.
+/// This is the "worst case" for enabled tracing.
+/// </remarks>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class TracingEnabledFormattingBenchmarks
+{
+    private FormattingTraceListener _listener = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _listener = new FormattingTraceListener();
+        TerminaTrace.Configure(_listener, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        TerminaTrace.Disable();
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("NoArgs")]
+    public void Formatting_NoArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message");
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("OneArg")]
+    public void Formatting_OneArg()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}", 42);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("TwoArgs")]
+    public void Formatting_TwoArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}, {1}", 42, "hello");
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("ThreeArgs")]
+    public void Formatting_ThreeArgs()
+    {
+        TerminaTrace.Focus.Debug(this, "Test message: {0}, {1}, {2}", 42, "hello", true);
+    }
+}
+
+/// <summary>
+/// A trace listener that does nothing - used to measure pure tracing overhead.
+/// </summary>
+internal sealed class NullTraceListener : ITerminaTraceListener
+{
+    public bool IsEnabled(TerminaTraceLevel level, TerminaTraceCategory category) => true;
+    public void Write(in TraceEvent evt) { }
+}
+
+/// <summary>
+/// A trace listener that formats the message - used to measure formatting cost.
+/// </summary>
+internal sealed class FormattingTraceListener : ITerminaTraceListener
+{
+    private string? _lastMessage;
+
+    public bool IsEnabled(TerminaTraceLevel level, TerminaTraceCategory category) => true;
+
+    public void Write(in TraceEvent evt)
+    {
+        // Force the message to be formatted
+        _lastMessage = evt.FormatMessage();
+    }
+}

--- a/demos/Termina.Demo/Pages/CounterPage.cs
+++ b/demos/Termina.Demo/Pages/CounterPage.cs
@@ -39,6 +39,10 @@ public class CounterPage : ReactivePage<CounterViewModel>
                 ViewModel.StatusMessageChanged
                     .Select(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
+                    .Height(1))
+            .WithChild(
+                new TextNode($"Trace log: {ViewModel.TraceFilePath}")
+                    .WithForeground(Color.DarkGray)
                     .Height(1));
     }
 }

--- a/demos/Termina.Demo/Pages/CounterViewModel.cs
+++ b/demos/Termina.Demo/Pages/CounterViewModel.cs
@@ -10,8 +10,20 @@ namespace Termina.Demo.Pages;
 /// </summary>
 public partial class CounterViewModel : ReactiveViewModel
 {
+    private readonly TraceFileInfo _traceFileInfo;
+
     [Reactive] private int _count;
     [Reactive] private string _statusMessage = "Press Up/Down to change count, T for todos, Q to quit";
+
+    public CounterViewModel(TraceFileInfo traceFileInfo)
+    {
+        _traceFileInfo = traceFileInfo;
+    }
+
+    /// <summary>
+    /// Gets the path to the trace log file for display in the UI.
+    /// </summary>
+    public string TraceFilePath => _traceFileInfo.FilePath;
 
     public override void OnActivated()
     {

--- a/demos/Termina.Demo/Pages/TodoListPage.cs
+++ b/demos/Termina.Demo/Pages/TodoListPage.cs
@@ -150,6 +150,10 @@ public class TodoListPage : ReactivePage<TodoListViewModel>
                 ViewModel.StatusMessageChanged
                     .Select(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
+                    .Height(1))
+            .WithChild(
+                new TextNode($"Trace log: {ViewModel.TraceFilePath}")
+                    .WithForeground(Color.DarkGray)
                     .Height(1));
 
         // Build the layer with modal overlays

--- a/demos/Termina.Demo/Pages/TodoListViewModel.cs
+++ b/demos/Termina.Demo/Pages/TodoListViewModel.cs
@@ -10,6 +10,18 @@ namespace Termina.Demo.Pages;
 /// </summary>
 public partial class TodoListViewModel : ReactiveViewModel
 {
+    private readonly TraceFileInfo _traceFileInfo;
+
+    public TodoListViewModel(TraceFileInfo traceFileInfo)
+    {
+        _traceFileInfo = traceFileInfo;
+    }
+
+    /// <summary>
+    /// Gets the path to the trace log file for display in the UI.
+    /// </summary>
+    public string TraceFilePath => _traceFileInfo.FilePath;
+
     [Reactive] private IReadOnlyList<TodoItem> _items = new List<TodoItem>
     {
         new("Learn Termina reactive patterns", false),

--- a/demos/Termina.Demo/Program.cs
+++ b/demos/Termina.Demo/Program.cs
@@ -1,5 +1,8 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Termina.Demo;
 using Termina.Demo.Pages;
+using Termina.Diagnostics;
 using Termina.Hosting;
 using Termina.Input;
 using Termina.Pages;
@@ -7,7 +10,16 @@ using Termina.Pages;
 // Check for --test flag (used in CI/CD to run scripted test and exit)
 var testMode = args.Contains("--test");
 
+// Set up diagnostic tracing with timestamped log file in temp directory
+var traceDir = Path.Combine(Path.GetTempPath(), "termina-logs");
+Directory.CreateDirectory(traceDir);
+var traceFile = Path.Combine(traceDir, $"trace-{DateTime.Now:yyyyMMdd-HHmmss}.log");
+
 var builder = Host.CreateApplicationBuilder(args);
+
+// Enable file tracing and register the path for UI display
+builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Debug);
+builder.Services.AddSingleton(new TraceFileInfo(traceFile));
 
 // Set up input source based on mode
 VirtualInputSource? scriptedInput = null;

--- a/demos/Termina.Demo/README.md
+++ b/demos/Termina.Demo/README.md
@@ -1,0 +1,113 @@
+# Termina Demo
+
+A demonstration application showcasing Termina's reactive TUI capabilities, including:
+
+- Counter page with reactive state
+- Todo list with modals and focus management
+- Navigation between pages
+- Diagnostic tracing integration
+
+## Running the Demo
+
+### Interactive Mode
+
+Run the demo interactively to explore the UI:
+
+```bash
+dotnet run --project demos/Termina.Demo
+```
+
+**Controls:**
+
+Counter Page:
+- `↑` / `↓` - Increment/decrement counter
+- `R` - Reset counter
+- `T` - Navigate to todo list
+- `Q` - Quit
+
+Todo List Page:
+- `↑` / `↓` - Navigate items
+- `Space` - Toggle completion
+- `A` - Add new item (opens modal)
+- `D` - Delete selected item
+- `C` - Navigate to counter
+- `Q` - Quit
+
+### Headless/CI Mode
+
+Run with `--test` flag for automated testing without user interaction:
+
+```bash
+dotnet run --project demos/Termina.Demo -- --test
+```
+
+This mode:
+- Uses `VirtualInputSource` to simulate keystrokes
+- Runs a scripted test sequence (increment counter, navigate to todos, toggle an item)
+- Exits automatically after completing the test sequence
+- Useful for CI/CD pipelines to verify the app starts and renders correctly
+
+## Diagnostic Tracing
+
+The demo automatically enables diagnostic tracing to help debug and understand Termina's internals.
+
+### Log File Location
+
+Trace logs are written to:
+```
+%TEMP%\termina-logs\trace-{timestamp}.log
+```
+
+For example: `C:\Users\you\AppData\Local\Temp\termina-logs\trace-20251217-133215.log`
+
+The trace file path is displayed at the bottom of both the Counter and Todo List pages.
+
+### Log Contents
+
+The trace logs capture:
+- **Page** - Navigation events, page lifecycle (creation, caching, activation)
+- **Input** - Input source startup and key events
+- **Render** - Screen mode changes, cursor visibility
+- **Focus** - Focus stack operations (when applicable)
+
+### Example Output
+
+```
+2025-12-17 13:32:15.390 [INFO] [Page] TerminaApplication#00D45D21 - Navigating to: /counter
+2025-12-17 13:32:15.391 [DEBUG] [Page] TerminaApplication#00D45D21 - Creating new page, behavior=PreserveState
+2025-12-17 13:32:15.399 [DEBUG] [Page] TerminaApplication#00D45D21 - Cached page: /counter
+2025-12-17 13:32:15.411 [INFO] [Page] TerminaApplication#00D45D21 - Navigation complete: /counter, page=CounterPage
+2025-12-17 13:32:15.419 [INFO] [Page] TerminaApplication#00D45D21 - RunAsync starting
+2025-12-17 13:32:15.422 [DEBUG] [Input] TerminaApplication#00D45D21 - Started 1 input source(s)
+2025-12-17 13:32:15.422 [DEBUG] [Render] TerminaApplication#00D45D21 - Entered alternate screen, cursor hidden
+```
+
+### Viewing Logs in Real-Time
+
+On Windows, you can tail the log file while the demo runs:
+
+```powershell
+# PowerShell
+Get-Content -Path "$env:TEMP\termina-logs\trace-*.log" -Tail 20 -Wait
+```
+
+On Unix-like systems:
+
+```bash
+tail -f /tmp/termina-logs/trace-*.log
+```
+
+## Configuration
+
+The demo configures tracing in `Program.cs`:
+
+```csharp
+// Set up diagnostic tracing with timestamped log file in temp directory
+var traceDir = Path.Combine(Path.GetTempPath(), "termina-logs");
+Directory.CreateDirectory(traceDir);
+var traceFile = Path.Combine(traceDir, $"trace-{DateTime.Now:yyyyMMdd-HHmmss}.log");
+
+builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Debug);
+```
+
+You can modify the trace categories and levels as needed. See the [Diagnostic Tracing documentation](/docs/advanced/diagnostics.md) for details.

--- a/demos/Termina.Demo/TraceFileInfo.cs
+++ b/demos/Termina.Demo/TraceFileInfo.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Demo;
+
+/// <summary>
+/// Holds information about the trace file location for display in the UI.
+/// </summary>
+public sealed record TraceFileInfo(string FilePath);

--- a/docs/advanced/diagnostics.md
+++ b/docs/advanced/diagnostics.md
@@ -1,0 +1,300 @@
+# Diagnostic Tracing
+
+Termina includes a built-in diagnostic tracing system for debugging and monitoring your TUI applications.
+
+## Overview
+
+The tracing system is designed with these goals:
+
+- **Zero-cost when disabled**: No allocations, minimal CPU overhead (a single boolean check)
+- **Deferred formatting**: Messages are only formatted when a listener actually needs them
+- **Lock-free I/O**: File output uses a Channel-based design that never blocks the UI thread
+- **Category filtering**: Focus on specific subsystems (Focus, Input, Layout, Render, etc.)
+- **Level filtering**: Control verbosity from Trace to Error
+
+## Default Behavior
+
+**Tracing is completely disabled by default.** When no listener is configured, all trace calls are no-ops with sub-nanosecond overhead and zero allocations.
+
+## Enabling Tracing
+
+### File Tracing (Recommended for Debugging)
+
+```csharp
+using Termina.Diagnostics;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Enable file tracing
+builder.Services.AddTerminaFileTracing("termina-trace.log");
+
+// Or with category and level filtering
+builder.Services.AddTerminaFileTracing(
+    "termina-trace.log",
+    TerminaTraceCategory.Focus | TerminaTraceCategory.Input,
+    TerminaTraceLevel.Debug);
+```
+
+### Microsoft.Extensions.Logging Integration
+
+Route Termina traces to your existing logging infrastructure:
+
+```csharp
+builder.Services
+    .AddLogging(logging => logging.AddConsole())
+    .AddTerminaLoggerTracing();
+
+// With filtering
+builder.Services.AddTerminaLoggerTracing(
+    TerminaTraceCategory.All,
+    TerminaTraceLevel.Info);
+```
+
+### Stderr Output (Quick Debugging)
+
+For quick debugging without file I/O:
+
+```csharp
+TerminaTrace.Configure(
+    FileTraceListener.CreateStdErr(),
+    TerminaTraceCategory.All,
+    TerminaTraceLevel.Debug);
+```
+
+### Manual Configuration (Without DI)
+
+```csharp
+var listener = new FileTraceListener("trace.log");
+TerminaTrace.Configure(listener, TerminaTraceCategory.All, TerminaTraceLevel.Debug);
+
+// When done, properly dispose to drain pending events
+await listener.DisposeAsync();
+```
+
+## Categories
+
+Filter traces by subsystem using the `TerminaTraceCategory` flags enum:
+
+| Category | Description |
+|----------|-------------|
+| `Focus` | Focus management, focus stack operations |
+| `Input` | Keyboard and mouse input processing |
+| `Layout` | Layout measurement and arrangement |
+| `Page` | Page navigation and lifecycle |
+| `Reactive` | Observable subscriptions and updates |
+| `Render` | Rendering operations and ANSI output |
+| `Platform` | Platform-specific console operations |
+| `All` | All categories enabled |
+| `None` | No categories (disabled) |
+
+Combine categories with bitwise OR:
+
+```csharp
+var categories = TerminaTraceCategory.Focus | TerminaTraceCategory.Input;
+```
+
+## Levels
+
+Control verbosity with `TerminaTraceLevel`:
+
+| Level | Description |
+|-------|-------------|
+| `Trace` | Most verbose, fine-grained diagnostic info |
+| `Debug` | Debugging information (default) |
+| `Info` | General informational messages |
+| `Warning` | Potential issues or unexpected conditions |
+| `Error` | Errors that don't crash the application |
+
+Setting a level includes all higher severity levels (e.g., `Debug` includes `Info`, `Warning`, and `Error`).
+
+## Output Format
+
+The `FileTraceListener` produces output in this format:
+
+```
+2024-01-15 10:30:45.123 [DEBUG] [Focus] FocusManager#12345678 - PushFocus: TextInputNode, stack depth=1
+2024-01-15 10:30:45.125 [TRACE] [Input] TextInputNode#87654321 - HandleInput: key=A, char='A'
+2024-01-15 10:30:45.130 [INFO] [Page] TerminaApplication#11111111 - Navigating to: /todos
+```
+
+Format: `{timestamp} [{level}] [{category}] {source_type}#{hash} - {message}`
+
+## Adding Traces to Your Code
+
+Use the category-specific loggers on `TerminaTrace`:
+
+```csharp
+// In a ViewModel or component
+public void HandleKeyPress(KeyPressed key)
+{
+    TerminaTrace.Input.Trace(this, "HandleKeyPress: key={0}", key.KeyInfo.Key);
+
+    // ... your logic ...
+
+    if (someCondition)
+    {
+        TerminaTrace.Input.Debug(this, "Special condition triggered");
+    }
+}
+```
+
+### Available Loggers
+
+| Logger | Category |
+|--------|----------|
+| `TerminaTrace.Focus` | Focus operations |
+| `TerminaTrace.Input` | Input handling |
+| `TerminaTrace.Layout` | Layout operations |
+| `TerminaTrace.Page` | Page navigation |
+| `TerminaTrace.Reactive` | Reactive subscriptions |
+| `TerminaTrace.Render` | Rendering |
+| `TerminaTrace.Platform` | Platform operations |
+
+### Method Overloads
+
+Each logger supports 0-3 arguments with deferred formatting:
+
+```csharp
+// No arguments
+TerminaTrace.Focus.Debug(this, "Focus changed");
+
+// One argument
+TerminaTrace.Focus.Debug(this, "Focused: {0}", nodeName);
+
+// Two arguments
+TerminaTrace.Input.Trace(this, "Key: {0}, Char: {1}", key.Key, key.KeyChar);
+
+// Three arguments
+TerminaTrace.Render.Trace(this, "Render at ({0},{1}) size {2}", x, y, size);
+```
+
+## Custom Listeners
+
+Implement `ITerminaTraceListener` for custom output:
+
+```csharp
+public interface ITerminaTraceListener
+{
+    bool IsEnabled(TerminaTraceLevel level, TerminaTraceCategory category);
+    void Write(in TraceEvent evt);
+}
+```
+
+Example: Console listener with colors:
+
+```csharp
+public class ColoredConsoleListener : ITerminaTraceListener
+{
+    private readonly TerminaTraceCategory _categories;
+    private readonly TerminaTraceLevel _minLevel;
+
+    public ColoredConsoleListener(
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minLevel = TerminaTraceLevel.Debug)
+    {
+        _categories = categories;
+        _minLevel = minLevel;
+    }
+
+    public bool IsEnabled(TerminaTraceLevel level, TerminaTraceCategory category)
+        => level >= _minLevel && (_categories & category) != 0;
+
+    public void Write(in TraceEvent evt)
+    {
+        var color = evt.Level switch
+        {
+            TerminaTraceLevel.Error => ConsoleColor.Red,
+            TerminaTraceLevel.Warning => ConsoleColor.Yellow,
+            TerminaTraceLevel.Info => ConsoleColor.White,
+            _ => ConsoleColor.Gray
+        };
+
+        var original = Console.ForegroundColor;
+        Console.ForegroundColor = color;
+        Console.Error.WriteLine($"[{evt.Level}] [{evt.Category}] {evt.FormatMessage()}");
+        Console.ForegroundColor = original;
+    }
+}
+```
+
+## Performance
+
+The tracing system is designed for minimal overhead:
+
+| Scenario | Time | Allocations |
+|----------|------|-------------|
+| Disabled (no listener) | ~1 ns | 0 B |
+| Enabled, no args | ~29 ns | 0 B |
+| Enabled, 1 arg | ~32 ns | 24 B |
+| Enabled, 2 args | ~32 ns | 24 B |
+| Enabled, 3 args | ~37 ns | 48 B |
+| With formatting | ~64-110 ns | 80-128 B |
+
+The small allocations when enabled come from boxing arguments. String formatting only occurs when the listener actually processes the event.
+
+## Best Practices
+
+### Use Appropriate Levels
+
+```csharp
+// Trace: Very frequent operations, detailed debugging
+TerminaTrace.Input.Trace(this, "Mouse move: {0},{1}", x, y);
+
+// Debug: Less frequent, useful for debugging
+TerminaTrace.Focus.Debug(this, "Focus pushed: {0}", nodeName);
+
+// Info: Significant events
+TerminaTrace.Page.Info(this, "Navigating to: {0}", path);
+
+// Warning: Unexpected but recoverable
+TerminaTrace.Layout.Warning(this, "Node has zero size: {0}", node);
+
+// Error: Problems that need attention
+TerminaTrace.Render.Error(this, "Render failed: {0}", exception.Message);
+```
+
+### Filter in Production
+
+Only enable categories and levels you need:
+
+```csharp
+// Development: Everything
+builder.Services.AddTerminaFileTracing("trace.log",
+    TerminaTraceCategory.All,
+    TerminaTraceLevel.Trace);
+
+// Production: Errors and warnings only
+builder.Services.AddTerminaFileTracing("trace.log",
+    TerminaTraceCategory.All,
+    TerminaTraceLevel.Warning);
+```
+
+### Dispose Listeners Properly
+
+The `FileTraceListener` uses async I/O. Always dispose properly to flush pending events:
+
+```csharp
+// With DI - automatic disposal
+builder.Services.AddTerminaFileTracing("trace.log");
+
+// Manual usage
+var listener = new FileTraceListener("trace.log");
+try
+{
+    TerminaTrace.Configure(listener, ...);
+    // ... run application ...
+}
+finally
+{
+    await listener.DisposeAsync(); // Drains pending events
+}
+```
+
+## Disabling Tracing
+
+```csharp
+// Disable at runtime
+TerminaTrace.Disable();
+```
+
+This immediately stops all trace output and returns to the zero-overhead state.

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -4,6 +4,10 @@ This section covers advanced Termina topics for building production-quality appl
 
 ## Topics
 
+### [Diagnostic Tracing](/advanced/diagnostics)
+
+Debug and monitor your applications with Termina's built-in tracing system. Zero-cost when disabled, with category and level filtering.
+
 ### [Testing](/advanced/testing)
 
 Learn to write automated tests for your Termina applications using `VirtualInputSource` to simulate user input without a real terminal.

--- a/src/Termina/Diagnostics/FileTraceListener.cs
+++ b/src/Termina/Diagnostics/FileTraceListener.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Threading.Channels;
+
+namespace Termina.Diagnostics;
+
+/// <summary>
+/// Trace listener that writes to a file or TextWriter using a lock-free channel.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This listener uses a channel-based design to avoid blocking the UI thread.
+/// Trace calls just push events to an unbounded channel (non-blocking), and a
+/// background task consumes them and writes to the output.
+/// </para>
+/// <para>
+/// Example output:
+/// </para>
+/// <code>
+/// 2024-01-15 10:30:45.123 [DEBUG] [Focus] FocusManager#12345678 - PushFocus: TextInputNode
+/// 2024-01-15 10:30:45.125 [TRACE] [Input] TextInputNode#87654321 - HandleInput: Key=A
+/// </code>
+/// </remarks>
+public sealed class FileTraceListener : ITerminaTraceListener, IAsyncDisposable, IDisposable
+{
+    private readonly Channel<TraceEvent> _channel;
+    private readonly Task _consumerTask;
+    private readonly TextWriter _writer;
+    private readonly bool _ownsWriter;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly TerminaTraceCategory _enabledCategories;
+    private readonly TerminaTraceLevel _minimumLevel;
+    private volatile bool _disposed;
+
+    /// <summary>
+    /// Create a file trace listener that writes to a file.
+    /// </summary>
+    /// <param name="filePath">Path to the output file.</param>
+    /// <param name="categories">Categories to enable (default: All).</param>
+    /// <param name="minimumLevel">Minimum level to trace (default: Debug).</param>
+    public FileTraceListener(
+        string filePath,
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minimumLevel = TerminaTraceLevel.Debug)
+    {
+        _writer = new StreamWriter(filePath, append: false) { AutoFlush = true };
+        _ownsWriter = true;
+        _enabledCategories = categories;
+        _minimumLevel = minimumLevel;
+
+        _channel = Channel.CreateUnbounded<TraceEvent>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+        _consumerTask = ConsumeEventsAsync(_cts.Token);
+    }
+
+    /// <summary>
+    /// Create a file trace listener that writes to a TextWriter.
+    /// </summary>
+    /// <param name="writer">The writer to output to (e.g., Console.Error).</param>
+    /// <param name="categories">Categories to enable (default: All).</param>
+    /// <param name="minimumLevel">Minimum level to trace (default: Debug).</param>
+    /// <param name="ownsWriter">Whether to dispose the writer when this listener is disposed.</param>
+    public FileTraceListener(
+        TextWriter writer,
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minimumLevel = TerminaTraceLevel.Debug,
+        bool ownsWriter = false)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _ownsWriter = ownsWriter;
+        _enabledCategories = categories;
+        _minimumLevel = minimumLevel;
+
+        _channel = Channel.CreateUnbounded<TraceEvent>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+        _consumerTask = ConsumeEventsAsync(_cts.Token);
+    }
+
+    /// <summary>
+    /// Create a file trace listener that writes to stderr.
+    /// </summary>
+    /// <param name="categories">Categories to enable (default: All).</param>
+    /// <param name="minimumLevel">Minimum level to trace (default: Debug).</param>
+    /// <returns>A new file trace listener writing to stderr.</returns>
+    public static FileTraceListener CreateStdErr(
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minimumLevel = TerminaTraceLevel.Debug)
+    {
+        return new FileTraceListener(Console.Error, categories, minimumLevel, ownsWriter: false);
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled(TerminaTraceLevel level, TerminaTraceCategory category)
+    {
+        return !_disposed
+               && level >= _minimumLevel
+               && (_enabledCategories & category) != 0;
+    }
+
+    /// <inheritdoc />
+    public void Write(in TraceEvent evt)
+    {
+        if (_disposed)
+            return;
+
+        // Non-blocking push to channel - UI thread never waits
+        _channel.Writer.TryWrite(evt);
+    }
+
+    /// <summary>
+    /// Background task that consumes events from the channel and writes to output.
+    /// </summary>
+    private async Task ConsumeEventsAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var evt in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                if (!IsEnabled(evt.Level, evt.Category))
+                    continue;
+
+                var line = FormatEvent(evt);
+                await _writer.WriteLineAsync(line).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on shutdown
+        }
+        catch (Exception ex)
+        {
+            // Don't let trace errors crash the app - write to stderr as last resort
+            try
+            {
+                await Console.Error.WriteLineAsync($"[TerminaTrace] Consumer error: {ex.Message}")
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore
+            }
+        }
+    }
+
+    private static string FormatEvent(in TraceEvent evt)
+    {
+        var timestamp = evt.Timestamp.ToLocalTime()
+            .ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
+        var levelStr = evt.Level.ToString().ToUpperInvariant();
+        var categoryStr = evt.Category.ToString();
+        var hashStr = evt.SourceHash.ToString("X8");
+        var message = evt.FormatMessage();
+
+        return $"{timestamp} [{levelStr}] [{categoryStr}] {evt.SourceType}#{hashStr} - {message}";
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        // Signal completion and wait for consumer to drain
+        _channel.Writer.Complete();
+
+        try
+        {
+            // Give consumer time to drain remaining events
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await _consumerTask.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout - some events may be lost
+        }
+        catch (Exception)
+        {
+            // Consumer task may have faulted
+        }
+
+        _cts.Cancel();
+        _cts.Dispose();
+
+        if (_ownsWriter)
+        {
+            await _writer.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        _channel.Writer.Complete();
+        _cts.Cancel();
+
+        // Synchronously wait for consumer with timeout
+        try
+        {
+            _consumerTask.Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            // Ignore - best effort
+        }
+
+        _cts.Dispose();
+
+        if (_ownsWriter)
+        {
+            _writer.Dispose();
+        }
+    }
+}

--- a/src/Termina/Diagnostics/ITerminaTraceListener.cs
+++ b/src/Termina/Diagnostics/ITerminaTraceListener.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Diagnostics;
+
+/// <summary>
+/// Interface for receiving Termina diagnostic trace output.
+/// </summary>
+/// <remarks>
+/// Implement this interface to create custom trace listeners that route
+/// Termina diagnostics to your preferred logging infrastructure.
+/// </remarks>
+public interface ITerminaTraceListener
+{
+    /// <summary>
+    /// Write a trace event.
+    /// </summary>
+    /// <param name="evt">The trace event. Call <see cref="TraceEvent.FormatMessage"/>
+    /// to get the formatted message string.</param>
+    void Write(in TraceEvent evt);
+
+    /// <summary>
+    /// Check if a specific category and level combination is enabled.
+    /// </summary>
+    /// <param name="level">The severity level to check.</param>
+    /// <param name="category">The category to check.</param>
+    /// <returns>True if tracing is enabled for this level and category.</returns>
+    bool IsEnabled(TerminaTraceLevel level, TerminaTraceCategory category);
+}

--- a/src/Termina/Diagnostics/LoggerTraceListener.cs
+++ b/src/Termina/Diagnostics/LoggerTraceListener.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Termina.Diagnostics;
+
+/// <summary>
+/// Trace listener that routes to Microsoft.Extensions.Logging.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This adapter allows Termina diagnostic output to be captured by any
+/// logging provider configured in your application (Serilog, NLog, file, etc.).
+/// </para>
+/// <para>
+/// Log messages are written with the category "Termina.{Category}" and include
+/// structured properties for component type and instance hash.
+/// </para>
+/// </remarks>
+public sealed class LoggerTraceListener : ITerminaTraceListener
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly Dictionary<TerminaTraceCategory, ILogger> _loggers = new();
+    private readonly TerminaTraceCategory _enabledCategories;
+    private readonly TerminaTraceLevel _minimumLevel;
+
+    /// <summary>
+    /// Create a logger trace listener.
+    /// </summary>
+    /// <param name="loggerFactory">The logger factory to create loggers from.</param>
+    /// <param name="categories">Categories to enable (default: All).</param>
+    /// <param name="minimumLevel">Minimum level to trace (default: Debug).</param>
+    public LoggerTraceListener(
+        ILoggerFactory loggerFactory,
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minimumLevel = TerminaTraceLevel.Debug)
+    {
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _enabledCategories = categories;
+        _minimumLevel = minimumLevel;
+
+        // Pre-create loggers for each category
+        foreach (TerminaTraceCategory category in Enum.GetValues(typeof(TerminaTraceCategory)))
+        {
+            if (category != TerminaTraceCategory.None && category != TerminaTraceCategory.All)
+            {
+                _loggers[category] = loggerFactory.CreateLogger($"Termina.{category}");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled(TerminaTraceLevel level, TerminaTraceCategory category)
+    {
+        return level >= _minimumLevel
+               && (_enabledCategories & category) != 0
+               && _loggers.TryGetValue(category, out var logger)
+               && logger.IsEnabled(ToLogLevel(level));
+    }
+
+    /// <inheritdoc />
+    public void Write(in TraceEvent evt)
+    {
+        if (!IsEnabled(evt.Level, evt.Category))
+            return;
+
+        if (_loggers.TryGetValue(evt.Category, out var logger))
+        {
+            var logLevel = ToLogLevel(evt.Level);
+            var message = evt.FormatMessage(); // Only format when actually logging
+
+            logger.Log(logLevel, "[{SourceType}#{SourceHash:X8}] {Message}",
+                evt.SourceType, evt.SourceHash, message);
+        }
+    }
+
+    private static LogLevel ToLogLevel(TerminaTraceLevel level) => level switch
+    {
+        TerminaTraceLevel.Trace => LogLevel.Trace,
+        TerminaTraceLevel.Debug => LogLevel.Debug,
+        TerminaTraceLevel.Info => LogLevel.Information,
+        TerminaTraceLevel.Warning => LogLevel.Warning,
+        TerminaTraceLevel.Error => LogLevel.Error,
+        _ => LogLevel.Debug
+    };
+}

--- a/src/Termina/Diagnostics/TerminaTrace.cs
+++ b/src/Termina/Diagnostics/TerminaTrace.cs
@@ -1,0 +1,326 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Termina.Diagnostics;
+
+/// <summary>
+/// Static entry point for Termina diagnostic trace logging.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Overview:</b> TerminaTrace provides lightweight, optional diagnostic output for debugging
+/// TUI applications. It uses a static API to avoid forcing dependency injection
+/// into all components while still supporting integration with Microsoft.Extensions.Logging.
+/// </para>
+/// <para>
+/// <b>Default Behavior:</b> Tracing is completely disabled by default. When no listener
+/// is configured via <see cref="Configure"/>:
+/// <list type="bullet">
+/// <item>All trace calls are no-ops (single inlined boolean check)</item>
+/// <item>No string formatting occurs</item>
+/// <item>No memory allocations occur</item>
+/// <item>No TraceEvent structs are created</item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Deferred Formatting:</b> All trace methods use template-based string formatting.
+/// The message is only formatted when tracing is enabled and the listener needs the string.
+/// This ensures zero allocation overhead when disabled.
+/// </para>
+/// <para>
+/// <b>Architecture:</b> The system uses a <see cref="TraceEvent"/> struct to capture
+/// timestamp, level, category, source type, and instance hash at creation time.
+/// The message template and arguments are stored but not formatted until
+/// <see cref="TraceEvent.FormatMessage"/> is called by the listener.
+/// </para>
+/// <para>
+/// <b>Lock-Free Design:</b> The <see cref="FileTraceListener"/> uses a channel-based
+/// design where trace calls push events to an unbounded channel (non-blocking), and
+/// a background task consumes them. This ensures tracing cannot become a global lock
+/// for the UI thread.
+/// </para>
+/// <para>
+/// <b>Enabling Tracing:</b> See <see cref="TerminaTraceExtensions"/> for DI integration,
+/// or use <see cref="Configure"/> for manual setup:
+/// </para>
+/// <code>
+/// // Manual configuration
+/// var listener = new FileTraceListener("trace.log");
+/// TerminaTrace.Configure(listener, TerminaTraceCategory.All, TerminaTraceLevel.Debug);
+///
+/// // Or use DI extension methods
+/// services.AddTerminaFileTracing("trace.log");
+/// services.AddTerminaLoggerTracing(); // M.E.Logging integration
+/// </code>
+/// <para>
+/// <b>Usage from Components:</b>
+/// </para>
+/// <code>
+/// // Simple trace - no allocation if tracing disabled
+/// TerminaTrace.Focus.Debug(this, "PushFocus called");
+///
+/// // With format args - formatting deferred until listener needs it
+/// TerminaTrace.Focus.Debug(this, "PushFocus: {0}, depth={1}", focusable.GetType().Name, depth);
+/// </code>
+/// </remarks>
+public static class TerminaTrace
+{
+    private static volatile ITerminaTraceListener? _listener;
+    private static volatile TerminaTraceCategory _enabledCategories = TerminaTraceCategory.None;
+    private static volatile TerminaTraceLevel _minimumLevel = TerminaTraceLevel.Debug;
+
+    /// <summary>
+    /// Gets the trace logger for focus management operations.
+    /// </summary>
+    public static CategoryTrace Focus { get; } = new(TerminaTraceCategory.Focus);
+
+    /// <summary>
+    /// Gets the trace logger for layout lifecycle operations.
+    /// </summary>
+    public static CategoryTrace Layout { get; } = new(TerminaTraceCategory.Layout);
+
+    /// <summary>
+    /// Gets the trace logger for input routing operations.
+    /// </summary>
+    public static CategoryTrace Input { get; } = new(TerminaTraceCategory.Input);
+
+    /// <summary>
+    /// Gets the trace logger for page lifecycle operations.
+    /// </summary>
+    public static CategoryTrace Page { get; } = new(TerminaTraceCategory.Page);
+
+    /// <summary>
+    /// Gets the trace logger for reactive subscription operations.
+    /// </summary>
+    public static CategoryTrace Reactive { get; } = new(TerminaTraceCategory.Reactive);
+
+    /// <summary>
+    /// Gets the trace logger for rendering operations.
+    /// </summary>
+    public static CategoryTrace Render { get; } = new(TerminaTraceCategory.Render);
+
+    /// <summary>
+    /// Gets the trace logger for platform console operations.
+    /// </summary>
+    public static CategoryTrace Platform { get; } = new(TerminaTraceCategory.Platform);
+
+    /// <summary>
+    /// Gets whether any tracing is currently enabled.
+    /// </summary>
+    public static bool IsEnabled => _listener != null && _enabledCategories != TerminaTraceCategory.None;
+
+    /// <summary>
+    /// Configure the trace listener and enabled categories.
+    /// </summary>
+    /// <param name="listener">The listener to receive trace output.</param>
+    /// <param name="categories">The categories to enable (default: All).</param>
+    /// <param name="minimumLevel">The minimum level to trace (default: Debug).</param>
+    public static void Configure(
+        ITerminaTraceListener listener,
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minimumLevel = TerminaTraceLevel.Debug)
+    {
+        _listener = listener;
+        _enabledCategories = categories;
+        _minimumLevel = minimumLevel;
+    }
+
+    /// <summary>
+    /// Disable all tracing.
+    /// </summary>
+    public static void Disable()
+    {
+        _listener = null;
+        _enabledCategories = TerminaTraceCategory.None;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool ShouldTrace(TerminaTraceCategory category, TerminaTraceLevel level)
+    {
+        return _listener != null
+               && (_enabledCategories & category) != 0
+               && level >= _minimumLevel;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteEvent(in TraceEvent evt)
+    {
+        _listener?.Write(in evt);
+    }
+
+    /// <summary>
+    /// Category-specific trace logger with deferred formatting.
+    /// </summary>
+    public sealed class CategoryTrace
+    {
+        private readonly TerminaTraceCategory _category;
+
+        internal CategoryTrace(TerminaTraceCategory category)
+        {
+            _category = category;
+        }
+
+        /// <summary>
+        /// Gets whether this category is currently enabled for any level.
+        /// </summary>
+        public bool IsEnabled => ShouldTrace(_category, _minimumLevel);
+
+        #region Trace Level
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Trace(object source, string message)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Trace)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Trace, _category,
+                source.GetType().Name, source.GetHashCode(), message));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Trace<T0>(object source, string template, T0 arg0)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Trace)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Trace, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Trace<T0, T1>(object source, string template, T0 arg0, T1 arg1)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Trace)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Trace, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0, arg1));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Trace<T0, T1, T2>(object source, string template, T0 arg0, T1 arg1, T2 arg2)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Trace)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Trace, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0, arg1, arg2));
+        }
+
+        #endregion
+
+        #region Debug Level
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Debug(object source, string message)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Debug)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Debug, _category,
+                source.GetType().Name, source.GetHashCode(), message));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Debug<T0>(object source, string template, T0 arg0)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Debug)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Debug, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Debug<T0, T1>(object source, string template, T0 arg0, T1 arg1)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Debug)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Debug, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0, arg1));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Debug<T0, T1, T2>(object source, string template, T0 arg0, T1 arg1, T2 arg2)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Debug)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Debug, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0, arg1, arg2));
+        }
+
+        #endregion
+
+        #region Info Level
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Info(object source, string message)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Info)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Info, _category,
+                source.GetType().Name, source.GetHashCode(), message));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Info<T0>(object source, string template, T0 arg0)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Info)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Info, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Info<T0, T1>(object source, string template, T0 arg0, T1 arg1)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Info)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Info, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0, arg1));
+        }
+
+        #endregion
+
+        #region Warning Level
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Warning(object source, string message)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Warning)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Warning, _category,
+                source.GetType().Name, source.GetHashCode(), message));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Warning<T0>(object source, string template, T0 arg0)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Warning)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Warning, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Warning<T0, T1>(object source, string template, T0 arg0, T1 arg1)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Warning)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Warning, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0, arg1));
+        }
+
+        #endregion
+
+        #region Error Level
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Error(object source, string message)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Error)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Error, _category,
+                source.GetType().Name, source.GetHashCode(), message));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Error<T0>(object source, string template, T0 arg0)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Error)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Error, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Error<T0, T1>(object source, string template, T0 arg0, T1 arg1)
+        {
+            if (!ShouldTrace(_category, TerminaTraceLevel.Error)) return;
+            WriteEvent(new TraceEvent(TerminaTraceLevel.Error, _category,
+                source.GetType().Name, source.GetHashCode(), template, arg0, arg1));
+        }
+
+        #endregion
+    }
+}

--- a/src/Termina/Diagnostics/TerminaTraceCategory.cs
+++ b/src/Termina/Diagnostics/TerminaTraceCategory.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Diagnostics;
+
+/// <summary>
+/// Categories for Termina diagnostic trace output.
+/// </summary>
+[Flags]
+public enum TerminaTraceCategory
+{
+    /// <summary>
+    /// No categories enabled.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Focus management operations (PushFocus, PopFocus, RouteInput).
+    /// </summary>
+    Focus = 1 << 0,
+
+    /// <summary>
+    /// Layout node lifecycle (OnActivate, OnDeactivate, Dispose).
+    /// </summary>
+    Layout = 1 << 1,
+
+    /// <summary>
+    /// Input routing and keystroke handling.
+    /// </summary>
+    Input = 1 << 2,
+
+    /// <summary>
+    /// Page lifecycle (OnNavigatedTo, OnNavigatingFrom, BuildLayout).
+    /// </summary>
+    Page = 1 << 3,
+
+    /// <summary>
+    /// Reactive subscription and observable emissions.
+    /// </summary>
+    Reactive = 1 << 4,
+
+    /// <summary>
+    /// Rendering and terminal output.
+    /// </summary>
+    Render = 1 << 5,
+
+    /// <summary>
+    /// Platform console operations.
+    /// </summary>
+    Platform = 1 << 6,
+
+    /// <summary>
+    /// All categories enabled.
+    /// </summary>
+    All = Focus | Layout | Input | Page | Reactive | Render | Platform
+}

--- a/src/Termina/Diagnostics/TerminaTraceExtensions.cs
+++ b/src/Termina/Diagnostics/TerminaTraceExtensions.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Termina.Diagnostics;
+
+/// <summary>
+/// Extension methods for configuring Termina diagnostic tracing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Default Behavior:</b> Tracing is completely disabled by default. When no listener
+/// is configured, all trace calls are no-ops with minimal overhead (a single boolean check).
+/// </para>
+/// <para>
+/// <b>Enabling Tracing:</b> Use one of the extension methods below to enable tracing
+/// to a file, Microsoft.Extensions.Logging, or a custom listener.
+/// </para>
+/// <para>
+/// <b>Categories:</b> Filter output by category (Focus, Layout, Input, Page, Reactive, Render, Platform)
+/// using the <see cref="TerminaTraceCategory"/> flags enum. Default is <c>All</c>.
+/// </para>
+/// <para>
+/// <b>Levels:</b> Filter output by severity (Trace, Debug, Info, Warning, Error) using
+/// <see cref="TerminaTraceLevel"/>. Default is <c>Debug</c>.
+/// </para>
+/// <para>
+/// <b>Usage Examples:</b>
+/// </para>
+/// <code>
+/// // 1. File tracing - writes to a file with a lock-free channel design
+/// services.AddTerminaFileTracing("termina-trace.log");
+///
+/// // 2. File tracing with category and level filtering
+/// services.AddTerminaFileTracing(
+///     "termina-trace.log",
+///     TerminaTraceCategory.Focus | TerminaTraceCategory.Input,
+///     TerminaTraceLevel.Debug);
+///
+/// // 3. M.E.Logging integration - routes to your configured logging providers
+/// services.AddLogging(builder => builder.AddConsole())
+///         .AddTerminaLoggerTracing();
+///
+/// // 4. Stderr output (useful for debugging without file I/O)
+/// TerminaTrace.Configure(
+///     FileTraceListener.CreateStdErr(),
+///     TerminaTraceCategory.All,
+///     TerminaTraceLevel.Debug);
+///
+/// // 5. Manual configuration without DI
+/// var listener = new FileTraceListener("trace.log");
+/// TerminaTrace.Configure(listener, TerminaTraceCategory.All, TerminaTraceLevel.Debug);
+/// // ... when done:
+/// await listener.DisposeAsync(); // Drains pending events before closing
+/// </code>
+/// <para>
+/// <b>Output Format (FileTraceListener):</b>
+/// </para>
+/// <code>
+/// 2024-01-15 10:30:45.123 [DEBUG] [Focus] FocusManager#12345678 - PushFocus: TextInputNode, stack depth=1
+/// 2024-01-15 10:30:45.125 [TRACE] [Input] TextInputNode#87654321 - HandleInput: key=A, char='A'
+/// </code>
+/// </remarks>
+public static class TerminaTraceExtensions
+{
+    /// <summary>
+    /// Enable Termina tracing to a file.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="filePath">Path to the trace output file.</param>
+    /// <param name="categories">Categories to enable (default: All).</param>
+    /// <param name="minimumLevel">Minimum level to trace (default: Debug).</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddTerminaFileTracing(
+        this IServiceCollection services,
+        string filePath,
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minimumLevel = TerminaTraceLevel.Debug)
+    {
+        var listener = new FileTraceListener(filePath, categories, minimumLevel);
+        TerminaTrace.Configure(listener, categories, minimumLevel);
+
+        // Register for disposal
+        services.AddSingleton<ITerminaTraceListener>(listener);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Enable Termina tracing to Microsoft.Extensions.Logging.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="categories">Categories to enable (default: All).</param>
+    /// <param name="minimumLevel">Minimum level to trace (default: Debug).</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// This must be called after logging is configured. The listener will be
+    /// created when the service provider is built.
+    /// </remarks>
+    public static IServiceCollection AddTerminaLoggerTracing(
+        this IServiceCollection services,
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minimumLevel = TerminaTraceLevel.Debug)
+    {
+        services.AddSingleton<ITerminaTraceListener>(sp =>
+        {
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var listener = new LoggerTraceListener(loggerFactory, categories, minimumLevel);
+            TerminaTrace.Configure(listener, categories, minimumLevel);
+            return listener;
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Enable Termina tracing to a custom listener.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="listener">The trace listener.</param>
+    /// <param name="categories">Categories to enable (default: All).</param>
+    /// <param name="minimumLevel">Minimum level to trace (default: Debug).</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddTerminaTracing(
+        this IServiceCollection services,
+        ITerminaTraceListener listener,
+        TerminaTraceCategory categories = TerminaTraceCategory.All,
+        TerminaTraceLevel minimumLevel = TerminaTraceLevel.Debug)
+    {
+        TerminaTrace.Configure(listener, categories, minimumLevel);
+        services.AddSingleton(listener);
+        return services;
+    }
+}

--- a/src/Termina/Diagnostics/TerminaTraceLevel.cs
+++ b/src/Termina/Diagnostics/TerminaTraceLevel.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Diagnostics;
+
+/// <summary>
+/// Log levels for Termina diagnostic trace output.
+/// </summary>
+public enum TerminaTraceLevel
+{
+    /// <summary>
+    /// Most detailed level - high frequency events like cursor blinks, render cycles.
+    /// </summary>
+    Trace = 0,
+
+    /// <summary>
+    /// Debug information useful during development.
+    /// </summary>
+    Debug = 1,
+
+    /// <summary>
+    /// Informational messages about normal operation.
+    /// </summary>
+    Info = 2,
+
+    /// <summary>
+    /// Warning conditions that don't prevent operation.
+    /// </summary>
+    Warning = 3,
+
+    /// <summary>
+    /// Error conditions that may affect operation.
+    /// </summary>
+    Error = 4
+}

--- a/src/Termina/Diagnostics/TraceEvent.cs
+++ b/src/Termina/Diagnostics/TraceEvent.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Diagnostics;
+
+/// <summary>
+/// A deferred trace event that captures all context at creation time
+/// but only formats the message string when actually needed.
+/// </summary>
+/// <remarks>
+/// This struct-based approach ensures zero string allocations when tracing
+/// is disabled. The message is only formatted when a listener calls
+/// <see cref="FormatMessage"/>.
+/// </remarks>
+public readonly struct TraceEvent
+{
+    /// <summary>
+    /// UTC timestamp when the event was created (as ticks for efficiency).
+    /// </summary>
+    public readonly long TimestampTicks;
+
+    /// <summary>
+    /// The severity level of this trace event.
+    /// </summary>
+    public readonly TerminaTraceLevel Level;
+
+    /// <summary>
+    /// The category this event belongs to.
+    /// </summary>
+    public readonly TerminaTraceCategory Category;
+
+    /// <summary>
+    /// The type name of the component that generated this event.
+    /// </summary>
+    public readonly string SourceType;
+
+    /// <summary>
+    /// Hash code of the source instance for tracking specific objects.
+    /// </summary>
+    public readonly int SourceHash;
+
+    /// <summary>
+    /// The message format template.
+    /// </summary>
+    public readonly string Template;
+
+    private readonly object? _arg0;
+    private readonly object? _arg1;
+    private readonly object? _arg2;
+    private readonly int _argCount;
+
+    /// <summary>
+    /// Create a trace event with no format arguments.
+    /// </summary>
+    public TraceEvent(
+        TerminaTraceLevel level,
+        TerminaTraceCategory category,
+        string sourceType,
+        int sourceHash,
+        string template)
+    {
+        TimestampTicks = DateTime.UtcNow.Ticks;
+        Level = level;
+        Category = category;
+        SourceType = sourceType;
+        SourceHash = sourceHash;
+        Template = template;
+        _arg0 = null;
+        _arg1 = null;
+        _arg2 = null;
+        _argCount = 0;
+    }
+
+    /// <summary>
+    /// Create a trace event with one format argument.
+    /// </summary>
+    public TraceEvent(
+        TerminaTraceLevel level,
+        TerminaTraceCategory category,
+        string sourceType,
+        int sourceHash,
+        string template,
+        object? arg0)
+    {
+        TimestampTicks = DateTime.UtcNow.Ticks;
+        Level = level;
+        Category = category;
+        SourceType = sourceType;
+        SourceHash = sourceHash;
+        Template = template;
+        _arg0 = arg0;
+        _arg1 = null;
+        _arg2 = null;
+        _argCount = 1;
+    }
+
+    /// <summary>
+    /// Create a trace event with two format arguments.
+    /// </summary>
+    public TraceEvent(
+        TerminaTraceLevel level,
+        TerminaTraceCategory category,
+        string sourceType,
+        int sourceHash,
+        string template,
+        object? arg0,
+        object? arg1)
+    {
+        TimestampTicks = DateTime.UtcNow.Ticks;
+        Level = level;
+        Category = category;
+        SourceType = sourceType;
+        SourceHash = sourceHash;
+        Template = template;
+        _arg0 = arg0;
+        _arg1 = arg1;
+        _arg2 = null;
+        _argCount = 2;
+    }
+
+    /// <summary>
+    /// Create a trace event with three format arguments.
+    /// </summary>
+    public TraceEvent(
+        TerminaTraceLevel level,
+        TerminaTraceCategory category,
+        string sourceType,
+        int sourceHash,
+        string template,
+        object? arg0,
+        object? arg1,
+        object? arg2)
+    {
+        TimestampTicks = DateTime.UtcNow.Ticks;
+        Level = level;
+        Category = category;
+        SourceType = sourceType;
+        SourceHash = sourceHash;
+        Template = template;
+        _arg0 = arg0;
+        _arg1 = arg1;
+        _arg2 = arg2;
+        _argCount = 3;
+    }
+
+    /// <summary>
+    /// Gets the timestamp as a DateTime.
+    /// </summary>
+    public DateTime Timestamp => new(TimestampTicks, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Format the message by applying arguments to the template.
+    /// Only call this when you actually need the formatted string.
+    /// </summary>
+    public string FormatMessage() => _argCount switch
+    {
+        0 => Template,
+        1 => string.Format(Template, _arg0),
+        2 => string.Format(Template, _arg0, _arg1),
+        3 => string.Format(Template, _arg0, _arg1, _arg2),
+        _ => Template
+    };
+}

--- a/src/Termina/Input/FocusManager.cs
+++ b/src/Termina/Input/FocusManager.cs
@@ -3,6 +3,7 @@
 
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Termina.Diagnostics;
 using Termina.Layout;
 
 namespace Termina.Input;
@@ -34,6 +35,7 @@ public sealed class FocusManager : IFocusManager, IDisposable
 
         if (!focusable.CanFocus)
         {
+            TerminaTrace.Focus.Debug(this, "PushFocus rejected: {0} CanFocus=false", focusable.GetType().Name);
             return;
         }
 
@@ -41,6 +43,7 @@ public sealed class FocusManager : IFocusManager, IDisposable
         if (_focusStack.Count > 0)
         {
             var current = _focusStack.Peek();
+            TerminaTrace.Focus.Debug(this, "Blurring current: {0}", current.GetType().Name);
             current.OnBlurred();
         }
 
@@ -48,27 +51,34 @@ public sealed class FocusManager : IFocusManager, IDisposable
         _focusStack.Push(focusable);
         focusable.OnFocused();
         _focusChanged.OnNext(focusable);
+        TerminaTrace.Focus.Debug(this, "PushFocus: {0}, stack depth={1}", focusable.GetType().Name, _focusStack.Count);
     }
 
     /// <inheritdoc />
     public void PopFocus()
     {
         if (_focusStack.Count == 0)
+        {
+            TerminaTrace.Focus.Debug(this, "PopFocus: stack empty, nothing to pop");
             return;
+        }
 
         // Blur and remove the current focus
         var current = _focusStack.Pop();
+        TerminaTrace.Focus.Debug(this, "PopFocus: popped {0}, stack depth={1}", current.GetType().Name, _focusStack.Count);
         current.OnBlurred();
 
         // Focus the previous component if any
         if (_focusStack.Count > 0)
         {
             var previous = _focusStack.Peek();
+            TerminaTrace.Focus.Debug(this, "PopFocus: restoring focus to {0}", previous.GetType().Name);
             previous.OnFocused();
             _focusChanged.OnNext(previous);
         }
         else
         {
+            TerminaTrace.Focus.Debug(this, "PopFocus: no previous focus, stack now empty");
             _focusChanged.OnNext(null);
         }
     }
@@ -115,6 +125,7 @@ public sealed class FocusManager : IFocusManager, IDisposable
     {
         if (_focusStack.Count == 0)
         {
+            TerminaTrace.Input.Trace(this, "RouteInput: no focus, key={0} not handled", key.Key);
             return false;
         }
 
@@ -123,10 +134,13 @@ public sealed class FocusManager : IFocusManager, IDisposable
 
         if (!current.CanFocus)
         {
+            TerminaTrace.Input.Debug(this, "RouteInput: {0} CanFocus=false, key={1} not handled", current.GetType().Name, key.Key);
             return false;
         }
 
-        return current.HandleInput(key);
+        var handled = current.HandleInput(key);
+        TerminaTrace.Input.Trace(this, "RouteInput: {0} key={1} handled={2}", current.GetType().Name, key.Key, handled);
+        return handled;
     }
 
     /// <summary>

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -4,6 +4,7 @@
 using System.Reactive;
 using System.Reactive.Subjects;
 using System.Timers;
+using Termina.Diagnostics;
 using Termina.Rendering;
 using Termina.Terminal;
 using Timer = System.Timers.Timer;
@@ -63,6 +64,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// <inheritdoc />
     public void OnFocused()
     {
+        TerminaTrace.Focus.Debug(this, "OnFocused");
         _hasFocus = true;
         _cursorVisible = true;
         Start(); // Ensure cursor is blinking
@@ -72,6 +74,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// <inheritdoc />
     public void OnBlurred()
     {
+        TerminaTrace.Focus.Debug(this, "OnBlurred");
         _hasFocus = false;
         Stop(); // Stop cursor blinking when not focused
         _invalidated.OnNext(Unit.Default);
@@ -257,8 +260,11 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         // Don't process input if disposed
         if (_disposed)
         {
+            TerminaTrace.Input.Debug(this, "HandleInput rejected: disposed");
             return false;
         }
+
+        TerminaTrace.Input.Trace(this, "HandleInput: key={0}, char='{1}'", key.Key, key.KeyChar);
 
         // Reset cursor to visible on any input
         _cursorVisible = true;
@@ -280,6 +286,8 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             _ when key.KeyChar != '\0' && !char.IsControl(key.KeyChar) => HandleCharacter(key.KeyChar, key.Modifiers),
             _ => false
         };
+
+        TerminaTrace.Input.Trace(this, "HandleInput result: handled={0}", handled);
 
         if (handled)
         {
@@ -462,6 +470,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     private bool HandleEnter()
     {
+        TerminaTrace.Input.Debug(this, "HandleEnter: submitting text length={0}", _text.Length);
         // Emit to observable - ViewModel decides what to do (add to history, clear text, etc.)
         _submitted.OnNext(_text);
         return true;

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -5,6 +5,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
+using Termina.Diagnostics;
 using Termina.Hosting;
 using Termina.Input;
 using Termina.Layout;
@@ -198,9 +199,12 @@ public sealed class TerminaApplication
         ReactivePageRegistration registration,
         IReadOnlyDictionary<string, object>? parameters)
     {
+        TerminaTrace.Page.Info(this, "Navigating to: {0}", path);
+
         // Notify current page/ViewModel they're leaving
         if (_currentPage != null && _currentViewModel != null)
         {
+            TerminaTrace.Page.Debug(this, "Deactivating current page: {0}", _currentPage.GetType().Name);
             _currentPage.OnNavigatingFrom();
             _currentViewModel.OnDeactivating();
         }
@@ -209,6 +213,7 @@ public sealed class TerminaApplication
         if (_currentPath != null && _currentPath != path)
         {
             _history.Push((_currentPath, _currentParameters));
+            TerminaTrace.Page.Debug(this, "Pushed to history: {0}, depth={1}", _currentPath, _history.Count);
         }
 
         // Generate a cache key that includes parameters for PreserveState pages
@@ -218,6 +223,7 @@ public sealed class TerminaApplication
         if (registration.Behavior == NavigationBehavior.PreserveState &&
             _cachedPages.TryGetValue(cacheKey, out var cached))
         {
+            TerminaTrace.Page.Debug(this, "Using cached page: {0}", cacheKey);
             _currentPage = cached.Page;
             _currentViewModel = cached.ViewModel;
 
@@ -229,6 +235,7 @@ public sealed class TerminaApplication
         }
         else
         {
+            TerminaTrace.Page.Debug(this, "Creating new page, behavior={0}", registration.Behavior);
             _currentPage = registration.PageFactory();
             _currentViewModel = registration.ViewModelFactory();
 
@@ -249,6 +256,7 @@ public sealed class TerminaApplication
             if (registration.Behavior == NavigationBehavior.PreserveState)
             {
                 _cachedPages[cacheKey] = (_currentPage, _currentViewModel);
+                TerminaTrace.Page.Debug(this, "Cached page: {0}", cacheKey);
             }
         }
 
@@ -259,6 +267,7 @@ public sealed class TerminaApplication
         // Notify new page/ViewModel they're active
         _currentPage.OnNavigatedTo();
         _currentViewModel.OnActivated();
+        TerminaTrace.Page.Info(this, "Navigation complete: {0}, page={1}", path, _currentPage.GetType().Name);
     }
 
     /// <summary>
@@ -319,10 +328,13 @@ public sealed class TerminaApplication
     /// <param name="cancellationToken">Optional cancellation token.</param>
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
+        TerminaTrace.Page.Info(this, "RunAsync starting");
+
         if (_inputSources.Count == 0)
         {
             // Add default console input source if none configured
             _inputSources.Add(new ConsoleInputSource());
+            TerminaTrace.Input.Debug(this, "Added default ConsoleInputSource");
         }
 
         // Create linked token - cancelled by either external token OR Shutdown()
@@ -334,11 +346,14 @@ public sealed class TerminaApplication
             .Select(source => source.RunAsync(_eventChannel.Writer, linkedToken))
             .ToList();
 
+        TerminaTrace.Input.Debug(this, "Started {0} input source(s)", _inputSources.Count);
+
         try
         {
             // Enter alternate screen and hide cursor
             _terminal.EnterAlternateScreen();
             _terminal.SetCursorVisible(false);
+            TerminaTrace.Render.Debug(this, "Entered alternate screen, cursor hidden");
 
             // Initial render
             RenderCurrentPage();
@@ -393,22 +408,28 @@ public sealed class TerminaApplication
     /// </summary>
     private void ProcessEvent(object evt)
     {
+        TerminaTrace.Input.Trace(this, "ProcessEvent: {0}", evt.GetType().Name);
+
         // Handle system events
         switch (evt)
         {
             case ShutdownRequested:
+                TerminaTrace.Page.Info(this, "ShutdownRequested received");
                 Shutdown();
                 return;
 
             case NavigationRequested navReq:
+                TerminaTrace.Page.Debug(this, "NavigationRequested: {0}", navReq.PageKey);
                 NavigateTo(navReq.PageKey);
                 return;
 
             case NavigationBackRequested:
+                TerminaTrace.Page.Debug(this, "NavigationBackRequested, canGoBack={0}", CanGoBack);
                 GoBack();
                 return;
 
-            case ResizeEvent:
+            case ResizeEvent resize:
+                TerminaTrace.Render.Debug(this, "ResizeEvent: {0}x{1}", resize.Width, resize.Height);
                 // Force full refresh on resize since terminal dimensions changed
                 _diffingTerminal?.ForceFullRefresh();
                 return;
@@ -420,11 +441,16 @@ public sealed class TerminaApplication
             // For key presses, give focused components first chance to handle
             if (inputEvent is KeyPressed keyPressed)
             {
+                TerminaTrace.Input.Trace(this, "KeyPressed: key={0}, mods={1}", keyPressed.KeyInfo.Key, keyPressed.KeyInfo.Modifiers);
                 if (_focusManager.RouteInput(keyPressed.KeyInfo))
+                {
+                    TerminaTrace.Input.Trace(this, "Key consumed by focused component");
                     return; // Input was consumed by focused component
+                }
             }
 
             // If not consumed, route to ViewModel via observable
+            TerminaTrace.Input.Trace(this, "Routing input to ViewModel");
             _inputSubject.OnNext(inputEvent);
         }
     }


### PR DESCRIPTION
## Summary

Closes #72

Implements a lightweight, zero-cost-when-disabled tracing system for debugging Termina TUI applications.

### Key Features
- **Custom abstraction over M.E.Logging** - No direct dependency required
- **Deferred string formatting** - TraceEvent struct captures template + args, formats only when needed
- **Lock-free file output** - Uses Channel with single reader pattern to avoid blocking UI thread
- **Category-based filtering** - Focus, Layout, Input, Page, Reactive, Render, Platform
- **Level-based filtering** - Trace, Debug, Info, Warning, Error
- **MEL integration** - Optional `LoggerTraceListener` adapter
- **DI extension methods** - `AddTerminaFileTracing`, `AddTerminaLoggerTracing`

### Default Behavior

**Tracing is completely disabled by default.** When no listener is configured:
- All trace calls are no-ops (single inlined boolean check)
- No string formatting occurs
- No memory allocations occur
- No TraceEvent structs are created

### Enabling Tracing

```csharp
// 1. File tracing - lock-free channel design
services.AddTerminaFileTracing("termina-trace.log");

// 2. With category and level filtering
services.AddTerminaFileTracing(
    "termina-trace.log",
    TerminaTraceCategory.Focus | TerminaTraceCategory.Input,
    TerminaTraceLevel.Debug);

// 3. M.E.Logging integration
services.AddLogging(builder => builder.AddConsole())
        .AddTerminaLoggerTracing();

// 4. Stderr output (debugging without file I/O)
TerminaTrace.Configure(
    FileTraceListener.CreateStdErr(),
    TerminaTraceCategory.All,
    TerminaTraceLevel.Debug);
```

### Output Format

```
2024-01-15 10:30:45.123 [DEBUG] [Focus] FocusManager#12345678 - PushFocus: TextInputNode, stack depth=1
2024-01-15 10:30:45.125 [TRACE] [Input] TextInputNode#87654321 - HandleInput: key=A, char='A'
```

### Architecture Decisions (per user requirements)

- **TraceEvent struct** - Captures timestamp, level, category, source at creation; formats only when listener needs it
- **Lock-free FileTraceListener** - Unbounded channel with TryWrite (non-blocking), background task consumes
- **Zero allocation when disabled** - Template args stored in struct, string.Format only called when logging

### Components with Tracing

- `FocusManager` - Focus push/pop/route operations
- `TerminaApplication` - Input processing, navigation, lifecycle
- `TextInputNode` - Focus events, key handling

### Benchmark Results

Benchmarks confirm zero-cost-when-disabled design goal:

#### Disabled (No Listener) - Zero overhead
| Method | Mean | Allocated |
|--------|------|-----------|
| Disabled_NoArgs | ~1 ns | 0 B |
| Disabled_OneArg | ~1 ns | 0 B |
| Disabled_TwoArgs | ~1 ns | 0 B |
| Disabled_ThreeArgs | ~1 ns | 0 B |

#### Enabled with Null Listener (TraceEvent creation only)
| Method | Mean | Allocated |
|--------|------|-----------|
| NullListener_NoArgs | ~29 ns | 0 B |
| NullListener_OneArg | ~32 ns | 24 B |
| NullListener_TwoArgs | ~32 ns | 24 B |
| NullListener_ThreeArgs | ~37 ns | 48 B |

#### Enabled with Formatting (full cost)
| Method | Mean | Allocated |
|--------|------|-----------|
| Formatting_NoArgs | ~64 ns | 80 B |
| Formatting_OneArg | ~78 ns | 104 B |
| Formatting_TwoArgs | ~87 ns | 104 B |
| Formatting_ThreeArgs | ~110 ns | 128 B |

**Key takeaway**: When disabled, tracing has <1ns overhead and zero allocations - the check is a single inlined boolean test.

### Demo App Integration

The `Termina.Demo` app now includes file tracing:
- Logs go to `%TEMP%/termina-logs/trace-{timestamp}.log`
- Trace file path displayed in status bar
- README added with usage instructions for interactive and headless modes

```bash
# Interactive
dotnet run --project demos/Termina.Demo

# Headless/CI mode
dotnet run --project demos/Termina.Demo -- --test
```

### Documentation

Added comprehensive documentation at `docs/advanced/diagnostics.md` covering:
- Default behavior and enabling tracing
- Category and level filtering
- Output format
- Adding traces to custom code
- Custom listener implementation
- Performance characteristics
- Best practices

## Test plan

- [x] Build passes
- [x] All 635 tests pass
- [x] Benchmark project builds
- [x] Run benchmarks - verified zero allocations when disabled
- [x] Test file tracing with demo app
- [x] Documentation added
- [ ] Test MEL integration