### PR TITLE
Add Diagnostics page to documentation sidebar navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
       '/advanced/': [
         { text: 'Advanced Topics', link: '/advanced/' },
         { text: 'Testing', link: '/advanced/testing' },
+        { text: 'Diagnostics', link: '/advanced/diagnostics' },
         { text: 'Custom Components', link: '/advanced/custom-components' },
         { text: 'AOT Compilation', link: '/advanced/aot' },
         { text: 'Akka.NET Integration', link: '/advanced/akka-integration' }


### PR DESCRIPTION
## Summary
- Add missing Diagnostics link to the Advanced section sidebar in VitePress config

The diagnostics.md page existed but was not linked from the sidebar navigation, making it only accessible via direct URL or the advanced index page.

## Test plan
- [ ] Verify diagnostics page appears in sidebar when visiting /termina/advanced/