### PR TITLE
Fix SelectionListNode issues and add component gallery demo

### DIFF
--- a/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryPage.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Linq;
+using Termina.Components.Streaming;
+using Termina.Extensions;
 using Termina.Layout;
 using Termina.Reactive;
 using Termina.Rendering;
@@ -11,60 +14,158 @@ namespace Termina.Demo.Gallery.Pages;
 
 /// <summary>
 /// Gallery page showcasing animated components.
+/// Demonstrates interactive spinner style selection.
 /// </summary>
 public class AnimationsGalleryPage : ReactivePage<AnimationsGalleryViewModel>
 {
+    private SelectionListNode<SpinnerStyleItem> _styleList = null!;
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+
+        // When user selects a style with Enter, update the ViewModel
+        _styleList.SelectionConfirmed
+            .Subscribe(items =>
+            {
+                var item = items.FirstOrDefault();
+                if (item != null)
+                {
+                    ViewModel.SelectedStyle = item.Style;
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        Focus.PushFocus(_styleList);
+    }
+
     public override ILayoutNode BuildLayout()
     {
+        _styleList = new SelectionListNode<SpinnerStyleItem>(
+            ViewModel.SpinnerStyles,
+            item => new SelectionItemContent()
+                .AddLine(
+                    new StaticTextSegment(item.Name, item.Color, decoration: TextDecoration.Bold),
+                    new StaticTextSegment($"  {item.Description}", Color.Gray)))
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Cyan)
+            .WithVisibleRows(8);
+
         return Layouts.Vertical()
             .WithChild(
                 new PanelNode()
                     .WithTitle("Animations Gallery")
                     .WithBorder(BorderStyle.Double)
                     .WithBorderColor(Color.Yellow)
-                    .WithContent(BuildAnimationsShowcase())
+                    .WithContent(BuildContent())
                     .Fill())
             .WithChild(
-                new TextNode("[Esc] Menu")
+                new TextNode("[↑/↓] Navigate  [Enter] Preview Style  [Esc] Menu")
                     .WithForeground(Color.BrightBlack)
                     .Height(1));
     }
 
-    private static ILayoutNode BuildAnimationsShowcase()
+    private ILayoutNode BuildContent()
     {
-        return Layouts.Vertical()
-            .WithChild(
-                new TextNode("\n  Spinner Styles\n")
-                    .WithForeground(Color.BrightCyan)
-                    .Bold())
-            .WithChild(BuildSpinnerRow("Dots", LayoutSpinnerStyle.Dots, Color.Blue))
-            .WithChild(BuildSpinnerRow("Line", LayoutSpinnerStyle.Line, Color.Green))
-            .WithChild(BuildSpinnerRow("Arrow", LayoutSpinnerStyle.Arrow, Color.Yellow))
-            .WithChild(BuildSpinnerRow("Bounce", LayoutSpinnerStyle.Bounce, Color.Magenta))
-            .WithChild(BuildSpinnerRow("Box", LayoutSpinnerStyle.Box, Color.Cyan))
-            .WithChild(BuildSpinnerRow("Circle", LayoutSpinnerStyle.Circle, Color.Red))
-            .WithChild(new TextNode(" ").Height(1))
-            .WithChild(
-                new TextNode("  Spinners with Labels\n")
-                    .WithForeground(Color.BrightCyan)
-                    .Bold())
-            .WithChild(
-                new SpinnerNode(LayoutSpinnerStyle.Dots, intervalMs: 80)
-                    .WithLabel("Loading data...")
-                    .WithSpinnerColor(Color.Blue)
-                    .WithLabelColor(Color.White))
-            .WithChild(
-                new SpinnerNode(LayoutSpinnerStyle.Arrow, intervalMs: 100)
-                    .WithLabel("Processing request...")
-                    .WithSpinnerColor(Color.Green)
-                    .WithLabelColor(Color.White));
+        var grid = new GridNode()
+            .WithColumns(SizeConstraint.Percentage(40), SizeConstraint.Percentage(60))
+            .WithRows(SizeConstraint.FillRemaining())
+            .WithGridLines(BorderStyle.Single)
+            .WithGridLineColor(Color.BrightBlack);
+
+        // Left column: Style selector
+        grid.SetCell(0, 0,
+            Layouts.Vertical()
+                .WithChild(
+                    new TextNode("Select Spinner Style")
+                        .WithForeground(Color.BrightCyan)
+                        .Bold()
+                        .Height(2))
+                .WithChild(_styleList));
+
+        // Right column: Live preview that updates when selection changes
+        grid.SetCell(0, 1,
+            Layouts.Vertical()
+                .WithChild(
+                    new TextNode("Live Preview")
+                        .WithForeground(Color.BrightYellow)
+                        .Bold()
+                        .Height(2))
+                .WithChild(BuildPreviewArea()));
+
+        return grid;
     }
 
-    private static ILayoutNode BuildSpinnerRow(string name, LayoutSpinnerStyle style, Color color)
+    private ILayoutNode BuildPreviewArea()
     {
-        return Layouts.Horizontal()
-            .WithChild(new TextNode($"  {name,-12}").WithForeground(Color.Gray).Width(14))
-            .WithChild(new SpinnerNode(style, intervalMs: 100).WithSpinnerColor(color))
-            .Height(1);
+        // Create a reactive layout that swaps spinners based on selection
+        return ViewModel.SelectedStyleChanged
+            .Select(style => BuildSpinnerPreview(style))
+            .AsLayout()
+            .Fill();
     }
+
+    private static ILayoutNode BuildSpinnerPreview(LayoutSpinnerStyle style)
+    {
+        var (name, color, _) = GetStyleInfo(style);
+
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle($"Style: {name}")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(color)
+                    .WithContent(
+                        Layouts.Vertical()
+                            .WithChild(new TextNode(" ").Height(1))
+                            .WithChild(
+                                Layouts.Horizontal()
+                                    .WithChild(new TextNode("  ").WidthAuto())
+                                    .WithChild(
+                                        new SpinnerNode(style, intervalMs: 80)
+                                            .WithSpinnerColor(color))
+                                    .Height(1))
+                            .WithChild(new TextNode(" ").Height(1))
+                            .WithChild(
+                                Layouts.Horizontal()
+                                    .WithChild(new TextNode("  ").WidthAuto())
+                                    .WithChild(
+                                        new SpinnerNode(style, intervalMs: 80)
+                                            .WithLabel("Loading...")
+                                            .WithSpinnerColor(color)
+                                            .WithLabelColor(Color.White))
+                                    .Height(1))
+                            .WithChild(new TextNode(" ").Height(1))
+                            .WithChild(
+                                Layouts.Horizontal()
+                                    .WithChild(new TextNode("  ").WidthAuto())
+                                    .WithChild(
+                                        new SpinnerNode(style, intervalMs: 120)
+                                            .WithLabel("Processing request...")
+                                            .WithSpinnerColor(color)
+                                            .WithLabelColor(Color.Gray))
+                                    .Height(1)))
+                    .Fill())
+            .WithChild(
+                new TextNode($"  Interval: 80ms (fast), 120ms (slow)")
+                    .WithForeground(Color.DarkGray)
+                    .Height(2));
+    }
+
+    private static (string Name, Color Color, string Description) GetStyleInfo(LayoutSpinnerStyle style) => style switch
+    {
+        LayoutSpinnerStyle.Dots => ("Dots", Color.Blue, "Braille dots pattern"),
+        LayoutSpinnerStyle.Line => ("Line", Color.Green, "Classic line spinner"),
+        LayoutSpinnerStyle.Arrow => ("Arrow", Color.Yellow, "Rotating arrow"),
+        LayoutSpinnerStyle.Bounce => ("Bounce", Color.Magenta, "Bouncing dot"),
+        LayoutSpinnerStyle.Box => ("Box", Color.Cyan, "Rotating box corners"),
+        LayoutSpinnerStyle.Circle => ("Circle", Color.Red, "Rotating circle"),
+        _ => ("Unknown", Color.White, "")
+    };
 }
