### PR TITLE
Add rich content support and interactive decision points to SelectionListNode

### DIFF
--- a/demos/Termina.Demo.Streaming/Actors/LlmSimulatorActor.cs
+++ b/demos/Termina.Demo.Streaming/Actors/LlmSimulatorActor.cs
@@ -16,7 +16,7 @@ public static class LlmMessages
     /// Request to generate a response for a prompt.
     /// Returns an IAsyncEnumerable of StreamToken via a channel.
     /// </summary>
-    public record GenerateRequest(string Prompt);
+    public record GenerateRequest(string Prompt, string? DecisionContext = null);
 
     /// <summary>
     /// Response containing the async stream of tokens.
@@ -37,6 +37,16 @@ public static class LlmMessages
     /// A chunk of generated text.
     /// </summary>
     public record TextChunk(string Text) : StreamToken;
+
+    /// <summary>
+    /// A decision point where the user must choose from options.
+    /// </summary>
+    public record DecisionPointToken(string Question, IReadOnlyList<DecisionChoice> Choices) : StreamToken;
+
+    /// <summary>
+    /// A choice for a decision point with title and description.
+    /// </summary>
+    public record DecisionChoice(string Title, string Description, string Category);
 
     /// <summary>
     /// Signal that generation is complete.
@@ -106,6 +116,115 @@ public class LlmSimulatorActor : ReceiveActor
         "Optimizing response clarity..."
     ];
 
+    // Decision point scenarios with follow-up responses
+    private static readonly DecisionScenario[] DecisionScenarios =
+    [
+        new DecisionScenario(
+            IntroText: "I'd be happy to explain different approaches to building concurrent systems. " +
+                       "There are several paradigms to choose from, each with unique strengths.",
+            Question: "Which concurrency model would you like to explore?",
+            Choices:
+            [
+                new LlmMessages.DecisionChoice("Actor Model", "Message-passing between isolated actors", "Distributed"),
+                new LlmMessages.DecisionChoice("Task Parallel Library", "Task-based async/await patterns", "Threading"),
+                new LlmMessages.DecisionChoice("Reactive Extensions", "Observable streams and LINQ operators", "Reactive"),
+            ],
+            FollowUps: new Dictionary<string, string>
+            {
+                ["Actor Model"] = "The Actor Model is a powerful paradigm where computation is performed by " +
+                    "independent actors that communicate exclusively through messages. Each actor has its own " +
+                    "private state and processes messages sequentially, eliminating the need for locks.\n\n" +
+                    "Akka.NET implements this model beautifully, providing location transparency, supervision " +
+                    "hierarchies for fault tolerance, and clustering for distributed systems. Actors can " +
+                    "supervise child actors, automatically restarting them when failures occur.",
+                ["Task Parallel Library"] = "The Task Parallel Library (TPL) in .NET provides a robust foundation " +
+                    "for parallel and asynchronous programming. Tasks represent units of work that can run " +
+                    "concurrently, and async/await syntax makes asynchronous code read like synchronous code.\n\n" +
+                    "TPL includes powerful constructs like Parallel.ForEach, Task.WhenAll, and dataflow blocks " +
+                    "for building producer-consumer pipelines. It integrates seamlessly with the .NET runtime's " +
+                    "thread pool for efficient resource utilization.",
+                ["Reactive Extensions"] = "Reactive Extensions (Rx) treats events as streams of data that can be " +
+                    "queried using LINQ-style operators. This declarative approach makes complex event processing " +
+                    "surprisingly elegant and composable.\n\n" +
+                    "With operators like Throttle, Buffer, Merge, and CombineLatest, you can express sophisticated " +
+                    "event handling logic concisely. Rx is particularly powerful for UI programming, real-time " +
+                    "data processing, and handling multiple asynchronous data sources."
+            }),
+
+        new DecisionScenario(
+            IntroText: "Great question about software architecture! There are several popular patterns " +
+                       "for structuring applications, each suited to different scenarios.",
+            Question: "Which architectural pattern interests you most?",
+            Choices:
+            [
+                new LlmMessages.DecisionChoice("Microservices", "Independent deployable services", "Distributed"),
+                new LlmMessages.DecisionChoice("Clean Architecture", "Dependency inversion layers", "Monolithic"),
+                new LlmMessages.DecisionChoice("Event Sourcing", "Append-only event logs", "Data"),
+            ],
+            FollowUps: new Dictionary<string, string>
+            {
+                ["Microservices"] = "Microservices architecture decomposes applications into small, independent " +
+                    "services that communicate via APIs. Each service owns its data and can be deployed, " +
+                    "scaled, and updated independently.\n\n" +
+                    "This approach enables teams to work autonomously, choose appropriate technologies per " +
+                    "service, and scale specific components based on demand. However, it introduces complexity " +
+                    "in service discovery, distributed transactions, and observability.",
+                ["Clean Architecture"] = "Clean Architecture, popularized by Robert C. Martin, organizes code in " +
+                    "concentric layers with dependencies pointing inward. The core business logic remains " +
+                    "independent of frameworks, databases, and UI concerns.\n\n" +
+                    "This separation makes the codebase highly testable and adaptable to change. You can swap " +
+                    "out databases, web frameworks, or UI technologies without touching the business rules. " +
+                    "The trade-off is additional abstraction layers and boilerplate.",
+                ["Event Sourcing"] = "Event Sourcing stores the state of an application as a sequence of events " +
+                    "rather than current state snapshots. Every change is captured as an immutable event, " +
+                    "providing a complete audit trail and enabling temporal queries.\n\n" +
+                    "Combined with CQRS (Command Query Responsibility Segregation), event sourcing enables " +
+                    "powerful patterns like event replay, debugging production issues by replaying events, " +
+                    "and building multiple read models from the same event stream."
+            }),
+
+        new DecisionScenario(
+            IntroText: "Terminal UI development has seen a renaissance lately! There are several " +
+                       "approaches to building rich console applications.",
+            Question: "What aspect of TUI development would you like to learn about?",
+            Choices:
+            [
+                new LlmMessages.DecisionChoice("Layout Systems", "Constraint-based positioning", "Structure"),
+                new LlmMessages.DecisionChoice("Input Handling", "Keyboard and mouse events", "Interaction"),
+                new LlmMessages.DecisionChoice("Rendering Pipeline", "Efficient screen updates", "Performance"),
+            ],
+            FollowUps: new Dictionary<string, string>
+            {
+                ["Layout Systems"] = "Modern TUI frameworks use constraint-based layout systems similar to CSS " +
+                    "Flexbox or native mobile layouts. Elements specify size constraints (fixed, fill, auto, " +
+                    "percentage) and the layout engine calculates final positions.\n\n" +
+                    "This declarative approach handles terminal resizing gracefully and supports nested layouts " +
+                    "like vertical/horizontal stacks, grids, and overlapping layers for modals. The key is " +
+                    "separating layout logic from rendering for cleaner, more maintainable code.",
+                ["Input Handling"] = "Console input handling goes beyond simple ReadLine calls. Modern TUI apps " +
+                    "need to handle arrow keys, function keys, mouse events, and key combinations while " +
+                    "maintaining responsive UI updates.\n\n" +
+                    "Focus management determines which component receives input. A focus stack enables modal " +
+                    "dialogs to capture input temporarily, then restore focus when dismissed. Input routing " +
+                    "typically flows from focused component up through parent containers.",
+                ["Rendering Pipeline"] = "Efficient TUI rendering uses a diff-based approach similar to React's " +
+                    "virtual DOM. Instead of clearing and redrawing the entire screen, the renderer compares " +
+                    "the new frame against the previous one and only updates changed cells.\n\n" +
+                    "This minimizes flickering and terminal escape sequence overhead. Double-buffering with " +
+                    "a frame buffer allows compositing complex layouts before flushing to the terminal in a " +
+                    "single write operation."
+            })
+    ];
+
+    private record DecisionScenario(
+        string IntroText,
+        string Question,
+        LlmMessages.DecisionChoice[] Choices,
+        Dictionary<string, string> FollowUps);
+
+    // Track pending decision for follow-up responses
+    private DecisionScenario? _pendingDecision;
+
     public LlmSimulatorActor()
     {
         _materializer = Context.Materializer();
@@ -119,7 +238,7 @@ public class LlmSimulatorActor : ReceiveActor
         var channel = Channel.CreateUnbounded<LlmMessages.StreamToken>();
 
         // Create Akka Stream source that generates tokens
-        var source = CreateTokenSource(request.Prompt, cts.Token);
+        var source = CreateTokenSource(request.Prompt, request.DecisionContext, cts.Token);
 
         // Run the stream, writing to the channel
         source
@@ -134,19 +253,47 @@ public class LlmSimulatorActor : ReceiveActor
         Sender.Tell(new LlmMessages.GenerateResponse(asyncEnumerable, cts));
     }
 
