### PR TITLE
Fix flaky spinner animation tests on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,49 @@ All layout nodes use fluent builder pattern with `With*` methods that return `th
 
 Use `SizeConstraint` (Fixed, Fill, Auto, Percent) for sizing rather than hardcoded values.
 
+## Testing Guidelines
+
+### Deterministic Observable Testing
+
+**Do NOT use `Thread.Sleep` to test time-based or event-driven behavior.** Instead, await the actual observable events using Rx operators.
+
+- Use `FirstAsync()` to await the first emission from an observable
+- Use `Timeout()` to prevent tests from hanging if events don't fire
+- Tests should observe **actual state changes**, not assume timing
+
+**Correct:**
+```csharp
+[Fact]
+public async Task AnimationChangesFrame()
+{
+    var spinner = new SpinnerSegment(SpinnerStyle.Line, intervalMs: 10);
+    var frame1 = spinner.GetCurrentSegment().Text;
+
+    // Wait for actual invalidation event
+    await spinner.Invalidated
+        .FirstAsync()
+        .Timeout(TimeSpan.FromSeconds(1));
+
+    var frame2 = spinner.GetCurrentSegment().Text;
+    Assert.NotEqual(frame1, frame2);
+}
+```
+
+**Incorrect:**
+```csharp
+[Fact]
+public void AnimationChangesFrame()
+{
+    var spinner = new SpinnerSegment(SpinnerStyle.Line, intervalMs: 10);
+    var frame1 = spinner.GetCurrentSegment().Text;
+
+    Thread.Sleep(50);  // NO - non-deterministic, flaky on Windows
+
+    var frame2 = spinner.GetCurrentSegment().Text;
+    Assert.NotEqual(frame1, frame2);
+}
+```
+
 ## Release Process
 
 ### Tag Naming Convention

--- a/tests/Termina.Tests/Layout/StreamingTextNodeTrackedSegmentTests.cs
+++ b/tests/Termina.Tests/Layout/StreamingTextNodeTrackedSegmentTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
+using System.Reactive.Linq;
 using Termina.Components.Streaming;
 using Termina.Layout;
 using Termina.Terminal;
@@ -185,15 +187,17 @@ public class StreamingTextNodeTrackedSegmentTests
     }
 
     [Fact]
-    public void SpinnerSegment_AnimationFramesChange()
+    public async Task SpinnerSegment_AnimationFramesChange()
     {
         var spinner = new SpinnerSegment(SpinnerStyle.Line, Color.Yellow, intervalMs: 10);
 
         // Get initial frame
         var frame1 = spinner.GetCurrentSegment().Text;
 
-        // Wait for animation to tick
-        Thread.Sleep(50);
+        // Wait for actual invalidation event instead of sleeping
+        await spinner.Invalidated
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(1));
 
         var frame2 = spinner.GetCurrentSegment().Text;
 
@@ -204,17 +208,16 @@ public class StreamingTextNodeTrackedSegmentTests
     }
 
     [Fact]
-    public void SpinnerSegment_InvalidatedEventFires()
+    public async Task SpinnerSegment_InvalidatedEventFires()
     {
         var spinner = new SpinnerSegment(SpinnerStyle.Dots, intervalMs: 10);
-        var eventFired = false;
 
-        spinner.Invalidated.Subscribe(_ => eventFired = true);
+        // Wait for actual invalidation event instead of sleeping
+        await spinner.Invalidated
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(1));
 
-        // Wait for at least one timer tick
-        Thread.Sleep(50);
-
-        Assert.True(eventFired);
+        // If we get here without timeout, the event fired
         spinner.Dispose();
     }
 
@@ -282,7 +285,7 @@ public class StreamingTextNodeTrackedSegmentTests
     }
 
     [Fact]
-    public void Replace_KeepTracked_SubscribesToNewAnimation()
+    public async Task Replace_KeepTracked_SubscribesToNewAnimation()
     {
         var node = StreamingTextNode.Create();
         var id = new SegmentId(1);
@@ -293,14 +296,12 @@ public class StreamingTextNodeTrackedSegmentTests
         var newSpinner = new SpinnerSegment(SpinnerStyle.Dots, intervalMs: 10);
         node.Replace(id, newSpinner, keepTracked: true);
 
-        var eventFired = false;
-        // Give animation time to invalidate
-        var subscription = node.ContentChanged.Subscribe(_ => eventFired = true);
+        // Wait for actual content change event instead of sleeping
+        await node.ContentChanged
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(1));
 
-        Thread.Sleep(50);
-
-        Assert.True(eventFired);
-        subscription.Dispose();
+        // If we get here without timeout, the event fired
         newSpinner.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- Replace `Thread.Sleep`-based timing assumptions with deterministic observable-based waits using `FirstAsync()` and `Timeout()`
- Fixes intermittent test failures on Windows CI where timer precision (~15.6ms) and thread scheduling differ from Linux (~1ms)
- Added testing guidelines to CLAUDE.md to prevent similar non-deterministic test patterns

Closes #75

## Test plan
- [x] All 635 tests pass locally
- [ ] CI passes on both Ubuntu and Windows runners