+
+/// <summary>
+/// Represents a spinner style option.
+/// </summary>
+public record SpinnerStyleItem(string Name, LayoutSpinnerStyle Style, Color Color, string Description);

--- a/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryPage.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+using LayoutSpinnerStyle = Termina.Layout.SpinnerStyle;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// Gallery page showcasing animated components.
+/// </summary>
+public class AnimationsGalleryPage : ReactivePage<AnimationsGalleryViewModel>
+{
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Animations Gallery")
+                    .WithBorder(BorderStyle.Double)
+                    .WithBorderColor(Color.Yellow)
+                    .WithContent(BuildAnimationsShowcase())
+                    .Fill())
+            .WithChild(
+                new TextNode("[Esc] Menu")
+                    .WithForeground(Color.BrightBlack)
+                    .Height(1));
+    }
+
+    private static ILayoutNode BuildAnimationsShowcase()
+    {
+        return Layouts.Vertical()
+            .WithChild(
+                new TextNode("\n  Spinner Styles\n")
+                    .WithForeground(Color.BrightCyan)
+                    .Bold())
+            .WithChild(BuildSpinnerRow("Dots", LayoutSpinnerStyle.Dots, Color.Blue))
+            .WithChild(BuildSpinnerRow("Line", LayoutSpinnerStyle.Line, Color.Green))
+            .WithChild(BuildSpinnerRow("Arrow", LayoutSpinnerStyle.Arrow, Color.Yellow))
+            .WithChild(BuildSpinnerRow("Bounce", LayoutSpinnerStyle.Bounce, Color.Magenta))
+            .WithChild(BuildSpinnerRow("Box", LayoutSpinnerStyle.Box, Color.Cyan))
+            .WithChild(BuildSpinnerRow("Circle", LayoutSpinnerStyle.Circle, Color.Red))
+            .WithChild(new TextNode(" ").Height(1))
+            .WithChild(
+                new TextNode("  Spinners with Labels\n")
+                    .WithForeground(Color.BrightCyan)
+                    .Bold())
+            .WithChild(
+                new SpinnerNode(LayoutSpinnerStyle.Dots, intervalMs: 80)
+                    .WithLabel("Loading data...")
+                    .WithSpinnerColor(Color.Blue)
+                    .WithLabelColor(Color.White))
+            .WithChild(
+                new SpinnerNode(LayoutSpinnerStyle.Arrow, intervalMs: 100)
+                    .WithLabel("Processing request...")
+                    .WithSpinnerColor(Color.Green)
+                    .WithLabelColor(Color.White));
+    }
+
+    private static ILayoutNode BuildSpinnerRow(string name, LayoutSpinnerStyle style, Color color)
+    {
+        return Layouts.Horizontal()
+            .WithChild(new TextNode($"  {name,-12}").WithForeground(Color.Gray).Width(14))
+            .WithChild(new SpinnerNode(style, intervalMs: 100).WithSpinnerColor(color))
+            .Height(1);
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryViewModel.cs
@@ -4,6 +4,8 @@
 using System.Reactive.Linq;
 using Termina.Input;
 using Termina.Reactive;
+using Termina.Terminal;
+using LayoutSpinnerStyle = Termina.Layout.SpinnerStyle;
 
 namespace Termina.Demo.Gallery.Pages;
 
@@ -12,6 +14,18 @@ namespace Termina.Demo.Gallery.Pages;
 /// </summary>
 public partial class AnimationsGalleryViewModel : ReactiveViewModel
 {
+    [Reactive] private Termina.Layout.SpinnerStyle _selectedStyle = Termina.Layout.SpinnerStyle.Dots;
+
+    public IReadOnlyList<SpinnerStyleItem> SpinnerStyles { get; } = new List<SpinnerStyleItem>
+    {
+        new("Dots", LayoutSpinnerStyle.Dots, Color.Blue, "Braille dots pattern"),
+        new("Line", LayoutSpinnerStyle.Line, Color.Green, "Classic line spinner"),
+        new("Arrow", LayoutSpinnerStyle.Arrow, Color.Yellow, "Rotating arrow"),
+        new("Bounce", LayoutSpinnerStyle.Bounce, Color.Magenta, "Bouncing dot"),
+        new("Box", LayoutSpinnerStyle.Box, Color.Cyan, "Rotating box corners"),
+        new("Circle", LayoutSpinnerStyle.Circle, Color.Red, "Rotating circle")
+    };
+
     public override void OnActivated()
     {
         Input.OfType<KeyPressed>()

--- a/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryViewModel.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// ViewModel for the Animations gallery page.
+/// </summary>
+public partial class AnimationsGalleryViewModel : ReactiveViewModel
+{
+    public override void OnActivated()
+    {
+        Input.OfType<KeyPressed>()
+            .Where(k => k.KeyInfo.Key == ConsoleKey.Escape)
+            .Subscribe(_ => Navigate("/menu"))
+            .DisposeWith(Subscriptions);
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/GalleryMenuPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GalleryMenuPage.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Components.Streaming;
+using Termina.Extensions;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// Main menu page for the component gallery.
+/// </summary>
+public class GalleryMenuPage : ReactivePage<GalleryMenuViewModel>
+{
+    private SelectionListNode<GalleryMenuItem> _menuList = null!;
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+
+        _menuList.SelectionConfirmed
+            .Subscribe(items =>
+            {
+                var item = items.FirstOrDefault();
+                if (item != null)
+                {
+                    ViewModel.NavigateToGallery(item.Route);
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        Focus.PushFocus(_menuList);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        _menuList = new SelectionListNode<GalleryMenuItem>(
+            ViewModel.MenuItems,
+            item => new SelectionItemContent()
+                .AddLine(new StaticTextSegment(item.Title, Color.BrightCyan, decoration: TextDecoration.Bold))
+                .AddLine(new StaticTextSegment($"   {item.Description}", Color.Gray)))
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Cyan)
+            .WithVisibleRows(12);
+
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Termina Component Gallery")
+                    .WithBorder(BorderStyle.Double)
+                    .WithBorderColor(Color.Magenta)
+                    .WithContent(
+                        Layouts.Vertical()
+                            .WithChild(
+                                new TextNode("\n  Welcome to the Termina Component Gallery!\n  Explore different UI components and their capabilities.\n")
+                                    .WithForeground(Color.White))
+                            .WithChild(_menuList))
+                    .Fill())
+            .WithChild(
+                new TextNode("[↑/↓] Navigate  [Enter] Select  [1-4] Quick Select  [Q] Quit")
+                    .WithForeground(Color.BrightBlack)
+                    .Height(1));
+    }
+}
+
+/// <summary>
+/// Represents a menu item in the gallery.
+/// </summary>
+public record GalleryMenuItem(string Title, string Description, string Route);

--- a/demos/Termina.Demo.Gallery/Pages/GalleryMenuViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GalleryMenuViewModel.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// ViewModel for the gallery menu.
+/// </summary>
+public partial class GalleryMenuViewModel : ReactiveViewModel
+{
+    public IReadOnlyList<GalleryMenuItem> MenuItems { get; } = new List<GalleryMenuItem>
+    {
+        new("Selection Lists", "Single/multi-select, numbered, Other option, rich content", "/selection"),
+        new("Text Input", "Text fields, placeholder text, submission handling", "/textinput"),
+        new("Layouts", "Vertical, horizontal, grid, panels, borders", "/layouts"),
+        new("Animations", "Spinners, streaming text, progress indicators", "/animations")
+    };
+
+    public override void OnActivated()
+    {
+        Input.OfType<KeyPressed>()
+            .Where(k => k.KeyInfo.Key == ConsoleKey.Q)
+            .Subscribe(_ => Shutdown())
+            .DisposeWith(Subscriptions);
+    }
+
+    public void NavigateToGallery(string route)
+    {
+        Navigate(route);
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/LayoutGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/LayoutGalleryPage.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// Gallery page showcasing layout components.
+/// </summary>
+public class LayoutGalleryPage : ReactivePage<LayoutGalleryViewModel>
+{
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Layout Gallery")
+                    .WithBorder(BorderStyle.Double)
+                    .WithBorderColor(Color.Green)
+                    .WithContent(BuildLayoutShowcase())
+                    .Fill())
+            .WithChild(
+                new TextNode("[Esc] Menu")
+                    .WithForeground(Color.BrightBlack)
+                    .Height(1));
+    }
+
+    private static ILayoutNode BuildLayoutShowcase()
+    {
+        var grid = new GridNode()
+            .WithColumns(SizeConstraint.Percentage(50), SizeConstraint.Percentage(50))
+            .WithRows(SizeConstraint.Percentage(50), SizeConstraint.Percentage(50))
+            .WithGridLines(BorderStyle.Single)
+            .WithGridLineColor(Color.BrightBlack);
+
+        // Top-left: Vertical layout
+        grid.SetCell(0, 0,
+            new PanelNode()
+                .WithTitle("VerticalLayout")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Cyan)
+                .WithContent(
+                    Layouts.Vertical()
+                        .WithChild(new TextNode("Item 1").WithForeground(Color.White).Height(1))
+                        .WithChild(new TextNode("Item 2").WithForeground(Color.Gray).Height(1))
+                        .WithChild(new TextNode("Item 3").WithForeground(Color.BrightBlack).Height(1))));
+
+        // Top-right: Horizontal layout
+        grid.SetCell(0, 1,
+            new PanelNode()
+                .WithTitle("HorizontalLayout")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Yellow)
+                .WithContent(
+                    Layouts.Horizontal()
+                        .WithChild(new TextNode("[A]").WithForeground(Color.Red).WidthAuto())
+                        .WithChild(new TextNode(" [B] ").WithForeground(Color.Green).WidthAuto())
+                        .WithChild(new TextNode("[C]").WithForeground(Color.Blue).WidthAuto())));
+
+        // Bottom-left: Panel styles
+        grid.SetCell(1, 0,
+            Layouts.Vertical()
+                .WithChild(
+                    new PanelNode()
+                        .WithTitle("Single Border")
+                        .WithBorder(BorderStyle.Single)
+                        .WithBorderColor(Color.Magenta)
+                        .WithContent(new TextNode("Content").WithForeground(Color.Gray)))
+                .WithChild(
+                    new PanelNode()
+                        .WithTitle("Double Border")
+                        .WithBorder(BorderStyle.Double)
+                        .WithBorderColor(Color.Blue)
+                        .WithContent(new TextNode("Content").WithForeground(Color.Gray))));
+
+        // Bottom-right: Nested layout
+        grid.SetCell(1, 1,
+            new PanelNode()
+                .WithTitle("Nested Layouts")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Green)
+                .WithContent(
+                    Layouts.Vertical()
+                        .WithChild(
+                            Layouts.Horizontal()
+                                .WithChild(new TextNode("Left").WithForeground(Color.Cyan).Fill())
+                                .WithChild(new TextNode("Right").WithForeground(Color.Yellow).Fill())
+                                .Height(1))
+                        .WithChild(
+                            new TextNode("Full Width")
+                                .WithForeground(Color.Magenta)
+                                .Height(1))));
+
+        return grid;
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/LayoutGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/LayoutGalleryViewModel.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// ViewModel for the Layout gallery page.
+/// </summary>
+public partial class LayoutGalleryViewModel : ReactiveViewModel
+{
+    public override void OnActivated()
+    {
+        Input.OfType<KeyPressed>()
+            .Where(k => k.KeyInfo.Key == ConsoleKey.Escape)
+            .Subscribe(_ => Navigate("/menu"))
+            .DisposeWith(Subscriptions);
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
@@ -46,8 +46,43 @@ public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewMod
             .Subscribe(items => ViewModel.OnNumberedSelection(items.FirstOrDefault() ?? ""))
             .DisposeWith(Subscriptions);
 
+        // Subscribe to Cancelled (Escape key) on all lists - navigate back to menu
+        _singleSelectList.Cancelled
+            .Subscribe(_ => ViewModel.NavigateToMenu())
+            .DisposeWith(Subscriptions);
+
+        _multiSelectRichList.Cancelled
+            .Subscribe(_ => ViewModel.NavigateToMenu())
+            .DisposeWith(Subscriptions);
+
+        _numberedList.Cancelled
+            .Subscribe(_ => ViewModel.NavigateToMenu())
+            .DisposeWith(Subscriptions);
+
+        // Subscribe to Tab key to cycle focus between lists
+        ViewModel.TabPressed
+            .Subscribe(_ => CycleFocus())
+            .DisposeWith(Subscriptions);
+
         // Default focus to first list
+        _focusedListIndex = 0;
         Focus.PushFocus(_singleSelectList);
+    }
+
+    private int _focusedListIndex;
+
+    private void CycleFocus()
+    {
+        _focusedListIndex = (_focusedListIndex + 1) % 3;
+        IFocusable targetList = _focusedListIndex switch
+        {
+            0 => _singleSelectList,
+            1 => _multiSelectRichList,
+            2 => _numberedList,
+            _ => _singleSelectList
+        };
+        Focus.PushFocus(targetList);
+        ViewModel.OnFocusChanged(_focusedListIndex);
     }
 
     public override ILayoutNode BuildLayout()
@@ -167,7 +202,7 @@ public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewMod
                     .AsLayout()
                     .Fill())
             .WithChild(
-                new TextNode("[Esc] Menu")
+                new TextNode("[Tab] Switch List  [Esc] Menu")
                     .WithForeground(Color.BrightBlack)
                     .NoWrap()
                     .WidthAuto())

--- a/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Components.Streaming;
+using Termina.Extensions;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// Gallery page showcasing SelectionListNode capabilities.
+/// Demonstrates:
+/// - 12+ items to show numbering works beyond 9 (Issue #101 fix)
+/// - "Other" option with fixed UX (Issue #102 fix)
+/// - Both single and multi-select modes
+/// - Rich multi-line content with styling
+/// </summary>
+public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewModel>
+{
+    private SelectionListNode<string> _singleSelectList = null!;
+    private SelectionListNode<ServerInfo> _multiSelectRichList = null!;
+    private SelectionListNode<string> _numberedList = null!;
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+
+        // Subscribe to selection events
+        _singleSelectList.SelectionConfirmed
+            .Subscribe(items => ViewModel.OnSingleSelection(items.FirstOrDefault() ?? ""))
+            .DisposeWith(Subscriptions);
+
+        _singleSelectList.OtherSelected
+            .Subscribe(text => ViewModel.OnOtherSelected(text))
+            .DisposeWith(Subscriptions);
+
+        _multiSelectRichList.SelectionConfirmed
+            .Subscribe(items => ViewModel.OnMultiSelection(items.Select(s => s.Name).ToList()))
+            .DisposeWith(Subscriptions);
+
+        _numberedList.SelectionConfirmed
+            .Subscribe(items => ViewModel.OnNumberedSelection(items.FirstOrDefault() ?? ""))
+            .DisposeWith(Subscriptions);
+
+        // Default focus to first list
+        Focus.PushFocus(_singleSelectList);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        // Single-select list with "Other" option - demonstrates Issue #102 fix
+        _singleSelectList = Layouts.SelectionList(
+            "Option Alpha", "Option Beta", "Option Gamma", "Option Delta")
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Green)
+            .WithOtherOption("Custom value...");
+
+        // Multi-select list with rich content
+        _multiSelectRichList = new SelectionListNode<ServerInfo>(
+            ViewModel.Servers,
+            server => new SelectionItemContent()
+                .AddLine(
+                    new StaticTextSegment(server.Name, Color.White, decoration: TextDecoration.Bold),
+                    new StaticTextSegment($" ({server.Region})", Color.Gray))
+                .AddLine(
+                    new StaticTextSegment("   Status: ", Color.Gray),
+                    new StaticTextSegment(server.Status, GetStatusColor(server.Status)),
+                    new StaticTextSegment($"  |  Load: {server.Load}%", Color.Gray)))
+            .WithMode(SelectionMode.Multi)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Yellow)
+            .WithVisibleRows(8);
+
+        // Numbered list with 12 items - demonstrates Issue #101 fix
+        _numberedList = Layouts.SelectionList(
+            Enumerable.Range(1, 12).Select(i => $"Item number {i}"))
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Cyan)
+            .WithVisibleRows(6);
+
+        return Layouts.Vertical()
+            .WithChild(BuildHeader())
+            .WithChild(BuildDemoGrid().Fill())
+            .WithChild(BuildStatusBar());
+    }
+
+    private static ILayoutNode BuildHeader()
+    {
+        return new PanelNode()
+            .WithTitle("SelectionListNode Gallery")
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Color.Magenta)
+            .WithContent(
+                new TextNode("Showcasing SelectionListNode: numbering beyond 9, fixed 'Other' UX, and rich content")
+                    .WithForeground(Color.Gray))
+            .Height(4);
+    }
+
+    private GridNode BuildDemoGrid()
+    {
+        var grid = new GridNode()
+            .WithColumns(
+                SizeConstraint.Percentage(33),
+                SizeConstraint.Percentage(34),
+                SizeConstraint.Percentage(33))
+            .WithRows(SizeConstraint.FillRemaining())
+            .WithGridLines(BorderStyle.Single)
+            .WithGridLineColor(Color.BrightBlack);
+
+        // Column 1: Single-select with Other
+        grid.SetCell(0, 0,
+            Layouts.Vertical()
+                .WithChild(
+                    new TextNode("Single Select + Other")
+                        .WithForeground(Color.BrightGreen)
+                        .Bold()
+                        .Height(1))
+                .WithChild(
+                    new TextNode("Press Enter/Space to edit 'Other'")
+                        .WithForeground(Color.DarkGray)
+                        .Height(2))
+                .WithChild(_singleSelectList));
+
+        // Column 2: Multi-select with rich content
+        grid.SetCell(0, 1,
+            Layouts.Vertical()
+                .WithChild(
+                    new TextNode("Multi-Select + Rich Content")
+                        .WithForeground(Color.BrightYellow)
+                        .Bold()
+                        .Height(1))
+                .WithChild(
+                    new TextNode("Space to toggle, Enter to confirm")
+                        .WithForeground(Color.DarkGray)
+                        .Height(2))
+                .WithChild(_multiSelectRichList));
+
+        // Column 3: Numbered list (12 items)
+        grid.SetCell(0, 2,
+            Layouts.Vertical()
+                .WithChild(
+                    new TextNode("12+ Items (Issue #101)")
+                        .WithForeground(Color.BrightCyan)
+                        .Bold()
+                        .Height(1))
+                .WithChild(
+                    new TextNode("All items show numbers!")
+                        .WithForeground(Color.DarkGray)
+                        .Height(2))
+                .WithChild(_numberedList));
+
+        return grid;
+    }
+
+    private ILayoutNode BuildStatusBar()
+    {
+        return Layouts.Horizontal()
+            .WithChild(
+                ViewModel.StatusMessageChanged
+                    .Select(msg => new TextNode(msg).WithForeground(Color.White))
+                    .AsLayout()
+                    .Fill())
+            .WithChild(
+                new TextNode("[Esc] Menu")
+                    .WithForeground(Color.BrightBlack)
+                    .NoWrap()
+                    .WidthAuto())
+            .Height(1);
+    }
+
+    private static Color GetStatusColor(string status) => status switch
+    {
+        "Online" => Color.Green,
+        "Degraded" => Color.Yellow,
+        "Offline" => Color.Red,
+        _ => Color.Gray
+    };
+}
+
+/// <summary>
+/// Represents a server for the multi-select demo.
+/// </summary>
+public record ServerInfo(string Name, string Region, string Status, int Load);