-    private Source<LlmMessages.StreamToken, NotUsed> CreateTokenSource(string prompt, CancellationToken ct)
+    private Source<LlmMessages.StreamToken, NotUsed> CreateTokenSource(string prompt, string? decisionContext, CancellationToken ct)
     {
-        var thinkingCount = _random.Next(3, 8);
-        var response = SampleResponses[_random.Next(SampleResponses.Length)];
+        var thinkingCount = _random.Next(3, 6);
 
-        // Create thinking tokens with delays using Throttle instead of Delay
-        // Throttle ensures elements come out at a specific rate (1 token per 200ms for faster response feel)
+        // Create thinking tokens
         var thinkingSource = Source.From(Enumerable.Range(0, thinkingCount))
             .Select(_ => ThinkingPhrases[_random.Next(ThinkingPhrases.Length)])
             .Select(text => (LlmMessages.StreamToken)new LlmMessages.ThinkingToken(text))
-            .Throttle(1, TimeSpan.FromMilliseconds(200), 1, ThrottleMode.Shaping);
+            .Throttle(1, TimeSpan.FromMilliseconds(150), 1, ThrottleMode.Shaping);
 
-        // Create text chunks source (character by character with small chunks)
+        // If we have a decision context, use the follow-up response
+        if (decisionContext != null && _pendingDecision != null)
+        {
+            var followUp = _pendingDecision.FollowUps.GetValueOrDefault(decisionContext)
+                ?? $"You selected '{decisionContext}'. That's an interesting choice!";
+            _pendingDecision = null;
+            return CreateTextStreamSource(thinkingSource, followUp);
+        }
+
+        // Check for test trigger: "decision" prompt forces a decision point for headless testing
+        var useDecision = prompt.Equals("decision", StringComparison.OrdinalIgnoreCase)
+            || _random.Next(100) < 40;
+
+        if (useDecision)
+        {
+            _pendingDecision = DecisionScenarios[_random.Next(DecisionScenarios.Length)];
+            return CreateDecisionSource(thinkingSource, _pendingDecision);
+        }
+        else
+        {
+            var response = SampleResponses[_random.Next(SampleResponses.Length)];
+            _pendingDecision = null;
+            return CreateTextStreamSource(thinkingSource, response);
+        }
+    }
+
+    private Source<LlmMessages.StreamToken, NotUsed> CreateTextStreamSource(
+        Source<LlmMessages.StreamToken, NotUsed> thinkingSource,
+        string response)
+    {
+        // Create text chunks source
         var chunkSize = _random.Next(1, 4);
         var chunks = new List<string>();
         for (var i = 0; i < response.Length; i += chunkSize)
@@ -158,13 +305,37 @@ public class LlmSimulatorActor : ReceiveActor
             .Select(chunk => (LlmMessages.StreamToken)new LlmMessages.TextChunk(chunk))
             .Throttle(10, TimeSpan.FromMilliseconds(50), 10, ThrottleMode.Shaping);
 
-        // Completion signal
         var completionSource = Source.Single((LlmMessages.StreamToken)new LlmMessages.GenerationComplete());
 
-        // Combine: thinking -> text -> complete
         return thinkingSource
             .Concat(textSource)
             .Concat(completionSource);
+    }
+
+    private Source<LlmMessages.StreamToken, NotUsed> CreateDecisionSource(
+        Source<LlmMessages.StreamToken, NotUsed> thinkingSource,
+        DecisionScenario scenario)
+    {
+        // Stream the intro text first
+        var chunkSize = _random.Next(1, 4);
+        var chunks = new List<string>();
+        for (var i = 0; i < scenario.IntroText.Length; i += chunkSize)
+        {
+            chunks.Add(scenario.IntroText.Substring(i, Math.Min(chunkSize, scenario.IntroText.Length - i)));
+        }
+
+        var introSource = Source.From(chunks)
+            .Select(chunk => (LlmMessages.StreamToken)new LlmMessages.TextChunk(chunk))
+            .Throttle(10, TimeSpan.FromMilliseconds(50), 10, ThrottleMode.Shaping);
+
+        // Then emit the decision point
+        var decisionSource = Source.Single(
+            (LlmMessages.StreamToken)new LlmMessages.DecisionPointToken(scenario.Question, scenario.Choices));
+
+        // No completion - wait for user decision
+        return thinkingSource
+            .Concat(introSource)
+            .Concat(decisionSource);
     }
 
     private static async IAsyncEnumerable<LlmMessages.StreamToken> ReadFromChannelAsync(

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using Termina.Components.Streaming;
+using Termina.Demo.Streaming.Actors;
 using Termina.Extensions;
 using Termina.Input;
 using Termina.Layout;
@@ -21,6 +24,10 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
     // Layout nodes owned by the Page
     private StreamingTextNode _chatHistory = null!;
     private TextInputNode _promptInput = null!;
+
+    // Decision list for interactive choices
+    private SelectionListNode<LlmMessages.DecisionChoice>? _decisionList;
+    private readonly Subject<ILayoutNode?> _decisionListChanged = new();
 
     protected override void OnBound()
     {
@@ -55,6 +62,14 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
 
                     case ReplaceTrackedSegment replace:
                         _chatHistory.Replace(replace.Id, replace.NewSegment, replace.KeepTracked);
+                        break;
+
+                    case ShowDecisionPoint decision:
+                        ShowDecisionList(decision);
+                        break;
+
+                    case HideDecisionPoint:
+                        HideDecisionList();
                         break;
 
                     default:
@@ -93,6 +108,21 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
         if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
         {
             ViewModel.RequestShutdown();
+            return;
+        }
+
+        // When decision list is visible, route input to it
+        if (ViewModel.ShowDecisionList && _decisionList != null)
+        {
+            // Escape cancels the decision
+            if (keyInfo.Key == ConsoleKey.Escape)
+            {
+                ViewModel.HandleDecisionCancelled();
+                return;
+            }
+
+            // Let the selection list handle the input
+            _decisionList.HandleInput(keyInfo);
             return;
         }
 
@@ -135,6 +165,65 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
         }
     }
 
+    private void ShowDecisionList(ShowDecisionPoint decision)
+    {
+        // Dispose any existing decision list
+        _decisionList?.Dispose();
+
+        // Create rich content for each choice - inline style, no panel
+        _decisionList = new SelectionListNode<LlmMessages.DecisionChoice>(
+                decision.Choices,
+                choice => new SelectionItemContent()
+                    .AddLine(
+                        new StaticTextSegment(choice.Title, Color.White, decoration: TextDecoration.Bold),
+                        new StaticTextSegment(" ", Color.Default),
+                        new StaticTextSegment($"[{choice.Category}]", Color.BrightBlack))
+                    .AddLine(
+                        new StaticTextSegment("   " + choice.Description, Color.Gray)))
+            .WithHighlightColors(Color.Black, Color.Cyan)
+            .WithForeground(Color.White)
+            .WithVisibleRows(8)
+            .WithShowNumbers(true)
+            .WithOtherOption("Something else...");
+
+        // Subscribe to selection confirmation
+        _decisionList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    ViewModel.HandleDecisionSelection(selected[0].Title);
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        // Subscribe to "Something else..." custom input
+        _decisionList.OtherSelected
+            .Subscribe(customPrompt =>
+            {
+                ViewModel.HandleCustomPrompt(customPrompt);
+            })
+            .DisposeWith(Subscriptions);
+
+        // Subscribe to cancellation
+        _decisionList.Cancelled
+            .Subscribe(_ => ViewModel.HandleDecisionCancelled())
+            .DisposeWith(Subscriptions);
+
+        // Focus the decision list
+        _decisionList.OnFocused();
+
+        // Signal layout change - just the list node itself, no panel wrapper
+        _decisionListChanged.OnNext(_decisionList);
+    }
+
+    private void HideDecisionList()
+    {
+        _decisionList?.Dispose();
+        _decisionList = null;
+        _decisionListChanged.OnNext(null);
+    }
+
     public override ILayoutNode BuildLayout()
     {
         return Layouts.Vertical()
@@ -145,7 +234,7 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                     .Bold()
                     .Height(1))
             .WithChild(new EmptyNode().Height(1))
-            // Chat history panel
+            // Chat history panel - fills available space
             .WithChild(
                 new PanelNode()
                     .WithTitle("Chat History")
@@ -155,7 +244,18 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                     .WithContent(_chatHistory.Fill())
                     .Fill())
             .WithChild(new EmptyNode().Height(1))
