### PR TITLE
Add missing demo projects to solution and mark benchmarks non-packable

### DIFF
--- a/Termina.slnx
+++ b/Termina.slnx
@@ -12,6 +12,8 @@
   </Folder>
   <Folder Name="/demos/">
     <Project Path="demos/Termina.Demo/Termina.Demo.csproj" />
+    <Project Path="demos/Termina.Demo.Gallery/Termina.Demo.Gallery.csproj" />
+    <Project Path="demos/Termina.Demo.Grid/Termina.Demo.Grid.csproj" />
     <Project Path="demos/Termina.Demo.RegionBased/Termina.Demo.RegionBased.csproj" />
     <Project Path="demos/Termina.Demo.Streaming/Termina.Demo.Streaming.csproj" />
   </Folder>

--- a/benchmarks/Termina.Benchmarks/Termina.Benchmarks.csproj
+++ b/benchmarks/Termina.Benchmarks/Termina.Benchmarks.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Added `Termina.Demo.Gallery` and `Termina.Demo.Grid` to the solution file (they were missing)
- Set `IsPackable=false` on the benchmark project to exclude it from NuGet packaging

## Test plan
- [ ] Verify solution loads correctly with all demo projects
- [ ] Verify `dotnet build` succeeds