### PR TITLE
Add BlockSegment wrapper for block-level streaming text

### DIFF
--- a/demos/Termina.Demo.Streaming/Actors/LlmSimulatorActor.cs
+++ b/demos/Termina.Demo.Streaming/Actors/LlmSimulatorActor.cs
@@ -255,13 +255,14 @@ public class LlmSimulatorActor : ReceiveActor
 
     private Source<LlmMessages.StreamToken, NotUsed> CreateTokenSource(string prompt, string? decisionContext, CancellationToken ct)
     {
-        var thinkingCount = _random.Next(3, 6);
+        // Generate 5-10 thinking tokens over 1.25-2.5 seconds (250ms each)
+        var thinkingCount = _random.Next(5, 11);
 
         // Create thinking tokens
         var thinkingSource = Source.From(Enumerable.Range(0, thinkingCount))
             .Select(_ => ThinkingPhrases[_random.Next(ThinkingPhrases.Length)])
             .Select(text => (LlmMessages.StreamToken)new LlmMessages.ThinkingToken(text))
-            .Throttle(1, TimeSpan.FromMilliseconds(150), 1, ThrottleMode.Shaping);
+            .Throttle(1, TimeSpan.FromMilliseconds(250), 1, ThrottleMode.Shaping);
 
         // If we have a decision context, use the follow-up response
         if (decisionContext != null && _pendingDecision != null)

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
@@ -62,6 +62,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
 {
     // Predefined segment IDs for tracked elements
     private static readonly SegmentId ThinkingSpinnerId = new(1);
+    private static readonly SegmentId ThinkingBlockId = new(2);
 
     private readonly IRequiredActor<LlmSimulatorActor> _llmActorProvider;
     private readonly List<string> _promptHistory = new();
@@ -69,6 +70,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
     private IActorRef? _llmActor;
     private CancellationTokenSource? _generationCts;
     private SpinnerSegment? _currentSpinner;
+    private bool _thinkingBlockShown;
 
     // Subjects for chat output - Page subscribes to these
     private readonly Subject<IChatMessage> _chatOutput = new();
@@ -269,6 +271,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         // Start generation
         IsGenerating = true;
         HasReceivedText = false;
+        _thinkingBlockShown = false;
         StatusMessage = "Generating response...";
 
         _ = ConsumeResponseStreamAsync(prompt, decisionContext);
@@ -296,13 +299,9 @@ public partial class StreamingChatViewModel : ReactiveViewModel
             {
                 switch (token)
                 {
-                    case LlmMessages.ThinkingToken:
-                        // Skip thinking tokens - status bar already shows "Generating response..."
-                        break;
-
-                    case LlmMessages.TextChunk chunk:
-                        // On first text chunk, replace the spinner with static empty segment
-                        if (!HasReceivedText)
+                    case LlmMessages.ThinkingToken thinking:
+                        // On first thinking token, replace spinner with thinking block
+                        if (!_thinkingBlockShown)
                         {
                             _chatOutput.OnNext(new ReplaceTrackedSegment(
                                 ThinkingSpinnerId,
@@ -310,6 +309,29 @@ public partial class StreamingChatViewModel : ReactiveViewModel
                                 KeepTracked: false));
                             _currentSpinner?.Dispose();
                             _currentSpinner = null;
+
+                            // Add thinking block that will update in place
+                            var thinkingSegment = new StaticTextSegment(
+                                $"💭 {thinking.Text}",
+                                new TextStyle { Foreground = Color.BrightBlack, Decoration = TextDecoration.Italic }).AsBlock();
+                            _chatOutput.OnNext(new AppendTrackedSegment(ThinkingBlockId, thinkingSegment));
+                            _thinkingBlockShown = true;
+                        }
+                        else
+                        {
+                            // Update existing thinking block
+                            var thinkingSegment = new StaticTextSegment(
+                                $"💭 {thinking.Text}",
+                                new TextStyle { Foreground = Color.BrightBlack, Decoration = TextDecoration.Italic }).AsBlock();
+                            _chatOutput.OnNext(new ReplaceTrackedSegment(ThinkingBlockId, thinkingSegment, KeepTracked: true));
+                        }
+                        break;
+
+                    case LlmMessages.TextChunk chunk:
+                        // On first text chunk, remove thinking block
+                        if (!HasReceivedText)
+                        {
+                            _chatOutput.OnNext(new RemoveTrackedSegment(ThinkingBlockId));
                             HasReceivedText = true;
                         }
 
@@ -323,15 +345,10 @@ public partial class StreamingChatViewModel : ReactiveViewModel
                         break;
 
                     case LlmMessages.DecisionPointToken decision:
-                        // On first content (decision point), replace spinner
+                        // On first content (decision point), remove thinking block
                         if (!HasReceivedText)
                         {
-                            _chatOutput.OnNext(new ReplaceTrackedSegment(
-                                ThinkingSpinnerId,
-                                new StaticTextSegment("", TextStyle.Default),
-                                KeepTracked: false));
-                            _currentSpinner?.Dispose();
-                            _currentSpinner = null;
+                            _chatOutput.OnNext(new RemoveTrackedSegment(ThinkingBlockId));
                             HasReceivedText = true;
                         }
 

--- a/docs/components/streaming-text-node.md
+++ b/docs/components/streaming-text-node.md
@@ -418,16 +418,154 @@ var blink = new BlinkSegment("URGENT", Color.Red);
 stream.AppendTracked(new SegmentId(1), blink);
 ```
 
+## Block-Level Segments
+
+Block-level segments force content to start on a new line and wrap vertically within their container. This is ideal for content that should update in-place without pushing surrounding text around, such as LLM "thinking" indicators or status blocks.
+
+### The `.AsBlock()` Extension
+
+Any `ITextSegment` can be wrapped as a block using the `.AsBlock()` fluent API:
+
+```csharp
+using Termina.Components.Streaming;
+
+var stream = StreamingTextNode.Create();
+
+// Regular inline content
+stream.Append("Status: ");
+
+// Block-level content (starts on new line)
+var statusBlock = new StaticTextSegment(
+    "Processing...",
+    new TextStyle { Foreground = Color.Yellow }
+).AsBlock();
+
+stream.AppendTracked(new SegmentId(1), statusBlock);
+```
+
+### How Block Segments Work
+
+When you append a `BlockSegment`:
+1. If the current line has content, a newline is automatically inserted
+2. The block content renders on its own line
+3. The content wraps vertically to fit the container width
+4. Surrounding content is not pushed when the block updates
+
+This creates a "window within a window" effect where the block updates in-place.
+
+### Real-World Example: LLM Thinking Indicator
+
+From the streaming chat demo, showing how thinking blocks update in-place:
+
+```csharp
+public partial class StreamingChatViewModel : ReactiveViewModel
+{
+    private static readonly SegmentId ThinkingSpinnerId = new(1);
+    private static readonly SegmentId ThinkingBlockId = new(2);
+    private bool _thinkingBlockShown;
+
+    private async Task ConsumeResponseStreamAsync()
+    {
+        await foreach (var token in response.TokenStream)
+        {
+            switch (token)
+            {
+                case LlmMessages.ThinkingToken thinking:
+                    // On first thinking token, replace spinner with thinking block
+                    if (!_thinkingBlockShown)
+                    {
+                        _chatOutput.OnNext(new ReplaceTrackedSegment(
+                            ThinkingSpinnerId,
+                            new StaticTextSegment("", TextStyle.Default),
+                            KeepTracked: false));
+
+                        // Add thinking block that updates in place
+                        var thinkingSegment = new StaticTextSegment(
+                            $"💭 {thinking.Text}",
+                            new TextStyle
+                            {
+                                Foreground = Color.BrightBlack,
+                                Decoration = TextDecoration.Italic
+                            }).AsBlock();
+
+                        _chatOutput.OnNext(new AppendTrackedSegment(ThinkingBlockId, thinkingSegment));
+                        _thinkingBlockShown = true;
+                    }
+                    else
+                    {
+                        // Update existing thinking block in-place
+                        var thinkingSegment = new StaticTextSegment(
+                            $"💭 {thinking.Text}",
+                            new TextStyle
+                            {
+                                Foreground = Color.BrightBlack,
+                                Decoration = TextDecoration.Italic
+                            }).AsBlock();
+
+                        _chatOutput.OnNext(new ReplaceTrackedSegment(
+                            ThinkingBlockId,
+                            thinkingSegment,
+                            KeepTracked: true));
+                    }
+                    break;
+
+                case LlmMessages.TextChunk chunk:
+                    // Remove thinking block when actual content arrives
+                    if (!HasReceivedText)
+                    {
+                        _chatOutput.OnNext(new RemoveTrackedSegment(ThinkingBlockId));
+                        HasReceivedText = true;
+                    }
+                    _chatOutput.OnNext(new AppendText(chunk.Text));
+                    break;
+            }
+        }
+    }
+}
+```
+
+In this example:
+- The thinking text (like "💭 Analyzing the question..." or "💭 Formulating response...") updates every ~250ms
+- The block stays on its own line, wrapping vertically if needed
+- When actual response text arrives, the thinking block is removed without leaving a gap
+- The surrounding content (previous messages, following response) stays in place
+
+### Block Segments with Animation
+
+Block segments work seamlessly with animated segments:
+
+```csharp
+// Animated spinner as a block
+var spinnerBlock = new SpinnerSegment(
+    SpinnerStyle.Dots,
+    Color.Yellow
+).AsBlock();
+
+stream.AppendTracked(new SegmentId(1), spinnerBlock);
+
+// The spinner animates on its own line
+// Updates don't affect surrounding content
+```
+
+### Use Cases
+
+- **LLM Thinking Indicators**: Show intermediate "thinking" steps that update in-place
+- **Multi-line Status Blocks**: Status information that needs 2-3 lines and updates frequently
+- **In-place Progress Indicators**: Progress that wraps across multiple lines
+- **Temporary Notifications**: Alerts that appear, update, then disappear without disrupting flow
+- **Live Metrics**: Real-time stats that update in a fixed block without scrolling
+
 ### Performance Considerations
 
 - **Untracked appends**: O(1), zero overhead
 - **Tracked appends**: O(1), minimal tracking overhead
 - **Remove/Replace**: O(n) buffer rebuild, but only when mutating
 - **Animation frames**: No rebuild, just invalidation for redraw
+- **Block segments**: Same performance as regular segments, just with automatic newline insertion
 
 Most content should be untracked. Only use tracked segments for dynamic elements that need mutation.
 
-### Use Cases
+### General Tracked Segment Use Cases
 
 - **Spinners**: Loading indicators while waiting for async operations
 - **Timers**: Countdown or elapsed time displays

--- a/src/Termina/Components/Streaming/BlockSegment.cs
+++ b/src/Termina/Components/Streaming/BlockSegment.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+
+namespace Termina.Components.Streaming;
+
+/// <summary>
+/// A wrapper segment that indicates the content should render as a block element,
+/// starting on a new line. The wrapped segment's text will word-wrap to fit
+/// the container width automatically.
+/// </summary>
+/// <remarks>
+/// Use the <see cref="TextSegmentExtensions.AsBlock"/> extension method to create
+/// block segments fluently:
+/// <code>
+/// var block = new StaticTextSegment("Long text...").AsBlock();
+/// streamingNode.AppendTracked(id, block);
+/// </code>
+/// </remarks>
+public sealed class BlockSegment : ITextSegment, IAnimatedTextSegment
+{
+    private readonly ITextSegment _inner;
+
+    /// <summary>
+    /// Creates a block segment wrapping the specified inner segment.
+    /// </summary>
+    /// <param name="inner">The segment to wrap as a block element.</param>
+    /// <exception cref="ArgumentNullException">Thrown if inner is null.</exception>
+    public BlockSegment(ITextSegment inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    /// <summary>
+    /// Gets the wrapped inner segment.
+    /// </summary>
+    public ITextSegment Inner => _inner;
+
+    /// <inheritdoc />
+    public StyledSegment GetCurrentSegment() => _inner.GetCurrentSegment();
+
+    /// <inheritdoc />
+    public IObservable<Unit> Invalidated =>
+        _inner is IAnimatedTextSegment animated
+            ? animated.Invalidated
+            : Observable.Empty<Unit>();
+
+    /// <inheritdoc />
+    public bool IsAnimating =>
+        _inner is IAnimatedTextSegment animated && animated.IsAnimating;
+
+    /// <inheritdoc />
+    public void Start()
+    {
+        if (_inner is IAnimatedTextSegment animated)
+            animated.Start();
+    }
+
+    /// <inheritdoc />
+    public void Stop()
+    {
+        if (_inner is IAnimatedTextSegment animated)
+            animated.Stop();
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _inner.Dispose();
+}

--- a/src/Termina/Components/Streaming/IStreamingTextBuffer.cs
+++ b/src/Termina/Components/Streaming/IStreamingTextBuffer.cs
@@ -29,6 +29,12 @@ public interface IStreamingTextBuffer
     bool HasContent { get; }
 
     /// <summary>
+    /// Gets whether the current (incomplete) line has any content.
+    /// Used to determine if a newline should be inserted before block elements.
+    /// </summary>
+    bool HasContentOnCurrentLine { get; }
+
+    /// <summary>
     /// Appends text to the buffer. Handles newlines appropriately.
     /// </summary>
     /// <param name="text">Text to append (may contain newlines).</param>

--- a/src/Termina/Components/Streaming/PersistedStreamBuffer.cs
+++ b/src/Termina/Components/Streaming/PersistedStreamBuffer.cs
@@ -76,6 +76,18 @@ public class PersistedStreamBuffer : IStreamingTextBuffer
         }
     }
 
+    /// <inheritdoc />
+    public bool HasContentOnCurrentLine
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _currentStyledLine.Length > 0;
+            }
+        }
+    }
+
     /// <summary>
     /// Gets or sets whether auto-scroll is enabled.
     /// When true (default), view scrolls to bottom on new content if not manually scrolled.

--- a/src/Termina/Components/Streaming/TextSegmentExtensions.cs
+++ b/src/Termina/Components/Streaming/TextSegmentExtensions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Components.Streaming;
+
+/// <summary>
+/// Extension methods for <see cref="ITextSegment"/>.
+/// </summary>
+public static class TextSegmentExtensions
+{
+    /// <summary>
+    /// Wraps this segment as a block element that starts on a new line.
+    /// Block segments word-wrap to fit the container width automatically.
+    /// </summary>
+    /// <param name="segment">The segment to wrap.</param>
+    /// <returns>A <see cref="BlockSegment"/> wrapping the original segment.</returns>
+    /// <example>
+    /// <code>
+    /// // Create a block segment that starts on its own line
+    /// var block = new StaticTextSegment("Long text that will wrap...").AsBlock();
+    /// streamingNode.AppendTracked(id, block);
+    ///
+    /// // Works with composite segments too
+    /// var composite = new CompositeTextSegment(
+    ///     new SpinnerSegment(),
+    ///     new StaticTextSegment(" Processing...")
+    /// ).AsBlock();
+    /// </code>
+    /// </example>
+    public static BlockSegment AsBlock(this ITextSegment segment)
+    {
+        // If already a BlockSegment, return as-is to avoid double-wrapping
+        if (segment is BlockSegment block)
+            return block;
+
+        return new BlockSegment(segment);
+    }
+}

--- a/src/Termina/Components/Streaming/WindowedStreamBuffer.cs
+++ b/src/Termina/Components/Streaming/WindowedStreamBuffer.cs
@@ -83,6 +83,18 @@ public class WindowedStreamBuffer : IStreamingTextBuffer
         }
     }
 
+    /// <inheritdoc />
+    public bool HasContentOnCurrentLine
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _currentStyledLine.Length > 0;
+            }
+        }
+    }
+
     /// <summary>
     /// Gets the number of lines that have been discarded due to window overflow.
     /// Useful for knowing how much content has scrolled past.

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -191,6 +191,7 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
     /// <summary>
     /// Appends a tracked text segment that can be removed or replaced later.
     /// The caller provides the ID to reference this segment.
+    /// If the segment is a <see cref="BlockSegment"/>, it will start on a new line.
     /// </summary>
     /// <param name="id">The unique identifier for this segment (provided by caller).</param>
     /// <param name="segment">The text segment to append.</param>
@@ -205,15 +206,21 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
             if (_segmentIndices.ContainsKey(id))
                 throw new ArgumentException($"SegmentId {id.Value} is already in use", nameof(id));
 
+            // If this is a block segment, ensure it starts on a new line
+            EnsureBlockNewLine(segment);
+
+            // Unwrap BlockSegment to get the inner segment
+            var innerSegment = UnwrapBlock(segment);
+
             var element = new TrackedElement(id, segment);
             var index = _content.Count;
 
             _content.Add(element);
             _segmentIndices[id] = index;
-            _buffer.Append(segment.GetCurrentSegment());
+            _buffer.Append(innerSegment.GetCurrentSegment());
 
             // Subscribe to animation invalidation if this is an animated segment
-            if (segment is IAnimatedTextSegment animated)
+            if (innerSegment is IAnimatedTextSegment animated)
             {
                 var subscription = animated.Invalidated.Subscribe(_ =>
                 {
@@ -353,15 +360,41 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
 
         foreach (var element in _content)
         {
-            var segment = element switch
+            switch (element)
             {
-                StaticElement s => s.Segment,
-                TrackedElement t => t.Segment.GetCurrentSegment(),
-                _ => throw new InvalidOperationException($"Unknown content element type: {element.GetType()}")
-            };
-
-            _buffer.Append(segment);
+                case StaticElement s:
+                    _buffer.Append(s.Segment);
+                    break;
+                case TrackedElement t:
+                    // Handle block segments in rebuild
+                    EnsureBlockNewLine(t.Segment);
+                    var inner = UnwrapBlock(t.Segment);
+                    _buffer.Append(inner.GetCurrentSegment());
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown content element type: {element.GetType()}");
+            }
         }
+    }
+
+    /// <summary>
+    /// If the segment is a BlockSegment and the current line has content,
+    /// ensures we start on a new line.
+    /// </summary>
+    private void EnsureBlockNewLine(ITextSegment segment)
+    {
+        if (segment is BlockSegment && _buffer.HasContentOnCurrentLine)
+        {
+            _buffer.AppendLine(string.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Unwraps a BlockSegment to get the inner segment, or returns the segment as-is.
+    /// </summary>
+    private static ITextSegment UnwrapBlock(ITextSegment segment)
+    {
+        return segment is BlockSegment block ? block.Inner : segment;
     }
 
     /// <summary>

--- a/tests/Termina.Tests/Components/Streaming/BlockSegmentTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/BlockSegmentTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Components.Streaming;
+using Termina.Terminal;
+using Xunit;
+
+namespace Termina.Tests.Components.Streaming;
+
+public class BlockSegmentTests
+{
+    [Fact]
+    public void AsBlock_WrapsSegment()
+    {
+        var inner = new StaticTextSegment("test", TextStyle.Default);
+        var block = inner.AsBlock();
+
+        Assert.IsType<BlockSegment>(block);
+        Assert.Same(inner, block.Inner);
+    }
+
+    [Fact]
+    public void AsBlock_DoesNotDoubleWrap()
+    {
+        var inner = new StaticTextSegment("test", TextStyle.Default);
+        var block1 = inner.AsBlock();
+        var block2 = block1.AsBlock();
+
+        Assert.Same(block1, block2);
+    }
+
+    [Fact]
+    public void BlockSegment_DelegatesGetCurrentSegment()
+    {
+        var inner = new StaticTextSegment("test", Color.Red);
+        var block = new BlockSegment(inner);
+
+        var result = block.GetCurrentSegment();
+
+        Assert.Equal("test", result.Text);
+        Assert.Equal(Color.Red, result.Style.Foreground);
+    }
+
+    [Fact]
+    public async Task BlockSegment_PropagatesInvalidation_FromAnimatedInner()
+    {
+        var spinner = new SpinnerSegment(SpinnerStyle.Dots, intervalMs: 10);
+        var block = new BlockSegment(spinner);
+
+        var invalidated = false;
+        block.Invalidated.Subscribe(_ => invalidated = true);
+
+        // Wait for spinner animation
+        await spinner.Invalidated.FirstAsync().Timeout(TimeSpan.FromSeconds(1));
+
+        Assert.True(invalidated);
+
+        spinner.Dispose();
+    }
+
+    [Fact]
+    public void BlockSegment_IsAnimating_ReturnsFalse_ForStaticInner()
+    {
+        var inner = new StaticTextSegment("test", TextStyle.Default);
+        var block = new BlockSegment(inner);
+
+        Assert.False(block.IsAnimating);
+    }
+
+    [Fact]
+    public void BlockSegment_IsAnimating_ReturnsTrue_ForAnimatedInner()
+    {
+        var spinner = new SpinnerSegment(SpinnerStyle.Dots);
+        var block = new BlockSegment(spinner);
+
+        Assert.True(block.IsAnimating);
+
+        spinner.Dispose();
+    }
+
+    [Fact]
+    public void BlockSegment_Dispose_DisposesInner()
+    {
+        var spinner = new SpinnerSegment(SpinnerStyle.Dots);
+        var block = new BlockSegment(spinner);
+
+        block.Dispose();
+
+        // After dispose, spinner should stop animating
+        Assert.False(spinner.IsAnimating);
+    }
+}

--- a/tests/Termina.Tests/Layout/StreamingTextNodeBlockSegmentTests.cs
+++ b/tests/Termina.Tests/Layout/StreamingTextNodeBlockSegmentTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Termina.Components.Streaming;
+using Termina.Layout;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for BlockSegment functionality in StreamingTextNode.
+/// </summary>
+public class StreamingTextNodeBlockSegmentTests
+{
+    [Fact]
+    public void AppendTracked_BlockSegment_StartsOnNewLine_WhenCurrentLineHasContent()
+    {
+        var node = StreamingTextNode.Create();
+        node.Append("First line content");
+
+        var id = new SegmentId(1);
+        node.AppendTracked(id, new StaticTextSegment("Block content", TextStyle.Default).AsBlock());
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal(2, lines.Count);
+        Assert.Equal("First line content", lines[0].ToPlainText());
+        Assert.Equal("Block content", lines[1].ToPlainText());
+    }
+
+    [Fact]
+    public void AppendTracked_BlockSegment_DoesNotAddExtraLine_WhenCurrentLineEmpty()
+    {
+        var node = StreamingTextNode.Create();
+
+        var id = new SegmentId(1);
+        node.AppendTracked(id, new StaticTextSegment("Block content", TextStyle.Default).AsBlock());
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Single(lines);
+        Assert.Equal("Block content", lines[0].ToPlainText());
+    }
+
+    [Fact]
+    public void AppendTracked_BlockSegment_CanBeRemoved()
+    {
+        var node = StreamingTextNode.Create();
+        var id = new SegmentId(1);
+        node.AppendTracked(id, new StaticTextSegment("Thinking...", TextStyle.Default).AsBlock());
+
+        var removed = node.Remove(id);
+
+        Assert.True(removed);
+        Assert.False(node.Buffer.HasContent);
+    }
+
+    [Fact]
+    public void AppendTracked_MultipleBlockSegments_EachStartsOnNewLine()
+    {
+        var node = StreamingTextNode.Create();
+        node.Append("Line 1");
+
+        var id1 = new SegmentId(1);
+        node.AppendTracked(id1, new StaticTextSegment("Block 1", TextStyle.Default).AsBlock());
+
+        var id2 = new SegmentId(2);
+        node.AppendTracked(id2, new StaticTextSegment("Block 2", TextStyle.Default).AsBlock());
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal(3, lines.Count);
+        Assert.Equal("Line 1", lines[0].ToPlainText());
+        Assert.Equal("Block 1", lines[1].ToPlainText());
+        Assert.Equal("Block 2", lines[2].ToPlainText());
+    }
+
+    [Fact]
+    public void Replace_WithBlockSegment_StartsOnNewLine()
+    {
+        var node = StreamingTextNode.Create();
+        node.Append("Prefix ");
+
+        var id = new SegmentId(1);
+        node.AppendTracked(id, new StaticTextSegment("Original", TextStyle.Default));
+
+        // Replace with block segment
+        node.Replace(id, new StaticTextSegment("Replaced Block", TextStyle.Default).AsBlock());
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal(2, lines.Count);
+        Assert.Equal("Prefix ", lines[0].ToPlainText());
+        Assert.Equal("Replaced Block", lines[1].ToPlainText());
+    }
+
+    [Fact]
+    public void AppendTracked_BlockSegment_AfterAppendLine()
+    {
+        var node = StreamingTextNode.Create();
+        node.AppendLine("Complete line");
+
+        var id = new SegmentId(1);
+        node.AppendTracked(id, new StaticTextSegment("Block on new line", TextStyle.Default).AsBlock());
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal(2, lines.Count);
+        Assert.Equal("Complete line", lines[0].ToPlainText());
+        Assert.Equal("Block on new line", lines[1].ToPlainText());
+    }
+
+    [Fact]
+    public void AppendTracked_BlockWithCompositeSegment()
+    {
+        var node = StreamingTextNode.Create();
+        node.Append("Before");
+
+        var composite = new CompositeTextSegment(
+            new StaticTextSegment("[", TextStyle.Default),
+            new StaticTextSegment("Status", Color.Green),
+            new StaticTextSegment("]", TextStyle.Default)
+        ).AsBlock();
+
+        var id = new SegmentId(1);
+        node.AppendTracked(id, composite);
+
+        var lines = node.Buffer.GetAllStyledLines();
+        Assert.Equal(2, lines.Count);
+        Assert.Equal("Before", lines[0].ToPlainText());
+        Assert.Equal("[Status]", lines[1].ToPlainText());
+    }
+
+    [Fact]
+    public async Task AppendTracked_BlockWithAnimatedSegment_UpdatesInPlace()
+    {
+        var node = StreamingTextNode.Create();
+        node.Append("Static line");
+
+        var spinner = new SpinnerSegment(Termina.Components.Streaming.SpinnerStyle.Dots, intervalMs: 10);
+        var blockSpinner = spinner.AsBlock();
+
+        var id = new SegmentId(2);
+        node.AppendTracked(id, blockSpinner);
+
+        var frame1 = node.Buffer.GetAllStyledLines()[1].ToPlainText();
+
+        // Wait for animation frame
+        await spinner.Invalidated.FirstAsync().Timeout(TimeSpan.FromSeconds(1));
+
+        var frame2 = node.Buffer.GetAllStyledLines()[1].ToPlainText();
+
+        Assert.NotEqual(frame1, frame2);
+        Assert.Equal(2, node.Buffer.GetAllStyledLines().Count); // Still 2 lines
+
+        spinner.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
Implements #107 - Adds `BlockSegment` wrapper and `.AsBlock()` fluent API for text segments that need to render as block elements starting on new lines with vertical word wrapping.

## Changes
- Added `BlockSegment` class that wraps any `ITextSegment` and signals block-level rendering
- Added `TextSegmentExtensions.AsBlock()` fluent API for creating block segments
- Added `HasContentOnCurrentLine` property to `IStreamingTextBuffer` interface
- Implemented `HasContentOnCurrentLine` in both `PersistedStreamBuffer` and `WindowedStreamBuffer`
- Modified `StreamingTextNode` to detect `BlockSegment` and automatically insert newlines
- Supports both static and animated content (spinners, status indicators)

## Use Case
Enables LLM agent "thinking" displays and similar streaming content that should:
- Update in-place within a fixed area
- Wrap text vertically rather than scrolling horizontally
- Not push surrounding content around

## Test Coverage
- Added `BlockSegmentTests.cs` with 7 tests covering wrapper behavior and animation propagation
- Added `StreamingTextNodeBlockSegmentTests.cs` with 7 tests covering block rendering in streaming nodes
- All 749 tests passing