-            // Input panel
+            // Decision list - appears between chat history and input when active
+            .WithChild(
+                _decisionListChanged
+                    .StartWith((ILayoutNode?)null)
+                    .Select(decisionList => decisionList == null
+                        ? (ILayoutNode)new EmptyNode().Height(0)
+                        : Layouts.Vertical()
+                            .WithChild(new TextNode("  Choose an option:").WithForeground(Color.Yellow).Height(1))
+                            .WithChild(decisionList)
+                            .HeightAuto()) // Auto-size to content, don't compete with Fill() elements
+                    .AsLayout())
+            // Input panel - always visible
             .WithChild(
                 new PanelNode()
                     .WithTitle("Your Prompt")
@@ -166,13 +266,15 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                     .Height(3))
             // Status bar
             .WithChild(
-                ViewModel.IsGeneratingChanged
-                    .Select(isGenerating => new TextNode(
-                        isGenerating
+                Observable.CombineLatest(
+                    ViewModel.IsGeneratingChanged,
+                    ViewModel.ShowDecisionListChanged.StartWith(false),
+                    (isGenerating, showDecision) => showDecision
+                        ? "[↑/↓] Navigate [Enter] Select [1-4] Quick Select [Esc] Skip"
+                        : isGenerating
                             ? "[Esc] Cancel [PgUp/PgDn] Scroll [Ctrl+Q] Quit"
                             : "[Enter] Send [↑/↓] History [PgUp/PgDn] Scroll [Esc] Clear/Quit [Ctrl+Q] Quit")
-                        .WithForeground(Color.BrightBlack)
-                        .NoWrap())
+                    .Select(text => new TextNode(text).WithForeground(Color.BrightBlack).NoWrap())
                     .AsLayout()
                     .Height(1))
             .WithChild(

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
@@ -44,6 +44,16 @@ public sealed record RemoveTrackedSegment(SegmentId Id) : IChatMessage;
 public sealed record ReplaceTrackedSegment(SegmentId Id, ITextSegment NewSegment, bool KeepTracked = false) : IChatMessage;
 
 /// <summary>
+/// Show a decision point with choices for the user.
+/// </summary>
+public sealed record ShowDecisionPoint(string Question, IReadOnlyList<LlmMessages.DecisionChoice> Choices) : IChatMessage;
+
+/// <summary>
+/// Hide the decision list (after selection or cancellation).
+/// </summary>
+public sealed record HideDecisionPoint : IChatMessage;
+
+/// <summary>
 /// ViewModel for the streaming chat demo.
 /// Contains only state and business logic - no UI concerns.
 /// Exposes observables for chat content that the Page subscribes to.
@@ -79,6 +89,10 @@ public partial class StreamingChatViewModel : ReactiveViewModel
     [Reactive] private bool _isGenerating = false;
     [Reactive] private bool _hasReceivedText = false; // Tracks if any text has arrived yet
     [Reactive] private string _statusMessage = "Ready. Enter a question to begin.";
+    [Reactive] private bool _showDecisionList = false; // Whether to show the decision list
+
+    // Track current decision context for follow-up
+    private string? _pendingDecisionContext;
 
     public StreamingChatViewModel(IRequiredActor<LlmSimulatorActor> llmActorProvider)
     {
@@ -177,6 +191,73 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         _chatOutput.OnNext(new AppendText(prompt, Color.White, IsNewLine: true));
         _chatOutput.OnNext(new AppendText("", IsNewLine: true));
 
+        StartGeneration(prompt, decisionContext: null);
+    }
+
+    /// <summary>
+    /// Handle decision selection from the SelectionListNode.
+    /// </summary>
+    public void HandleDecisionSelection(string choiceTitle)
+    {
+        // Hide the decision list
+        ShowDecisionList = false;
+        _chatOutput.OnNext(new HideDecisionPoint());
+
+        // Show the user's choice in the chat
+        _chatOutput.OnNext(new AppendText("", IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("   → ", Color.BrightBlack));
+        _chatOutput.OnNext(new AppendText(choiceTitle, Color.Cyan, TextDecoration.Bold, IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("", IsNewLine: true));
+
+        // Start follow-up generation with the decision context
+        StartGeneration("continue", decisionContext: choiceTitle);
+    }
+
+    /// <summary>
+    /// Handle decision cancellation.
+    /// </summary>
+    public void HandleDecisionCancelled()
+    {
+        ShowDecisionList = false;
+        _chatOutput.OnNext(new HideDecisionPoint());
+        _chatOutput.OnNext(new AppendText(" [decision skipped]", Color.Yellow, TextDecoration.Italic, IsNewLine: true));
+        CleanupGeneration();
+        StatusMessage = "Ready. Enter another question.";
+    }
+
+    /// <summary>
+    /// Handle custom prompt from "Something else..." option.
+    /// </summary>
+    public void HandleCustomPrompt(string customPrompt)
+    {
+        customPrompt = customPrompt.Trim();
+        if (string.IsNullOrEmpty(customPrompt))
+        {
+            HandleDecisionCancelled();
+            return;
+        }
+
+        // Hide the decision list
+        ShowDecisionList = false;
+        _chatOutput.OnNext(new HideDecisionPoint());
+
+        // Show the custom prompt as user input
+        _chatOutput.OnNext(new AppendText("", IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("👤 ", Color.Cyan));
+        _chatOutput.OnNext(new AppendText("You: ", Color.Cyan, TextDecoration.Bold));
+        _chatOutput.OnNext(new AppendText(customPrompt, Color.White, IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("", IsNewLine: true));
+
+        // Add to history
+        _promptHistory.Add(customPrompt);
+        _historyIndex = -1;
+
+        // Start generation with the custom prompt (not as decision context)
+        StartGeneration(customPrompt, decisionContext: null);
+    }
+
+    private void StartGeneration(string prompt, string? decisionContext)
+    {
         // Add Assistant prefix and append animated spinner
         _chatOutput.OnNext(new AppendText("🤖 ", Color.Yellow));
         _chatOutput.OnNext(new AppendText("Assistant: ", Color.Green, TextDecoration.Bold));
@@ -190,10 +271,10 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         HasReceivedText = false;
         StatusMessage = "Generating response...";
 
-        _ = ConsumeResponseStreamAsync(prompt);
+        _ = ConsumeResponseStreamAsync(prompt, decisionContext);
     }
 
-    private async Task ConsumeResponseStreamAsync(string prompt)
+    private async Task ConsumeResponseStreamAsync(string prompt, string? decisionContext = null)
     {
         if (_llmActor is null)
         {
@@ -206,7 +287,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         try
         {
             var response = await _llmActor.Ask<LlmMessages.GenerateResponse>(
-                new LlmMessages.GenerateRequest(prompt),
+                new LlmMessages.GenerateRequest(prompt, decisionContext),
                 TimeSpan.FromSeconds(30));
 
             _generationCts = response.Cancellation;
@@ -240,6 +321,27 @@ public partial class StreamingChatViewModel : ReactiveViewModel
                         StatusMessage = "Ready. Enter another question.";
                         completedNormally = true;
                         break;
+
+                    case LlmMessages.DecisionPointToken decision:
+                        // On first content (decision point), replace spinner
+                        if (!HasReceivedText)
+                        {
+                            _chatOutput.OnNext(new ReplaceTrackedSegment(
+                                ThinkingSpinnerId,
+                                new StaticTextSegment("", TextStyle.Default),
+                                KeepTracked: false));
+                            _currentSpinner?.Dispose();
+                            _currentSpinner = null;
+                            HasReceivedText = true;
+                        }
+
+                        // Show the decision list
+                        _chatOutput.OnNext(new ShowDecisionPoint(decision.Question, decision.Choices));
+                        ShowDecisionList = true;
+                        StatusMessage = "Make a selection below...";
+
+                        // We don't mark this as complete - we wait for user to make a decision
+                        return;
                 }
             }
         }

--- a/demos/Termina.Demo.Streaming/Program.cs
+++ b/demos/Termina.Demo.Streaming/Program.cs
@@ -56,16 +56,36 @@ if (testMode && scriptedInput != null)
         // Wait for streaming to complete (actor produces tokens over ~3-5 seconds)
         await Task.Delay(6000);
 
-        // Type another prompt to test second interaction
-        scriptedInput.EnqueueString("Test");
-
-        // Submit
+        // Test decision point: "decision" prompt forces a decision list to appear
+        scriptedInput.EnqueueString("decision");
         scriptedInput.EnqueueKey(ConsoleKey.Enter);
 
-        // Wait a bit then cancel mid-stream
-        await Task.Delay(1500);
-        scriptedInput.EnqueueKey(ConsoleKey.Escape);
-        await Task.Delay(500);
+        // Wait for intro text streaming and decision list to appear
+        await Task.Delay(4000);
+
+        // Navigate down in the selection list
+        scriptedInput.EnqueueKey(ConsoleKey.DownArrow);
+        await Task.Delay(200);
+
+        // Select the second option (Enter confirms)
+        scriptedInput.EnqueueKey(ConsoleKey.Enter);
+
+        // Wait for follow-up response to stream
+        await Task.Delay(5000);
+
+        // Test "Something else..." option - trigger another decision
+        scriptedInput.EnqueueString("decision");
+        scriptedInput.EnqueueKey(ConsoleKey.Enter);
+        await Task.Delay(4000);
+
+        // Navigate to "Something else..." (4th option)
+        scriptedInput.EnqueueKey(ConsoleKey.D4); // Quick select option 4
+        await Task.Delay(200);
+
+        // Type custom prompt and submit
+        scriptedInput.EnqueueString("custom question");
+        scriptedInput.EnqueueKey(ConsoleKey.Enter);
+        await Task.Delay(5000);
 
         // Quit with Ctrl+Q
         scriptedInput.EnqueueKey(ConsoleKey.Q, control: true);

--- a/docs/components/selection-list-node.md
+++ b/docs/components/selection-list-node.md
@@ -1,6 +1,6 @@
 # SelectionListNode
 
-An interactive list selection component with keyboard navigation, supporting single and multi-select modes.
+An interactive list selection component with keyboard navigation, supporting single and multi-select modes. Supports both simple text items and rich content with multiple lines and styled/animated segments.
 
 ## Basic Usage
 
@@ -13,6 +13,84 @@ var list = Layouts.SelectionList(options);
 
 // Typed list with custom display
 var list = Layouts.SelectionList(items, item => item.Name);
+```
+
+## Rich Content
+
+For items that need multiple lines, styled text, or animated elements (like spinners), use the constructor that accepts a `Func<T, SelectionItemContent>`:
+
+```csharp
+var list = new SelectionListNode<ServerInfo>(servers, server =>
+    new SelectionItemContent()
+        .AddLine(server.Name, Color.White, decoration: TextDecoration.Bold)
+        .AddLine($"   {server.Address}:{server.Port}", Color.BrightBlack)
+);
+```
+
+### Multi-line Items with Animations
+
+Rich content items can include animated segments like spinners:
+
+```csharp
+var list = new SelectionListNode<ConnectionState>(connections, conn =>
+{
+    var content = new SelectionItemContent()
+        .AddLine(conn.ServerName, Color.Cyan, decoration: TextDecoration.Bold);
+
+    if (conn.IsConnecting)
+    {
+        content.AddLine(
+            new StaticTextSegment("   "),
+            new SpinnerSegment(SpinnerStyle.Dots, Color.Yellow),
+            new StaticTextSegment(" Connecting...", Color.Yellow)
+        );
+    }
+    else
+    {
+        content.AddLine($"   Status: {conn.Status}", Color.Green);
+    }
+
+    return content;
+});
+```
+
+### SelectionItemContent API
+
+`SelectionItemContent` provides a fluent API for building multi-line, styled content:
+
+```csharp
+var content = new SelectionItemContent()
+    // Add a simple text line
+    .AddLine("First line")
+
+    // Add a styled text line
+    .AddLine("Bold and Blue", Color.Blue, decoration: TextDecoration.Bold)
+
+    // Add a line with multiple segments
+    .AddLine(
+        new StaticTextSegment("Status: ", Color.White),
+        new StaticTextSegment("Active", Color.Green, decoration: TextDecoration.Bold)
+    )
+
+    // Add a line with an animated spinner
+    .AddLine(
+        new SpinnerSegment(SpinnerStyle.Line, Color.Cyan),
+        new StaticTextSegment(" Loading...")
+    );
+```
+
+### CompositeTextSegment
+
+Use `CompositeTextSegment` to combine multiple segments into a single unit:
+
+```csharp
+var composite = new CompositeTextSegment(
+    new StaticTextSegment("["),
+    new SpinnerSegment(SpinnerStyle.Dots, Color.Blue),
+    new StaticTextSegment("] Processing...")
+);
+
+content.AddLine(composite);
 ```
 
 ## Features
@@ -284,6 +362,13 @@ public class SettingsPage : ReactivePage<SettingsViewModel>
 
 ## API Reference
 
+### Constructors
+
+| Constructor | Description |
+|-------------|-------------|
+| `SelectionListNode(IEnumerable<T>, Func<T, string>)` | Create with plain text display |
+| `SelectionListNode(IEnumerable<T>, Func<T, SelectionItemContent>)` | Create with rich content display |
+
 ### Properties
 
 | Property | Type | Description |
@@ -312,9 +397,30 @@ public class SettingsPage : ReactivePage<SettingsViewModel>
 | Property | Type | Description |
 |----------|------|-------------|
 | `Value` | `T` | The item value |
-| `DisplayText` | `string` | Text shown in the list |
+| `DisplayText` | `string` | First line text (plain text) |
+| `Content` | `SelectionItemContent` | Full rich content with all lines and styling |
+| `LineCount` | `int` | Number of lines this item occupies |
 | `IsSelected` | `bool` | Whether item is selected |
 | `IsOther` | `bool` | Whether this is the "Other" option |
+
+### SelectionItemContent Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Lines` | `IReadOnlyList<IReadOnlyList<ITextSegment>>` | All lines of content |
+| `LineCount` | `int` | Number of lines |
+| `HasAnimations` | `bool` | Whether content has animated segments |
+| `Invalidated` | `IObservable<Unit>` | Fires when animated content changes |
+
+### SelectionItemContent Methods
+
+| Method | Description |
+|--------|-------------|
+| `.AddLine(params ITextSegment[])` | Add a line with multiple segments |
+| `.AddLine(string, Color?, Color?, TextDecoration)` | Add a simple styled text line |
+| `.ToPlainText()` | Get all lines as plain text |
+| `.GetFirstLineText()` | Get first line as plain text |
+| `FromString(string)` | Static factory for single-line content |
 
 ### Enums
 
@@ -328,4 +434,16 @@ public class SettingsPage : ReactivePage<SettingsViewModel>
 
 ::: details View SelectionListNode implementation
 <<< @/../src/Termina/Layout/SelectionListNode.cs{csharp}
+:::
+
+::: details View SelectionItemContent implementation
+<<< @/../src/Termina/Layout/SelectionItemContent.cs{csharp}
+:::
+
+::: details View SelectionItem implementation
+<<< @/../src/Termina/Layout/SelectionItem.cs{csharp}
+:::
+
+::: details View CompositeTextSegment implementation
+<<< @/../src/Termina/Components/Streaming/CompositeTextSegment.cs{csharp}
 :::

--- a/src/Termina/Components/Streaming/CompositeTextSegment.cs
+++ b/src/Termina/Components/Streaming/CompositeTextSegment.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using Termina.Terminal;
+
+namespace Termina.Components.Streaming;
+
+/// <summary>
+/// A composite text segment that groups multiple child segments together.
+/// Useful for combining static and animated segments into a single trackable unit.
+/// </summary>
+/// <remarks>
+/// Example usage:
+/// <code>
+/// var composite = new CompositeTextSegment(
+///     new StaticTextSegment("["),
+///     new SpinnerSegment(SpinnerStyle.Dots, Color.Blue),
+///     new StaticTextSegment(" Processing...]")
+/// );
+/// </code>
+/// </remarks>
+public sealed class CompositeTextSegment : ICompositeTextSegment, IAnimatedTextSegment
+{
+    private readonly List<ITextSegment> _children;
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly CompositeDisposable _subscriptions = new();
+    private bool _disposed;
+    private bool _isAnimating;
+
+    /// <summary>
+    /// Creates a composite segment from the provided children.
+    /// </summary>
+    /// <param name="children">The child segments to compose together.</param>
+    public CompositeTextSegment(params ITextSegment[] children) : this((IEnumerable<ITextSegment>)children)
+    {
+    }
+
+    /// <summary>
+    /// Creates a composite segment from the provided children.
+    /// </summary>
+    /// <param name="children">The child segments to compose together.</param>
+    public CompositeTextSegment(IEnumerable<ITextSegment> children)
+    {
+        _children = children.ToList();
+
+        // Subscribe to any animated children's invalidation events
+        foreach (var child in _children)
+        {
+            if (child is IAnimatedTextSegment animated)
+            {
+                var subscription = animated.Invalidated.Subscribe(_ =>
+                {
+                    if (!_disposed)
+                    {
+                        _invalidated.OnNext(Unit.Default);
+                    }
+                });
+                _subscriptions.Add(subscription);
+                _isAnimating = _isAnimating || animated.IsAnimating;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<ITextSegment> Children => _children.AsReadOnly();
+
+    /// <inheritdoc />
+    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+
+    /// <inheritdoc />
+    public bool IsAnimating => _isAnimating && _children.OfType<IAnimatedTextSegment>().Any(a => a.IsAnimating);
+
+    /// <summary>
+    /// Gets the combined text of all children as a single segment.
+    /// Note: Individual child styles are not preserved in this representation.
+    /// To render with proper styles, iterate <see cref="Children"/> and call GetCurrentSegment on each.
+    /// </summary>
+    public StyledSegment GetCurrentSegment()
+    {
+        var sb = new StringBuilder();
+        foreach (var child in _children)
+        {
+            sb.Append(child.GetCurrentSegment().Text);
+        }
+        return new StyledSegment(sb.ToString());
+    }
+
+    /// <inheritdoc />
+    public void Start()
+    {
+        foreach (var child in _children.OfType<IAnimatedTextSegment>())
+        {
+            child.Start();
+        }
+        _isAnimating = true;
+    }
+
+    /// <inheritdoc />
+    public void Stop()
+    {
+        foreach (var child in _children.OfType<IAnimatedTextSegment>())
+        {
+            child.Stop();
+        }
+        _isAnimating = false;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        Stop();
+        _subscriptions.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+
+        foreach (var child in _children)
+        {
+            child.Dispose();
+        }
+    }
+}

--- a/src/Termina/Layout/SelectionItem.cs
+++ b/src/Termina/Layout/SelectionItem.cs
@@ -1,16 +1,23 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
+using Termina.Components.Streaming;
+
 namespace Termina.Layout;
 
 /// <summary>
 /// Represents an item in a SelectionListNode.
 /// </summary>
 /// <typeparam name="T">The type of the underlying value.</typeparam>
-public sealed class SelectionItem<T>
+public sealed class SelectionItem<T> : IDisposable
 {
+    private readonly SelectionItemContent _content;
+    private IDisposable? _animationSubscription;
+    private bool _disposed;
+
     /// <summary>
-    /// Creates a new selection item.
+    /// Creates a new selection item with plain text display.
     /// </summary>
     /// <param name="value">The underlying value.</param>
     /// <param name="displayText">The text to display for this item.</param>
@@ -18,8 +25,21 @@ public sealed class SelectionItem<T>
     public SelectionItem(T value, string displayText, bool isOther = false)
     {
         Value = value;
-        DisplayText = displayText;
         IsOther = isOther;
+        _content = SelectionItemContent.FromString(displayText);
+    }
+
+    /// <summary>
+    /// Creates a new selection item with rich content display.
+    /// </summary>
+    /// <param name="value">The underlying value.</param>
+    /// <param name="content">The rich content to display for this item.</param>
+    /// <param name="isOther">Whether this is the "Other..." option.</param>
+    public SelectionItem(T value, SelectionItemContent content, bool isOther = false)
+    {
+        Value = value;
+        IsOther = isOther;
+        _content = content ?? throw new ArgumentNullException(nameof(content));
     }
 
     /// <summary>
@@ -28,9 +48,20 @@ public sealed class SelectionItem<T>
     public T Value { get; }
 
     /// <summary>
-    /// The text displayed for this item.
+    /// The text displayed for this item (first line, plain text).
+    /// For full content with multiple lines and styling, use <see cref="Content"/>.
     /// </summary>
-    public string DisplayText { get; }
+    public string DisplayText => _content.GetFirstLineText();
+
+    /// <summary>
+    /// The rich content for this item, supporting multiple lines and styled segments.
+    /// </summary>
+    public SelectionItemContent Content => _content;
+
+    /// <summary>
+    /// Gets the number of lines this item occupies.
+    /// </summary>
+    public int LineCount => _content.LineCount;
 
     /// <summary>
     /// Whether this item is selected.
@@ -41,4 +72,26 @@ public sealed class SelectionItem<T>
     /// Whether this item represents the "Other..." option for custom input.
     /// </summary>
     public bool IsOther { get; }
+
+    /// <summary>
+    /// Subscribes to animation invalidation events from this item's content.
+    /// </summary>
+    /// <param name="onInvalidated">The action to invoke when content changes.</param>
+    internal void SubscribeToAnimations(Action<Unit> onInvalidated)
+    {
+        if (_content.HasAnimations && _animationSubscription == null)
+        {
+            _animationSubscription = _content.Invalidated.Subscribe(onInvalidated);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _animationSubscription?.Dispose();
+        _content.Dispose();
+    }
 }

--- a/src/Termina/Layout/SelectionItemContent.cs
+++ b/src/Termina/Layout/SelectionItemContent.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Termina.Components.Streaming;
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Represents the display content for a selection list item, supporting multiple lines
+/// and multiple styled/animated segments per line.
+/// </summary>
+/// <remarks>
+/// Example usage:
+/// <code>
+/// var content = new SelectionItemContent()
+///     .AddLine(new StaticTextSegment("Server Name", Color.White, decoration: TextDecoration.Bold))
+///     .AddLine(
+///         new StaticTextSegment("   "),
+///         new SpinnerSegment(SpinnerStyle.Dots, Color.Blue),
+///         new StaticTextSegment(" Connecting...")
+///     );
+/// </code>
+/// </remarks>
+public sealed class SelectionItemContent : IDisposable
+{
+    private readonly List<IReadOnlyList<ITextSegment>> _lines = new();
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly CompositeDisposable _subscriptions = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets all lines of content. Each line is a list of segments.
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<ITextSegment>> Lines => _lines.AsReadOnly();
+
+    /// <summary>
+    /// Gets the number of lines in this content.
+    /// </summary>
+    public int LineCount => _lines.Count;
+
+    /// <summary>
+    /// Observable that fires when any animated segment in this content changes.
+    /// </summary>
+    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+
+    /// <summary>
+    /// Gets whether this content contains any animated segments.
+    /// </summary>
+    public bool HasAnimations => _subscriptions.Count > 0;
+
+    /// <summary>
+    /// Adds a line with the specified segments.
+    /// </summary>
+    /// <param name="segments">The segments that make up this line.</param>
+    /// <returns>This instance for fluent chaining.</returns>
+    public SelectionItemContent AddLine(params ITextSegment[] segments)
+    {
+        return AddLine((IEnumerable<ITextSegment>)segments);
+    }
+
+    /// <summary>
+    /// Adds a line with the specified segments.
+    /// </summary>
+    /// <param name="segments">The segments that make up this line.</param>
+    /// <returns>This instance for fluent chaining.</returns>
+    public SelectionItemContent AddLine(IEnumerable<ITextSegment> segments)
+    {
+        var lineSegments = segments.ToList();
+        _lines.Add(lineSegments.AsReadOnly());
+
+        // Subscribe to any animated segments
+        foreach (var segment in lineSegments)
+        {
+            SubscribeToAnimations(segment);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a simple text line with optional styling.
+    /// </summary>
+    /// <param name="text">The text for this line.</param>
+    /// <param name="foreground">Optional foreground color.</param>
+    /// <param name="background">Optional background color.</param>
+    /// <param name="decoration">Optional text decoration.</param>
+    /// <returns>This instance for fluent chaining.</returns>
+    public SelectionItemContent AddLine(string text, Color? foreground = null, Color? background = null,
+        TextDecoration decoration = TextDecoration.None)
+    {
+        return AddLine(new StaticTextSegment(text, foreground, background, decoration));
+    }
+
+    /// <summary>
+    /// Gets the plain text representation of this content (all lines joined with newlines).
+    /// </summary>
+    public string ToPlainText()
+    {
+        return string.Join("\n", _lines.Select(line =>
+            string.Concat(line.Select(s => s.GetCurrentSegment().Text))));
+    }
+
+    /// <summary>
+    /// Gets the plain text of the first line (for display in single-line contexts).
+    /// </summary>
+    public string GetFirstLineText()
+    {
+        if (_lines.Count == 0) return string.Empty;
+        return string.Concat(_lines[0].Select(s => s.GetCurrentSegment().Text));
+    }
+
+    private void SubscribeToAnimations(ITextSegment segment)
+    {
+        if (segment is IAnimatedTextSegment animated)
+        {
+            var subscription = animated.Invalidated.Subscribe(_ =>
+            {
+                if (!_disposed)
+                {
+                    _invalidated.OnNext(Unit.Default);
+                }
+            });
+            _subscriptions.Add(subscription);
+        }
+
+        // Also check composite segments for nested animations
+        if (segment is ICompositeTextSegment composite)
+        {
+            foreach (var child in composite.Children)
+            {
+                SubscribeToAnimations(child);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a simple single-line content from a plain string.
+    /// </summary>
+    /// <param name="text">The text to display.</param>
+    /// <returns>A new SelectionItemContent with one line.</returns>
+    public static SelectionItemContent FromString(string text)
+    {
+        return new SelectionItemContent().AddLine(text);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _subscriptions.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+
+        // Dispose all segments
+        foreach (var line in _lines)
+        {
+            foreach (var segment in line)
+            {
+                segment.Dispose();
+            }
+        }
+    }
+}

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -4,6 +4,7 @@
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Termina.Components.Streaming;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -24,6 +25,10 @@ namespace Termina.Layout;
 /// - Escape to cancel
 /// </para>
 /// <para>
+/// Supports both simple string display and rich content with multiple lines
+/// and styled/animated segments.
+/// </para>
+/// <para>
 /// Optionally supports an "Other" option for custom text input.
 /// </para>
 /// </remarks>
@@ -34,10 +39,9 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     private readonly Subject<string> _otherSelected = new();
     private readonly Subject<Unit> _cancelled = new();
     private readonly List<SelectionItem<T>> _items = new();
-    private readonly Func<T, string> _displaySelector;
 
     private int _highlightedIndex;
-    private int _scrollOffset;
+    private int _scrollOffset; // Now in lines, not items
     private int _visibleRows = 10;
     private bool _isEditingOther;
     private TextInputNode? _otherInput;
@@ -54,21 +58,49 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     private bool _showNumbers = true;
 
     /// <summary>
-    /// Creates a new SelectionListNode with the specified items.
+    /// Creates a new SelectionListNode with the specified items and plain text display.
     /// </summary>
     /// <param name="items">The items to display.</param>
     /// <param name="displaySelector">A function to convert items to display text.</param>
     public SelectionListNode(IEnumerable<T> items, Func<T, string> displaySelector)
     {
-        _displaySelector = displaySelector ?? throw new ArgumentNullException(nameof(displaySelector));
+        ArgumentNullException.ThrowIfNull(displaySelector);
 
         foreach (var item in items)
         {
-            _items.Add(new SelectionItem<T>(item, displaySelector(item)));
+            var selectionItem = new SelectionItem<T>(item, displaySelector(item));
+            _items.Add(selectionItem);
+            SubscribeToItemAnimations(selectionItem);
         }
 
         if (_items.Count > 0)
             _highlightedIndex = 0;
+    }
+
+    /// <summary>
+    /// Creates a new SelectionListNode with rich content display supporting multiple lines
+    /// and styled/animated segments.
+    /// </summary>
+    /// <param name="items">The items to display.</param>
+    /// <param name="contentSelector">A function to convert items to rich content.</param>
+    public SelectionListNode(IEnumerable<T> items, Func<T, SelectionItemContent> contentSelector)
+    {
+        ArgumentNullException.ThrowIfNull(contentSelector);
+
+        foreach (var item in items)
+        {
+            var selectionItem = new SelectionItem<T>(item, contentSelector(item));
+            _items.Add(selectionItem);
+            SubscribeToItemAnimations(selectionItem);
+        }
+
+        if (_items.Count > 0)
+            _highlightedIndex = 0;
+    }
+
+    private void SubscribeToItemAnimations(SelectionItem<T> item)
+    {
+        item.SubscribeToAnimations(_ => Invalidate());
     }
 
     /// <inheritdoc />
@@ -122,6 +154,11 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     /// Gets the items in the list.
     /// </summary>
     public IReadOnlyList<SelectionItem<T>> Items => _items;
+
+    /// <summary>
+    /// Gets the total number of lines across all items.
+    /// </summary>
+    private int TotalLineCount => _items.Sum(i => i.LineCount);
 
     /// <summary>
     /// Sets the selection mode (Single or Multi).
@@ -190,7 +227,8 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
 
         // Add Other as a special item at the end
         // We use default(T)! as the value since it won't be used
-        _items.Add(new SelectionItem<T>(default!, label, isOther: true));
+        var otherItem = new SelectionItem<T>(default!, label, isOther: true);
+        _items.Add(otherItem);
 
         return this;
     }
@@ -323,15 +361,31 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
         }
     }
 
+    /// <summary>
+    /// Gets the starting line offset for a given item index.
+    /// </summary>
+    private int GetItemLineOffset(int itemIndex)
+    {
+        var offset = 0;
+        for (var i = 0; i < itemIndex && i < _items.Count; i++)
+        {
+            offset += _items[i].LineCount;
+        }
+        return offset;
+    }
+
     private void EnsureVisible()
     {
-        if (_highlightedIndex < _scrollOffset)
+        var itemLineStart = GetItemLineOffset(_highlightedIndex);
+        var itemLineEnd = itemLineStart + (_highlightedIndex < _items.Count ? _items[_highlightedIndex].LineCount : 1);
+
+        if (itemLineStart < _scrollOffset)
         {
-            _scrollOffset = _highlightedIndex;
+            _scrollOffset = itemLineStart;
         }
-        else if (_highlightedIndex >= _scrollOffset + _visibleRows)
+        else if (itemLineEnd > _scrollOffset + _visibleRows)
         {
-            _scrollOffset = _highlightedIndex - _visibleRows + 1;
+            _scrollOffset = itemLineEnd - _visibleRows;
         }
     }
 
@@ -418,11 +472,12 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     /// <inheritdoc />
     public Size Measure(Size available)
     {
-        var height = Math.Min(_items.Count, _visibleRows);
+        var totalLines = TotalLineCount;
+        var height = Math.Min(totalLines, _visibleRows);
 
         // Calculate width based on content
         var maxItemWidth = _items.Count > 0
-            ? _items.Max(i => GetItemDisplayLength(i, _items.IndexOf(i)))
+            ? _items.Max(i => GetItemDisplayWidth(i, _items.IndexOf(i)))
             : 10;
 
         var width = Math.Min(maxItemWidth + 2, available.Width);
@@ -430,10 +485,19 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
         return new Size(width, height);
     }
 
-    private int GetItemDisplayLength(SelectionItem<T> item, int index)
+    private int GetItemDisplayWidth(SelectionItem<T> item, int index)
     {
         var prefix = GetItemPrefix(item, index);
-        return prefix.Length + item.DisplayText.Length;
+
+        // Find the maximum width across all lines
+        var maxLineWidth = 0;
+        foreach (var line in item.Content.Lines)
+        {
+            var lineWidth = line.Sum(s => s.GetCurrentSegment().Text.Length);
+            maxLineWidth = Math.Max(maxLineWidth, lineWidth);
+        }
+
+        return prefix.Length + maxLineWidth;
     }
 
     private string GetItemPrefix(SelectionItem<T> item, int index)
@@ -465,34 +529,58 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
         if (!bounds.HasArea || _items.Count == 0)
             return;
 
-        var visibleCount = Math.Min(_visibleRows, bounds.Height);
-        var needsScrollbar = _items.Count > visibleCount;
+        // Create a sub-context for this node's bounds so all coordinates are relative
+        var subContext = context.CreateSubContext(bounds);
+
+        var visibleLines = Math.Min(_visibleRows, bounds.Height);
+        var needsScrollbar = TotalLineCount > visibleLines;
         var contentWidth = needsScrollbar ? bounds.Width - 1 : bounds.Width;
 
-        for (var row = 0; row < visibleCount; row++)
-        {
-            var itemIndex = _scrollOffset + row;
-            if (itemIndex >= _items.Count)
-                break;
+        var currentLine = 0;
+        var currentItemLineOffset = 0;
 
+        for (var itemIndex = 0; itemIndex < _items.Count && currentLine < visibleLines; itemIndex++)
+        {
             var item = _items[itemIndex];
+            var itemLineCount = item.LineCount;
+            var itemEndOffset = currentItemLineOffset + itemLineCount;
+
+            // Skip items entirely before the scroll offset
+            if (itemEndOffset <= _scrollOffset)
+            {
+                currentItemLineOffset = itemEndOffset;
+                continue;
+            }
+
+            // Calculate which lines of this item to render
+            var itemLineStart = Math.Max(0, _scrollOffset - currentItemLineOffset);
+            var renderRow = currentLine;
 
             // If this is the "Other" item and we're editing, render the text input instead
             if (item.IsOther && _isEditingOther && _otherInput != null)
             {
-                RenderOtherInput(context, row, contentWidth, itemIndex);
+                RenderOtherInput(subContext, renderRow, contentWidth, itemIndex);
+                currentLine++;
             }
             else
             {
                 var isHighlighted = itemIndex == _highlightedIndex && _hasFocus && !_isEditingOther;
-                RenderItem(context, item, itemIndex, row, contentWidth, isHighlighted);
+
+                // Render each visible line of this item
+                for (var lineIndex = itemLineStart; lineIndex < itemLineCount && currentLine < visibleLines; lineIndex++)
+                {
+                    RenderItemLine(subContext, item, itemIndex, lineIndex, currentLine, contentWidth, isHighlighted);
+                    currentLine++;
+                }
             }
+
+            currentItemLineOffset = itemEndOffset;
         }
 
         // Render scrollbar if needed
         if (needsScrollbar)
         {
-            RenderScrollbar(context, bounds.Width - 1, visibleCount);
+            RenderScrollbar(subContext, bounds.Width - 1, visibleLines);
         }
     }
 
@@ -519,51 +607,117 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
         _otherInput.Render(inputContext, innerBounds);
     }
 
-    private void RenderItem(IRenderContext context, SelectionItem<T> item, int index, int row,
-        int width, bool isHighlighted)
+    private void RenderItemLine(IRenderContext context, SelectionItem<T> item, int itemIndex,
+        int lineIndex, int row, int width, bool isHighlighted)
     {
-        // Set colors
+        // Get the line content
+        var lines = item.Content.Lines;
+        if (lineIndex >= lines.Count)
+            return;
+
+        var lineSegments = lines[lineIndex];
+
+        // Calculate prefix - only show on first line
+        var prefix = lineIndex == 0 ? GetItemPrefix(item, itemIndex) : new string(' ', GetItemPrefix(item, itemIndex).Length);
+
+        // Set background for highlighted items
         if (isHighlighted)
         {
-            context.SetForeground(_highlightForeground);
             context.SetBackground(_highlightBackground);
-        }
-        else if (item.IsSelected && _selectedForeground.HasValue)
-        {
-            context.SetForeground(_selectedForeground.Value);
-        }
-        else if (_foreground.HasValue)
-        {
-            context.SetForeground(_foreground.Value);
+            // Fill the entire row with background color
+            context.Fill(0, row, width, 1, ' ');
         }
 
-        // Build display string
-        var prefix = GetItemPrefix(item, index);
-        var displayText = prefix + item.DisplayText;
-
-        // Truncate if needed
-        if (displayText.Length > width)
+        // Render prefix
+        if (prefix.Length > 0)
         {
-            displayText = displayText[..(width - 1)] + "…";
+            if (isHighlighted)
+            {
+                context.SetForeground(_highlightForeground);
+            }
+            else if (lineIndex > 0)
+            {
+                // Indent continuation lines with dimmed color
+                context.SetForeground(Color.BrightBlack);
+            }
+            else if (item.IsSelected && _selectedForeground.HasValue)
+            {
+                context.SetForeground(_selectedForeground.Value);
+            }
+            else if (_foreground.HasValue)
+            {
+                context.SetForeground(_foreground.Value);
+            }
+
+            context.WriteAt(0, row, prefix);
         }
 
-        // Pad to full width for highlight background
-        if (isHighlighted)
+        // Render segments
+        var xPos = prefix.Length;
+        foreach (var segment in lineSegments)
         {
-            displayText = displayText.PadRight(width);
+            if (xPos >= width)
+                break;
+
+            var styledSegment = segment.GetCurrentSegment();
+            var text = styledSegment.Text;
+            var style = styledSegment.Style;
+
+            // Truncate if needed
+            var remainingWidth = width - xPos;
+            if (text.Length > remainingWidth)
+            {
+                text = text[..(remainingWidth - 1)] + "…";
+            }
+
+            // Apply colors - highlight overrides segment colors for foreground
+            if (isHighlighted)
+            {
+                context.SetForeground(_highlightForeground);
+                context.SetBackground(_highlightBackground);
+            }
+            else
+            {
+                // Apply segment style, falling back to item/list defaults
+                var fg = style.HasForeground ? style.Foreground :
+                    (item.IsSelected && _selectedForeground.HasValue ? _selectedForeground.Value :
+                    (_foreground ?? Color.Default));
+                var bg = style.HasBackground ? style.Background : Color.Default;
+
+                context.SetForeground(fg);
+                if (style.HasBackground)
+                {
+                    context.SetBackground(bg);
+                }
+            }
+
+            // Apply decoration if present
+            if (style.HasDecoration)
+            {
+                context.SetDecoration(style.Decoration);
+            }
+
+            context.WriteAt(xPos, row, text);
+            xPos += text.Length;
+
+            // Reset decoration after each segment
+            if (style.HasDecoration)
+            {
+                context.SetDecoration(TextDecoration.None);
+            }
         }
 
-        context.WriteAt(0, row, displayText);
         context.ResetColors();
     }
 
     private void RenderScrollbar(IRenderContext context, int x, int height)
     {
-        if (_items.Count <= height)
+        var totalLines = TotalLineCount;
+        if (totalLines <= height)
             return;
 
-        var thumbSize = Math.Max(1, height * height / _items.Count);
-        var thumbPos = _scrollOffset * (height - thumbSize) / (_items.Count - height);
+        var thumbSize = Math.Max(1, height * height / totalLines);
+        var thumbPos = _scrollOffset * (height - thumbSize) / (totalLines - height);
 
         context.SetForeground(Color.BrightBlack);
 
@@ -620,5 +774,11 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
         _cancelled.Dispose();
 
         _otherInput?.Dispose();
+
+        // Dispose all items (which will dispose their content and animation subscriptions)
+        foreach (var item in _items)
+        {
+            item.Dispose();
+        }
     }
 }

--- a/tests/Termina.Tests/Components/Streaming/CompositeTextSegmentTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/CompositeTextSegmentTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using Termina.Components.Streaming;
+using Termina.Terminal;
+
+namespace Termina.Tests.Components.Streaming;
+
+/// <summary>
+/// Tests for the CompositeTextSegment class.
+/// </summary>
+public class CompositeTextSegmentTests
+{
+    [Fact]
+    public void Constructor_WithStaticSegments_CreatesComposite()
+    {
+        using var composite = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("Hello ")),
+            new StaticTextSegment(new StyledSegment("World")));
+
+        Assert.Equal(2, composite.Children.Count);
+    }
+
+    [Fact]
+    public void GetCurrentSegment_CombinesAllChildText()
+    {
+        using var composite = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("Hello ")),
+            new StaticTextSegment(new StyledSegment("World")));
+
+        var segment = composite.GetCurrentSegment();
+
+        Assert.Equal("Hello World", segment.Text);
+    }
+
+    [Fact]
+    public void Children_ReturnsReadOnlyList()
+    {
+        using var composite = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("A")),
+            new StaticTextSegment(new StyledSegment("B")),
+            new StaticTextSegment(new StyledSegment("C")));
+
+        Assert.Equal(3, composite.Children.Count);
+        Assert.Equal("A", composite.Children[0].GetCurrentSegment().Text);
+        Assert.Equal("B", composite.Children[1].GetCurrentSegment().Text);
+        Assert.Equal("C", composite.Children[2].GetCurrentSegment().Text);
+    }
+
+    [Fact]
+    public void IsAnimating_WithoutAnimatedChildren_ReturnsFalse()
+    {
+        using var composite = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("Static 1")),
+            new StaticTextSegment(new StyledSegment("Static 2")));
+
+        Assert.False(composite.IsAnimating);
+    }
+
+    [Fact]
+    public void IsAnimating_WithAnimatedChild_ReturnsTrue()
+    {
+        using var spinner = new SpinnerSegment(SpinnerStyle.Dots, intervalMs: 1000);
+        using var composite = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("[")),
+            spinner,
+            new StaticTextSegment(new StyledSegment("]")));
+
+        Assert.True(composite.IsAnimating);
+    }
+
+    [Fact]
+    public async Task Invalidated_PropagatesFromAnimatedChild()
+    {
+        using var spinner = new SpinnerSegment(SpinnerStyle.Line, intervalMs: 10);
+        using var composite = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("Loading: ")),
+            spinner);
+
+        // Wait for invalidation from spinner
+        await composite.Invalidated
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(1));
+
+        // If we got here, invalidation was propagated
+        Assert.True(true);
+    }
+
+    [Fact]
+    public void Stop_StopsAllAnimatedChildren()
+    {
+        using var spinner = new SpinnerSegment(SpinnerStyle.Dots, intervalMs: 100);
+        using var composite = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("Status: ")),
+            spinner);
+
+        Assert.True(spinner.IsAnimating);
+
+        composite.Stop();
+
+        Assert.False(spinner.IsAnimating);
+    }
+
+    [Fact]
+    public void Start_StartsAllAnimatedChildren()
+    {
+        using var spinner = new SpinnerSegment(SpinnerStyle.Dots, intervalMs: 100);
+        spinner.Stop();
+
+        using var composite = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("Status: ")),
+            spinner);
+
+        composite.Start();
+
+        Assert.True(spinner.IsAnimating);
+    }
+
+    [Fact]
+    public void Dispose_DisposesAllChildren()
+    {
+        var static1 = new StaticTextSegment(new StyledSegment("A"));
+        var static2 = new StaticTextSegment(new StyledSegment("B"));
+        var composite = new CompositeTextSegment(static1, static2);
+
+        var invalidatedCompleted = false;
+        composite.Invalidated.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => invalidatedCompleted = true);
+
+        composite.Dispose();
+
+        Assert.True(invalidatedCompleted);
+    }
+
+    [Fact]
+    public void Constructor_WithEnumerable_CreatesComposite()
+    {
+        var segments = new ITextSegment[]
+        {
+            new StaticTextSegment(new StyledSegment("One")),
+            new StaticTextSegment(new StyledSegment(" ")),
+            new StaticTextSegment(new StyledSegment("Two"))
+        };
+
+        using var composite = new CompositeTextSegment(segments);
+
+        Assert.Equal(3, composite.Children.Count);
+        Assert.Equal("One Two", composite.GetCurrentSegment().Text);
+    }
+
+    [Fact]
+    public void NestedComposite_CombinesCorrectly()
+    {
+        using var inner = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("inner")),
+            new StaticTextSegment(new StyledSegment("-text")));
+
+        using var outer = new CompositeTextSegment(
+            new StaticTextSegment(new StyledSegment("[")),
+            inner,
+            new StaticTextSegment(new StyledSegment("]")));
+
+        Assert.Equal("[inner-text]", outer.GetCurrentSegment().Text);
+    }
+}