--- a/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryViewModel.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Termina.Extensions;
 using Termina.Input;
 using Termina.Reactive;
 
@@ -12,7 +15,11 @@ namespace Termina.Demo.Gallery.Pages;
 /// </summary>
 public partial class SelectionListGalleryViewModel : ReactiveViewModel
 {
+    private readonly Subject<Unit> _tabPressed = new();
+
     [Reactive] private string _statusMessage = "Select items and explore different SelectionList features";
+
+    public IObservable<Unit> TabPressed => _tabPressed.AsObservable();
 
     public IReadOnlyList<ServerInfo> Servers { get; } = new List<ServerInfo>
     {
@@ -24,21 +31,25 @@ public partial class SelectionListGalleryViewModel : ReactiveViewModel
         new("dev-local", "Local", "Offline", 0)
     };
 
+    private static readonly string[] ListNames = { "Single Select", "Multi-Select", "Numbered List" };
+
     public override void OnActivated()
     {
+        // Handle Tab key to cycle focus between lists
         Input.OfType<KeyPressed>()
-            .Subscribe(HandleKeyPress)
+            .Where(k => k.KeyInfo.Key == ConsoleKey.Tab)
+            .Subscribe(_ => _tabPressed.OnNext(Unit.Default))
             .DisposeWith(Subscriptions);
     }
 
-    private void HandleKeyPress(KeyPressed key)
+    public void NavigateToMenu()
     {
-        switch (key.KeyInfo.Key)
-        {
-            case ConsoleKey.Escape:
-                Navigate("/menu");
-                break;
-        }
+        Navigate("/menu");
+    }
+
+    public void OnFocusChanged(int listIndex)
+    {
+        StatusMessage = $"Focus: {ListNames[listIndex]} - Use Tab to switch lists";
     }
 
     public void OnSingleSelection(string item)

--- a/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryViewModel.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// ViewModel for the SelectionList gallery page.
+/// </summary>
+public partial class SelectionListGalleryViewModel : ReactiveViewModel
+{
+    [Reactive] private string _statusMessage = "Select items and explore different SelectionList features";
+
+    public IReadOnlyList<ServerInfo> Servers { get; } = new List<ServerInfo>
+    {
+        new("prod-us-east-1", "US East", "Online", 45),
+        new("prod-us-west-2", "US West", "Online", 72),
+        new("prod-eu-west-1", "EU West", "Degraded", 89),
+        new("prod-ap-south-1", "AP South", "Online", 23),
+        new("staging-us-east-1", "US East", "Online", 12),
+        new("dev-local", "Local", "Offline", 0)
+    };
+
+    public override void OnActivated()
+    {
+        Input.OfType<KeyPressed>()
+            .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+    }
+
+    private void HandleKeyPress(KeyPressed key)
+    {
+        switch (key.KeyInfo.Key)
+        {
+            case ConsoleKey.Escape:
+                Navigate("/menu");
+                break;
+        }
+    }
+
+    public void OnSingleSelection(string item)
+    {
+        StatusMessage = $"Single selected: {item}";
+    }
+
+    public void OnOtherSelected(string customValue)
+    {
+        StatusMessage = $"Custom value entered: \"{customValue}\"";
+    }
+
+    public void OnMultiSelection(IReadOnlyList<string> items)
+    {
+        StatusMessage = $"Multi-selected {items.Count} servers: {string.Join(", ", items)}";
+    }
+
+    public void OnNumberedSelection(string item)
+    {
+        StatusMessage = $"Numbered selection: {item}";
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/TextInputGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/TextInputGalleryPage.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Extensions;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// Gallery page showcasing TextInputNode capabilities.
+/// </summary>
+public class TextInputGalleryPage : ReactivePage<TextInputGalleryViewModel>
+{
+    private TextInputNode _basicInput = null!;
+    private TextInputNode _placeholderInput = null!;
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+
+        _basicInput.Submitted
+            .Subscribe(text => ViewModel.OnBasicInputSubmitted(text))
+            .DisposeWith(Subscriptions);
+
+        _placeholderInput.Submitted
+            .Subscribe(text => ViewModel.OnPlaceholderInputSubmitted(text))
+            .DisposeWith(Subscriptions);
+
+        Focus.PushFocus(_basicInput);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        _basicInput = new TextInputNode();
+
+        _placeholderInput = new TextInputNode()
+            .WithPlaceholder("Type something here...");
+
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("TextInputNode Gallery")
+                    .WithBorder(BorderStyle.Double)
+                    .WithBorderColor(Color.Blue)
+                    .WithContent(
+                        Layouts.Vertical()
+                            .WithChild(
+                                new TextNode("\n  Text input components for user data entry.\n")
+                                    .WithForeground(Color.Gray))
+                            .WithChild(
+                                new TextNode("  Basic Input:")
+                                    .WithForeground(Color.BrightCyan)
+                                    .Height(1))
+                            .WithChild(
+                                Layouts.Horizontal()
+                                    .WithChild(new TextNode("  ").Width(2))
+                                    .WithChild(_basicInput.Fill())
+                                    .Height(1))
+                            .WithChild(new TextNode("").Height(1))
+                            .WithChild(
+                                new TextNode("  Input with Placeholder:")
+                                    .WithForeground(Color.BrightCyan)
+                                    .Height(1))
+                            .WithChild(
+                                Layouts.Horizontal()
+                                    .WithChild(new TextNode("  ").Width(2))
+                                    .WithChild(_placeholderInput.Fill())
+                                    .Height(1)))
+                    .Fill())
+            .WithChild(
+                new TextNode("[Tab] Switch field  [Enter] Submit  [Esc] Menu")
+                    .WithForeground(Color.BrightBlack)
+                    .Height(1))
+            .WithChild(
+                ViewModel.StatusMessageChanged
+                    .Select(msg => new TextNode(msg).WithForeground(Color.White))
+                    .AsLayout()
+                    .Height(1));
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/TextInputGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/TextInputGalleryViewModel.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// ViewModel for the TextInput gallery page.
+/// </summary>
+public partial class TextInputGalleryViewModel : ReactiveViewModel
+{
+    [Reactive] private string _statusMessage = "Type in the input fields and press Enter to submit";
+
+    public override void OnActivated()
+    {
+        Input.OfType<KeyPressed>()
+            .Where(k => k.KeyInfo.Key == ConsoleKey.Escape)
+            .Subscribe(_ => Navigate("/menu"))
+            .DisposeWith(Subscriptions);
+    }
+
+    public void OnBasicInputSubmitted(string text)
+    {
+        StatusMessage = $"Basic input submitted: \"{text}\"";
+    }
+
+    public void OnPlaceholderInputSubmitted(string text)
+    {
+        StatusMessage = $"Placeholder input submitted: \"{text}\"";
+    }
+}

--- a/demos/Termina.Demo.Gallery/Program.cs
+++ b/demos/Termina.Demo.Gallery/Program.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Hosting;
+using Termina.Demo.Gallery.Pages;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Pages;
+
+// Check for --test flag (used in CI/CD to run scripted test and exit)
+var testMode = args.Contains("--test");
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Set up input source based on mode
+VirtualInputSource? scriptedInput = null;
+if (testMode)
+{
+    scriptedInput = new VirtualInputSource();
+    builder.Services.AddTerminaVirtualInput(scriptedInput);
+}
+
+// Register Termina with gallery pages using route-based navigation
+builder.Services.AddTermina("/menu", termina =>
+{
+    termina.RegisterRoute<GalleryMenuPage, GalleryMenuViewModel>("/menu", NavigationBehavior.PreserveState);
+    termina.RegisterRoute<SelectionListGalleryPage, SelectionListGalleryViewModel>("/selection", NavigationBehavior.PreserveState);
+    termina.RegisterRoute<TextInputGalleryPage, TextInputGalleryViewModel>("/textinput", NavigationBehavior.PreserveState);
+    termina.RegisterRoute<LayoutGalleryPage, LayoutGalleryViewModel>("/layouts", NavigationBehavior.PreserveState);
+    termina.RegisterRoute<AnimationsGalleryPage, AnimationsGalleryViewModel>("/animations", NavigationBehavior.PreserveState);
+});
+
+var host = builder.Build();
+
+if (testMode && scriptedInput != null)
+{
+    // Queue up scripted input to test basic functionality then quit
+    _ = Task.Run(async () =>
+    {
+        await Task.Delay(500); // Wait for initial render
+
+        // Navigate through menu
+        scriptedInput.EnqueueKey(ConsoleKey.DownArrow);
+        scriptedInput.EnqueueKey(ConsoleKey.Enter); // Enter SelectionList gallery
+        await Task.Delay(300);
+
+        // Navigate in selection list
+        scriptedInput.EnqueueKey(ConsoleKey.DownArrow);
+        scriptedInput.EnqueueKey(ConsoleKey.DownArrow);
+        scriptedInput.EnqueueKey(ConsoleKey.Spacebar);
+
+        // Return to menu
+        scriptedInput.EnqueueKey(ConsoleKey.Escape);
+        await Task.Delay(200);
+
+        // Quit
+        scriptedInput.EnqueueKey(ConsoleKey.Q);
+        scriptedInput.Complete();
+    });
+}
+
+await host.RunAsync();

--- a/demos/Termina.Demo.Gallery/Termina.Demo.Gallery.csproj
+++ b/demos/Termina.Demo.Gallery/Termina.Demo.Gallery.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+
+    <!-- AOT Publishing Support -->
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+
+    <!-- Don't publish demo as NuGet package -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Termina\Termina.csproj" />
+    <!-- Source generator - compile-time only, never publish -->
+    <ProjectReference Include="..\..\src\Termina.Generators\Termina.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all"
+                      Publish="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -348,17 +348,7 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
 
         _highlightedIndex = Math.Clamp(_highlightedIndex + delta, 0, _items.Count - 1);
         EnsureVisible();
-
-        // Auto-start text input when navigating to "Other" option
-        var item = _items[_highlightedIndex];
-        if (item.IsOther && !_isEditingOther)
-        {
-            StartOtherInput();
-        }
-        else
-        {
-            Invalidate();
-        }
+        Invalidate();
     }
 
     /// <summary>
@@ -504,8 +494,8 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     {
         var parts = new List<string>();
 
-        // Number prefix
-        if (_showNumbers && index < 9)
+        // Number prefix (display numbers for all items; keyboard shortcuts still limited to 1-9)
+        if (_showNumbers)
         {
             parts.Add($"{index + 1}.");
         }
@@ -589,8 +579,8 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
         if (_otherInput == null)
             return;
 
-        // Render the number prefix (e.g., "4. ") in dimmed color
-        var prefix = _showNumbers && itemIndex < 9 ? $"{itemIndex + 1}. " : "";
+        // Render the number prefix (e.g., "4. " or "10. ") in dimmed color
+        var prefix = _showNumbers ? $"{itemIndex + 1}. " : "";
         if (prefix.Length > 0)
         {
             context.SetForeground(Color.BrightBlack);

--- a/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
@@ -378,13 +378,13 @@ public class SelectionListNodeTests
     }
 
     [Fact]
-    public void SelectionListNode_OtherOption_AutoStartsEditingOnNavigate()
+    public void SelectionListNode_OtherOption_NavigationHighlightsWithoutStartingEdit()
     {
         using var list = Layouts.SelectionList("A", "B")
             .WithOtherOption("Custom...");
         list.OnFocused();
 
-        // Move to Other option - should auto-start editing
+        // Move to Other option - should highlight but NOT auto-start editing
         var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
         list.HandleInput(downKey);
         list.HandleInput(downKey);
@@ -392,13 +392,70 @@ public class SelectionListNodeTests
         // Verify we're on the Other option
         Assert.True(list.HighlightedItem?.IsOther);
 
-        // Should be able to type immediately without pressing Enter first
-        list.HandleInput(new ConsoleKeyInfo('T', ConsoleKey.T, false, false, false));
-        list.HandleInput(new ConsoleKeyInfo('e', ConsoleKey.E, false, false, false));
-        list.HandleInput(new ConsoleKeyInfo('s', ConsoleKey.S, false, false, false));
-        list.HandleInput(new ConsoleKeyInfo('t', ConsoleKey.T, false, false, false));
+        // Typing should NOT work (not in edit mode yet) - returns false (unhandled)
+        var typingResult = list.HandleInput(new ConsoleKeyInfo('T', ConsoleKey.T, false, false, false));
+        Assert.False(typingResult);
+    }
 
-        // This test verifies navigating to Other auto-starts text input mode
+    [Fact]
+    public void SelectionListNode_OtherOption_EnterStartsEditing()
+    {
+        using var list = Layouts.SelectionList("A", "B")
+            .WithOtherOption("Custom...");
+        list.OnFocused();
+
+        string? customValue = null;
+        list.OtherSelected.Subscribe(text => customValue = text);
+
+        // Navigate to Other option
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+        list.HandleInput(downKey);
+        Assert.True(list.HighlightedItem?.IsOther);
+
+        // Press Enter to start editing
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        // Now typing should work
+        list.HandleInput(new ConsoleKeyInfo('H', ConsoleKey.H, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('i', ConsoleKey.I, false, false, false));
+
+        // Press Enter to confirm
+        list.HandleInput(enterKey);
+
+        Assert.Equal("Hi", customValue);
+    }
+
+    [Fact]
+    public void SelectionListNode_OtherOption_SpaceStartsEditing()
+    {
+        using var list = Layouts.SelectionList("A", "B")
+            .WithOtherOption("Custom...");
+        list.OnFocused();
+
+        string? customValue = null;
+        list.OtherSelected.Subscribe(text => customValue = text);
+
+        // Navigate to Other option
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        list.HandleInput(downKey);
+        list.HandleInput(downKey);
+        Assert.True(list.HighlightedItem?.IsOther);
+
+        // Press Space to start editing
+        var spaceKey = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+        list.HandleInput(spaceKey);
+
+        // Now typing should work
+        list.HandleInput(new ConsoleKeyInfo('Y', ConsoleKey.Y, false, false, false));
+        list.HandleInput(new ConsoleKeyInfo('o', ConsoleKey.O, false, false, false));
+
+        // Press Enter to confirm
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        Assert.Equal("Yo", customValue);
     }
 
     [Fact]
@@ -411,17 +468,20 @@ public class SelectionListNodeTests
         string? customValue = null;
         list.OtherSelected.Subscribe(text => customValue = text);
 
-        // Navigate to Other - auto-starts editing
+        // Navigate to Other
         var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
         list.HandleInput(downKey);
         list.HandleInput(downKey);
 
-        // Type "Hi" immediately (no Enter needed to start)
+        // Press Enter to start editing (required - no auto-start on navigation)
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        list.HandleInput(enterKey);
+
+        // Now type "Hi"
         list.HandleInput(new ConsoleKeyInfo('H', ConsoleKey.H, false, false, false));
         list.HandleInput(new ConsoleKeyInfo('i', ConsoleKey.I, false, false, false));
 
         // Press Enter to confirm
-        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
         list.HandleInput(enterKey);
 
         Assert.Equal("Hi", customValue);
@@ -453,6 +513,65 @@ public class SelectionListNodeTests
 
         Assert.Equal("Fast", customValue);
     }
+
+    #region Number Display Tests
+
+    [Fact]
+    public void SelectionListNode_ShowsNumbersForAllItems_NotJustFirstNine()
+    {
+        // Create list with 12 items
+        var items = Enumerable.Range(1, 12).Select(i => $"Item {i}").ToArray();
+        using var list = new SelectionListNode<string>(items, s => s)
+            .WithShowNumbers(true);
+
+        // All 12 items should be in the list
+        Assert.Equal(12, list.Items.Count);
+
+        // Measure to ensure the component can handle 12 numbered items
+        var size = list.Measure(new Size(80, 20));
+
+        // The measured size should accommodate all items
+        Assert.True(size.Width > 0);
+        Assert.True(size.Height > 0);
+    }
+
+    [Fact]
+    public void SelectionListNode_NumberKeysOnlyWorkFor1Through9()
+    {
+        // Create list with 12 items
+        var items = Enumerable.Range(1, 12).Select(i => $"Item {i}").ToArray();
+        using var list = new SelectionListNode<string>(items, s => s)
+            .WithShowNumbers(true)
+            .WithMode(SelectionMode.Multi);
+        list.OnFocused();
+
+        // Number key 9 should work
+        var key9 = new ConsoleKeyInfo('9', ConsoleKey.D9, false, false, false);
+        list.HandleInput(key9);
+        Assert.True(list.Items[8].IsSelected); // 9th item (index 8)
+
+        // The highlighted item should be the 9th item after pressing '9'
+        Assert.Equal("Item 9", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_CanNavigateToItemsBeyondNine()
+    {
+        // Create list with 12 items
+        var items = Enumerable.Range(1, 12).Select(i => $"Item {i}").ToArray();
+        using var list = new SelectionListNode<string>(items, s => s)
+            .WithShowNumbers(true);
+        list.OnFocused();
+
+        // Navigate to end
+        var endKey = new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false);
+        list.HandleInput(endKey);
+
+        // Should be on the 12th item
+        Assert.Equal("Item 12", list.HighlightedItem?.DisplayText);
+    }
+
+    #endregion
 
     #region Rich Content Tests
 


### PR DESCRIPTION
## Summary
- Fix #101: Show number prefixes for all items in SelectionListNode, not just items 1-9
- Fix #102: Remove auto-start text input when navigating to "Other" option (now requires Enter/Space to activate)
- Add new `Termina.Demo.Gallery` project showcasing UI components

## Test plan
- [ ] Run gallery demo locally: `dotnet run --project demos/Termina.Demo.Gallery`
- [ ] Verify SelectionListGallery shows numbers for all 12 items in the right column
- [ ] Verify navigating to "Other" option with arrow keys does NOT auto-start text input
- [ ] Verify pressing Enter or Space on "Other" option starts text input mode
- [ ] Run full test suite: `dotnet test`