### PR TITLE
Fix nullability propagation in [Reactive] source generator

### DIFF
--- a/src/Termina.Generators/ReactivePropertyGenerator.cs
+++ b/src/Termina.Generators/ReactivePropertyGenerator.cs
@@ -29,6 +29,18 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
     private const string FromRouteAttributeFullName = "Termina.Routing.FromRouteAttribute";
 
     /// <summary>
+    /// Symbol display format that includes nullable reference type annotations (e.g., string? instead of string).
+    /// Based on FullyQualifiedFormat but with IncludeNullableReferenceTypeModifier added.
+    /// </summary>
+    private static readonly SymbolDisplayFormat FullyQualifiedFormatWithNullability = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
+                              SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
+                              SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
+
+    /// <summary>
     /// Diagnostic reported when a ReactiveViewModel subclass has a custom Dispose() method
     /// but needs to call DisposeReactiveFields() to properly dispose generated BehaviorSubjects.
     /// </summary>
@@ -133,9 +145,9 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
             }
         }
 
-        // Get field name and type
+        // Get field name and type (including nullability annotations)
         var fieldName = fieldSymbol.Name;
-        var fieldType = fieldSymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var fieldType = fieldSymbol.Type.ToDisplayString(FullyQualifiedFormatWithNullability);
 
         // Get the initial value if present
         string? initialValue = null;

--- a/tests/Termina.Tests/ReactiveViewModelTests.cs
+++ b/tests/Termina.Tests/ReactiveViewModelTests.cs
@@ -196,6 +196,37 @@ public class ReactiveViewModelTests
         Assert.Throws<ObjectDisposedException>(() => vm.Value = 100);
     }
 
+    [Fact]
+    public void ReactiveViewModel_WithNullableFields_PreservesNullability()
+    {
+        var vm = new TestReactiveViewModelWithNullable();
+
+        // Properties should be nullable and initially null
+        Assert.Null(vm.NullableString);
+        Assert.Null(vm.NullableInt);
+        Assert.Null(vm.NullableObject);
+
+        // Can set to non-null values
+        vm.NullableString = "test";
+        vm.NullableInt = 42;
+        vm.NullableObject = new object();
+
+        Assert.Equal("test", vm.NullableString);
+        Assert.Equal(42, vm.NullableInt);
+        Assert.NotNull(vm.NullableObject);
+
+        // Can set back to null
+        vm.NullableString = null;
+        vm.NullableInt = null;
+        vm.NullableObject = null;
+
+        Assert.Null(vm.NullableString);
+        Assert.Null(vm.NullableInt);
+        Assert.Null(vm.NullableObject);
+
+        vm.Dispose();
+    }
+
     private class TestViewModel : ReactiveViewModel
     {
         public bool WasActivated { get; private set; }
@@ -248,5 +279,15 @@ public partial class TestReactiveViewModelWithCustomDispose : ReactiveViewModel
         DisposeReactiveFields();
         base.Dispose();
     }
+}
+
+/// <summary>
+/// Test ViewModel with nullable [Reactive] fields to verify nullability annotations are preserved.
+/// </summary>
+public partial class TestReactiveViewModelWithNullable : ReactiveViewModel
+{
+    [Reactive] private string? _nullableString = null;
+    [Reactive] private int? _nullableInt = null;
+    [Reactive] private object? _nullableObject = null;
 }
 


### PR DESCRIPTION
## Summary
- Fix nullability annotations not being preserved in generated properties from `[Reactive]` fields
- Add custom `SymbolDisplayFormat` with `IncludeNullableReferenceTypeModifier` option
- Add tests for nullable reactive fields

## Problem
The source generator was using `SymbolDisplayFormat.FullyQualifiedFormat` which doesn't include nullable reference type annotations. This caused nullable fields like `string? _field` to generate non-nullable properties, losing the nullability hints.

## Solution
Created a custom `SymbolDisplayFormat` that includes the `IncludeNullableReferenceTypeModifier` option, ensuring types like `string?`, `int?`, and custom nullable types preserve their nullability in generated code.

## Test plan
- [x] Added `TestReactiveViewModelWithNullable` test class with nullable fields
- [x] Added `ReactiveViewModel_WithNullableFields_PreservesNullability` test
- [x] All 750 tests pass