--- a/tests/Termina.Tests/Layout/SelectionItemContentTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionItemContentTests.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using Termina.Components.Streaming;
+using Termina.Layout;
+using Termina.Terminal;
+using Streaming = Termina.Components.Streaming;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for the SelectionItemContent builder class.
+/// </summary>
+public class SelectionItemContentTests
+{
+    [Fact]
+    public void AddLine_WithSegments_CreatesLine()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(new StaticTextSegment(new StyledSegment("Hello World")));
+
+        Assert.Equal(1, content.LineCount);
+        Assert.Single(content.Lines);
+        Assert.Single(content.Lines[0]);
+    }
+
+    [Fact]
+    public void AddLine_Multiple_CreatesMultipleLines()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(new StaticTextSegment(new StyledSegment("Line 1")))
+            .AddLine(new StaticTextSegment(new StyledSegment("Line 2")))
+            .AddLine(new StaticTextSegment(new StyledSegment("Line 3")));
+
+        Assert.Equal(3, content.LineCount);
+    }
+
+    [Fact]
+    public void AddLine_WithMultipleSegments_StoresAll()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(
+                new StaticTextSegment("Status: ", Color.Gray),
+                new StaticTextSegment("Connected", Color.Green));
+
+        Assert.Equal(1, content.LineCount);
+        Assert.Equal(2, content.Lines[0].Count);
+    }
+
+    [Fact]
+    public void AddLine_WithString_CreatesStaticSegment()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine("Simple text");
+
+        Assert.Equal(1, content.LineCount);
+        Assert.Equal("Simple text", content.GetFirstLineText());
+    }
+
+    [Fact]
+    public void AddLine_WithStringAndColor_AppliesStyle()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine("Colored text", Color.Red);
+
+        var segment = content.Lines[0][0].GetCurrentSegment();
+        Assert.Equal("Colored text", segment.Text);
+        Assert.Equal(Color.Red, segment.Style.Foreground);
+    }
+
+    [Fact]
+    public void ToPlainText_SingleLine_ReturnsText()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(new StaticTextSegment(new StyledSegment("Hello World")));
+
+        Assert.Equal("Hello World", content.ToPlainText());
+    }
+
+    [Fact]
+    public void ToPlainText_MultipleLines_JoinsWithNewlines()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(new StaticTextSegment(new StyledSegment("Line 1")))
+            .AddLine(new StaticTextSegment(new StyledSegment("Line 2")));
+
+        Assert.Equal("Line 1\nLine 2", content.ToPlainText());
+    }
+
+    [Fact]
+    public void ToPlainText_MultipleSegmentsPerLine_Concatenates()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(
+                new StaticTextSegment(new StyledSegment("A")),
+                new StaticTextSegment(new StyledSegment("B")),
+                new StaticTextSegment(new StyledSegment("C")));
+
+        Assert.Equal("ABC", content.ToPlainText());
+    }
+
+    [Fact]
+    public void GetFirstLineText_ReturnsFirstLineOnly()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(new StaticTextSegment(new StyledSegment("First")))
+            .AddLine(new StaticTextSegment(new StyledSegment("Second")));
+
+        Assert.Equal("First", content.GetFirstLineText());
+    }
+
+    [Fact]
+    public void GetFirstLineText_Empty_ReturnsEmptyString()
+    {
+        using var content = new SelectionItemContent();
+
+        Assert.Equal(string.Empty, content.GetFirstLineText());
+    }
+
+    [Fact]
+    public void FromString_CreatesSimpleContent()
+    {
+        using var content = SelectionItemContent.FromString("Simple");
+
+        Assert.Equal(1, content.LineCount);
+        Assert.Equal("Simple", content.GetFirstLineText());
+    }
+
+    [Fact]
+    public void HasAnimations_WithoutAnimated_ReturnsFalse()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(new StaticTextSegment(new StyledSegment("Static content")));
+
+        Assert.False(content.HasAnimations);
+    }
+
+    [Fact]
+    public void HasAnimations_WithAnimated_ReturnsTrue()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(new SpinnerSegment(Streaming.SpinnerStyle.Dots, intervalMs: 1000));
+
+        Assert.True(content.HasAnimations);
+    }
+
+    [Fact]
+    public async Task Invalidated_EmitsOnAnimationChange()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(new SpinnerSegment(Streaming.SpinnerStyle.Line, intervalMs: 10));
+
+        // Wait for invalidation
+        await content.Invalidated
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(1));
+
+        Assert.True(true); // Got here means invalidation was received
+    }
+
+    [Fact]
+    public void Dispose_CompletesInvalidated()
+    {
+        var content = new SelectionItemContent()
+            .AddLine(new StaticTextSegment(new StyledSegment("Test")));
+
+        var completed = false;
+        content.Invalidated.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => completed = true);
+
+        content.Dispose();
+
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public void AddLine_ReturnsSelf_ForFluent()
+    {
+        using var content = new SelectionItemContent();
+
+        var result = content.AddLine(new StaticTextSegment(new StyledSegment("Test")));
+
+        Assert.Same(content, result);
+    }
+
+    [Fact]
+    public void ComplexContent_MultiLineMultiSegment()
+    {
+        using var content = new SelectionItemContent()
+            .AddLine(
+                new StaticTextSegment("Server: ", Color.Gray),
+                new StaticTextSegment("Production", Color.White, decoration: TextDecoration.Bold))
+            .AddLine(
+                new StaticTextSegment("   Status: ", Color.Gray),
+                new StaticTextSegment("Connected", Color.Green))
+            .AddLine(
+                new StaticTextSegment("   Latency: ", Color.Gray),
+                new StaticTextSegment("3ms", Color.Cyan));
+
+        Assert.Equal(3, content.LineCount);
+        Assert.Equal("Server: Production", content.GetFirstLineText());
+        Assert.Contains("Connected", content.ToPlainText());
+        Assert.Contains("3ms", content.ToPlainText());
+    }
+}

--- a/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
@@ -3,9 +3,11 @@
 
 using System.Reactive;
 using System.Reactive.Linq;
+using Termina.Components.Streaming;
 using Termina.Layout;
 using Termina.Rendering;
 using Termina.Terminal;
+using Streaming = Termina.Components.Streaming;
 
 namespace Termina.Tests.Layout;
 
@@ -451,4 +453,173 @@ public class SelectionListNodeTests
 
         Assert.Equal("Fast", customValue);
     }
+
+    #region Rich Content Tests
+
+    [Fact]
+    public void SelectionListNode_WithRichContent_CanBeCreated()
+    {
+        var items = new[] { "Item 1", "Item 2", "Item 3" };
+        using var list = new SelectionListNode<string>(items, s =>
+            new SelectionItemContent().AddLine(new StaticTextSegment(s, Color.Green)));
+
+        Assert.NotNull(list);
+        Assert.Equal(3, list.Items.Count);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithRichContent_MultiLine_HasCorrectLineCount()
+    {
+        var items = new[] { "Server A", "Server B" };
+        using var list = new SelectionListNode<string>(items, s =>
+            new SelectionItemContent()
+                .AddLine(new StaticTextSegment(s, Color.White, decoration: TextDecoration.Bold))
+                .AddLine(new StaticTextSegment("   Status: Connected", Color.Green)));
+
+        // Each item has 2 lines
+        Assert.Equal(2, list.Items[0].LineCount);
+        Assert.Equal(2, list.Items[1].LineCount);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithRichContent_DisplayText_ReturnsFirstLine()
+    {
+        using var list = new SelectionListNode<string>(
+            new[] { "Test" },
+            s => new SelectionItemContent()
+                .AddLine(new StaticTextSegment(new StyledSegment("Header")))
+                .AddLine(new StaticTextSegment(new StyledSegment("Body"))));
+
+        Assert.Equal("Header", list.Items[0].DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithRichContent_NavigationWorks()
+    {
+        var items = new[] { "A", "B", "C" };
+        using var list = new SelectionListNode<string>(items, s =>
+            new SelectionItemContent().AddLine(new StaticTextSegment(new StyledSegment(s))));
+        list.OnFocused();
+
+        Assert.Equal("A", list.HighlightedItem?.DisplayText);
+
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+
+        Assert.Equal("B", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithRichContent_SelectionWorks()
+    {
+        var items = new[] { "Option 1", "Option 2" };
+        using var list = new SelectionListNode<string>(items, s =>
+            new SelectionItemContent().AddLine(new StaticTextSegment(s, Color.Cyan)))
+            .WithMode(SelectionMode.Multi);
+        list.OnFocused();
+
+        var spaceKey = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+        list.HandleInput(spaceKey);
+
+        Assert.True(list.Items[0].IsSelected);
+        Assert.Single(list.SelectedItems);
+        Assert.Equal("Option 1", list.SelectedItems[0]);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithRichContent_ConfirmationWorks()
+    {
+        var items = new[] { "Choice A", "Choice B" };
+        using var list = new SelectionListNode<string>(items, s =>
+            new SelectionItemContent()
+                .AddLine(new StaticTextSegment(new StyledSegment(s)))
+                .AddLine(new StaticTextSegment("   Description", Color.Gray)));
+        list.OnFocused();
+
+        var confirmed = new List<string>();
+        list.SelectionConfirmed.Subscribe(selected => confirmed.AddRange(selected));
+
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        Assert.Single(confirmed);
+        Assert.Equal("Choice A", confirmed[0]);
+    }
+
+    [Fact]
+    public async Task SelectionListNode_WithAnimatedContent_PropagatesInvalidation()
+    {
+        using var list = new SelectionListNode<string>(
+            new[] { "Loading" },
+            s => new SelectionItemContent()
+                .AddLine(
+                    new SpinnerSegment(Streaming.SpinnerStyle.Dots, Color.Blue, intervalMs: 10),
+                    new StaticTextSegment($" {s}...", Color.White)));
+
+        // Wait for invalidation from spinner
+        await list.Invalidated
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(1));
+
+        Assert.True(true); // Got here means invalidation propagated
+    }
+
+    [Fact]
+    public void SelectionListNode_WithRichContent_Dispose_DisposesItems()
+    {
+        var list = new SelectionListNode<string>(
+            new[] { "Test" },
+            s => new SelectionItemContent().AddLine(new StaticTextSegment(new StyledSegment(s))));
+
+        var completed = 0;
+        list.Invalidated.Subscribe(
+            onNext: _ => { },
+            onCompleted: () => completed++);
+
+        list.Dispose();
+
+        Assert.Equal(1, completed);
+    }
+
+    [Fact]
+    public void SelectionListNode_MixedContentStyles_WorksCorrectly()
+    {
+        var items = new[]
+        {
+            ("Server 1", "Connected", Color.Green),
+            ("Server 2", "Disconnected", Color.Red),
+            ("Server 3", "Connecting", Color.Yellow)
+        };
+
+        using var list = new SelectionListNode<(string Name, string Status, Color StatusColor)>(
+            items,
+            item => new SelectionItemContent()
+                .AddLine(new StaticTextSegment(item.Name, Color.White, decoration: TextDecoration.Bold))
+                .AddLine(
+                    new StaticTextSegment("   Status: ", Color.Gray),
+                    new StaticTextSegment(item.Status, item.StatusColor)));
+
+        Assert.Equal(3, list.Items.Count);
+        Assert.Equal("Server 1", list.Items[0].DisplayText);
+        Assert.Equal("Server 2", list.Items[1].DisplayText);
+        Assert.Equal(2, list.Items[0].LineCount);
+    }
+
+    [Fact]
+    public void SelectionListNode_Content_AccessibleThroughSelectItem()
+    {
+        using var list = new SelectionListNode<string>(
+            new[] { "Test" },
+            s => new SelectionItemContent()
+                .AddLine("Header", Color.White)
+                .AddLine("Body", Color.Gray));
+
+        var item = list.Items[0];
+
+        Assert.NotNull(item.Content);
+        Assert.Equal(2, item.Content.LineCount);
+        Assert.Equal("Header\nBody", item.Content.ToPlainText());
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Adds `SelectionItemContent` class for multi-line, styled selection items with support for `ITextSegment` (static and animated)
- Adds "Something else..." option with inline text input for custom user responses
- Implements interactive decision points in the streaming chat demo
- Fixes inline layout positioning for dynamic content

Closes #92

## Changes

### Core Library (`src/Termina`)

- **`SelectionItemContent`**: New class for building rich, multi-line selection item content with styled segments
- **`CompositeTextSegment`**: Combines multiple `ITextSegment` instances into a single segment
- **`SelectionListNode`**: 
  - New constructor accepting `Func<T, SelectionItemContent>` for rich content
  - `WithOtherOption()` method for adding custom input option
  - `OtherSelected` observable for custom input submissions
  - Sub-context rendering fix for proper coordinate translation
- **`SelectionItem`**: Extended to support `SelectionItemContent` and "Other" item type

### Demo (`demos/Termina.Demo.Streaming`)

- **`LlmSimulatorActor`**: Simulates decision points with choices
- **`StreamingChatPage`**: Handles decision list display inline between chat history and input
- **`StreamingChatViewModel`**: Manages decision point state and user responses

### Tests

- 35 tests for `SelectionListNode` (all passing)
- Tests for `SelectionItemContent` and `CompositeTextSegment`

## Test plan

- [x] All 673 tests pass
- [x] Demo shows decision list inline without clearing other UI
- [x] Selection via arrow keys and Enter works
- [x] Quick selection via number keys (1-9) works
- [x] "Something else..." option opens inline text input
- [x] Custom input submission triggers follow-up response
- [x] Escape cancels decision and continues