### PR TITLE
Add scrollbar, mouse wheel scroll, and paste features

### DIFF
--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -33,7 +33,8 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
     {
         // Create layout nodes
         _chatHistory = StreamingTextNode.Create()
-            .WithPrefix("  ", Color.Gray);
+            .WithPrefix("  ", Color.Gray)
+            .WithScrollbar();
 
         _promptInput = new TextInputNode()
             .WithPlaceholder("Enter your question...")
@@ -94,6 +95,23 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
         // Handle keyboard input - Page routes to interactive layout nodes
         ViewModel.Input.OfType<KeyPressed>()
             .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+
+        // Route bracketed paste events to the prompt input
+        ViewModel.Input.OfType<PasteEvent>()
+            .Subscribe(paste => _promptInput.HandlePaste(paste))
+            .DisposeWith(Subscriptions);
+
+        // Route mouse scroll events to chat history (when no focused IScrollable captures them)
+        ViewModel.Input.OfType<MouseScrollEvent>()
+            .Subscribe(scroll =>
+            {
+                IScrollable scrollable = _chatHistory;
+                if (scroll.Delta > 0)
+                    scrollable.ScrollUp(3);
+                else
+                    scrollable.ScrollDown(3);
+            })
             .DisposeWith(Subscriptions);
 
         // Emit welcome message
@@ -272,8 +290,8 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                     (isGenerating, showDecision) => showDecision
                         ? "[↑/↓] Navigate [Enter] Select [1-4] Quick Select [Esc] Skip"
                         : isGenerating
-                            ? "[Esc] Cancel [PgUp/PgDn] Scroll [Ctrl+Q] Quit"
-                            : "[Enter] Send [↑/↓] History [PgUp/PgDn] Scroll [Esc] Clear/Quit [Ctrl+Q] Quit")
+                            ? "[Esc] Cancel  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit"
+                            : "[Enter/Paste] Send  [↑/↓] History  [PgUp/PgDn/Wheel] Scroll  [Esc] Clear/Quit  [Ctrl+Q] Quit")
                     .Select(text => new TextNode(text).WithForeground(Color.BrightBlack).NoWrap())
                     .AsLayout()
                     .Height(1))

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -291,7 +291,7 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                         ? "[↑/↓] Navigate [Enter] Select [1-4] Quick Select [Esc] Skip"
                         : isGenerating
                             ? "[Esc] Cancel  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit"
-                            : "[Enter/Paste] Send  [↑/↓] History  [PgUp/PgDn/Wheel] Scroll  [Esc] Clear/Quit  [Ctrl+Q] Quit")
+                            : "[Enter] Send  [Ctrl+Shift+V] Paste  [↑/↓] History  [PgUp/PgDn/Wheel] Scroll  [Esc] Clear/Quit  [Ctrl+Q] Quit")
                     .Select(text => new TextNode(text).WithForeground(Color.BrightBlack).NoWrap())
                     .AsLayout()
                     .Height(1))

--- a/docs/components/streaming-text-node.md
+++ b/docs/components/streaming-text-node.md
@@ -574,6 +574,78 @@ Most content should be untracked. Only use tracked segments for dynamic elements
 - **Status indicators**: Live updating connection status, typing indicators
 - **Placeholders**: Temporary content replaced when data loads
 
+## Scrollbar
+
+`StreamingTextNode` can display a visual scrollbar to indicate the current scroll position within the content. The scrollbar auto-hides when all content fits in the viewport.
+
+### Basic Scrollbar
+
+```csharp
+var stream = StreamingTextNode.Create()
+    .WithScrollbar();  // Enable with default options
+```
+
+### Custom Scrollbar
+
+```csharp
+var stream = StreamingTextNode.Create()
+    .WithScrollbar(new ScrollbarOptions(
+        TrackChar: '│',         // Default: '░'
+        ThumbChar: '┃',         // Default: '█'
+        TrackColor: Color.BrightBlack,  // Default: BrightBlack
+        ThumbColor: Color.Cyan,         // Default: White
+        AutoHide: true          // Default: true (hide when content fits)
+    ));
+```
+
+### ScrollbarOptions
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `TrackChar` | `char` | `'░'` | Character for the track (non-thumb area) |
+| `ThumbChar` | `char` | `'█'` | Character for the thumb (position indicator) |
+| `TrackColor` | `Color?` | `BrightBlack` | Track foreground color |
+| `ThumbColor` | `Color?` | `White` | Thumb foreground color |
+| `AutoHide` | `bool` | `true` | Hide scrollbar when content fits in viewport |
+
+The scrollbar occupies 1 column on the right edge, reducing the content area width by 1. When `AutoHide` is `true` (the default), the full width is available until content exceeds the viewport.
+
+## Mouse Wheel Scrolling
+
+`StreamingTextNode` implements `IScrollable`, which enables automatic mouse wheel scroll support. When a `StreamingTextNode` has focus, mouse wheel events are routed to it automatically — no additional code is needed.
+
+```csharp
+// Mouse wheel scrolling works automatically when the node has focus
+var stream = StreamingTextNode.Create()
+    .WithScrollbar();  // Visual indicator of scroll position
+
+// The framework routes MouseScrollEvent to IScrollable.ScrollUp/ScrollDown
+// Each wheel tick scrolls 3 lines
+```
+
+### Scroll State
+
+Query the current scroll state programmatically:
+
+```csharp
+var canUp = stream.CanScrollUp;    // More content above?
+var canDown = stream.CanScrollDown; // More content below?
+```
+
+### IScrollable Interface
+
+Any component that implements `IScrollable` automatically receives mouse wheel events when focused:
+
+```csharp
+public interface IScrollable
+{
+    bool CanScrollUp { get; }
+    bool CanScrollDown { get; }
+    void ScrollUp(int lines = 1);
+    void ScrollDown(int lines = 1);
+}
+```
+
 ## Scrolling API
 
 For persisted buffers:
@@ -598,6 +670,7 @@ stream.HandleInput(keyInfo, viewportHeight: 20, viewportWidth: 80);
 | `PageDown` | Scroll down one page |
 | `Ctrl+Home` | Scroll to top |
 | `Ctrl+End` | Scroll to bottom |
+| Mouse wheel | Scroll 3 lines per tick |
 
 ## Real-World Example
 
@@ -650,6 +723,8 @@ StreamingTextNode.CreateWindowed(windowSize: 100)
 | `Prefix` | `string?` | Line prefix |
 | `PrefixColor` | `Color?` | Prefix color |
 | `ContentChanged` | `IObservable<Unit>` | Content change notifications |
+| `CanScrollUp` | `bool` | Whether content exists above viewport |
+| `CanScrollDown` | `bool` | Whether content exists below viewport |
 
 ### Methods
 
@@ -688,6 +763,8 @@ StreamingTextNode.CreateWindowed(windowSize: 100)
 | `.WithForeground(Color)` | Set default text color |
 | `.WithBackground(Color)` | Set default background color |
 | `.WithPrefix(string, Color?)` | Set line prefix |
+| `.WithScrollbar()` | Enable scrollbar with default options |
+| `.WithScrollbar(ScrollbarOptions)` | Enable scrollbar with custom options |
 
 ## Source Code
 

--- a/docs/components/text-input-node.md
+++ b/docs/components/text-input-node.md
@@ -126,6 +126,48 @@ public class MyPage : ReactivePage<MyViewModel>
 }
 ```
 
+## Paste Handling
+
+`TextInputNode` implements `IPasteReceiver` and automatically handles bracketed paste mode. When the user pastes text from the clipboard, Termina detects the terminal's paste escape sequences and delivers the content as a single `PasteEvent` rather than individual key presses.
+
+### How It Works
+
+1. The user pastes text (Ctrl+V or right-click paste)
+2. The terminal wraps the content in `ESC[200~...ESC[201~` markers
+3. Termina detects the markers and emits a `PasteEvent`
+4. `TextInputNode` shows a summary: `[Pasted 500 lines, 12345 chars]`
+5. On **Enter**, the full paste content (with newlines preserved) is submitted
+6. On any **editing action** (typing, backspace, delete, escape), the paste is cleared
+
+This prevents multi-line pastes from triggering individual submissions for each line — a common issue in terminal applications.
+
+```csharp
+// Paste handling is automatic — no additional setup needed
+var input = new TextInputNode()
+    .WithPlaceholder("Paste or type here...");
+
+// Submitted receives the full paste content when Enter is pressed
+input.Submitted.Subscribe(text =>
+{
+    // 'text' contains the full paste with newlines preserved
+    Console.WriteLine($"Received {text.Length} chars");
+});
+```
+
+### Paste in ViewModels
+
+If you need to handle paste events at the ViewModel level (e.g., when no `TextInputNode` has focus):
+
+```csharp
+Input.OfType<PasteEvent>()
+    .Subscribe(paste =>
+    {
+        // paste.Content contains the full pasted text
+        ProcessPastedContent(paste.Content);
+    })
+    .DisposeWith(Subscriptions);
+```
+
 ## Observables
 
 | Observable | Type | Description |
@@ -153,6 +195,7 @@ public class MyPage : ReactivePage<MyViewModel>
 | Method | Description |
 |--------|-------------|
 | `HandleInput(ConsoleKeyInfo)` | Process a key press |
+| `HandlePaste(PasteEvent)` | Handle bracketed paste (implements `IPasteReceiver`) |
 | `Clear()` | Clear text and reset cursor |
 | `Start()` | Start cursor animation |
 | `Stop()` | Stop cursor animation |

--- a/docs/concepts/input-handling.md
+++ b/docs/concepts/input-handling.md
@@ -211,7 +211,20 @@ All input events implement `IInputEvent`. The framework provides:
 
 - `KeyPressed` - Keyboard input
 - `MouseEvent` - Mouse clicks, movement, scrolling
+- `MouseScrollEvent` - Mouse wheel scroll (routed to `IScrollable` components)
+- `PasteEvent` - Bracketed paste (routed to `IPasteReceiver` components)
 - `ResizeEvent` - Terminal window resize
+
+### Automatic Routing
+
+Some events are automatically routed to the focused component before reaching the ViewModel's `Input` observable:
+
+| Event | Routed To | Fallback |
+|-------|-----------|----------|
+| `MouseScrollEvent` | Focused `IScrollable` component | `ViewModel.Input` |
+| `PasteEvent` | Focused `IPasteReceiver` component | `ViewModel.Input` |
+
+This means `StreamingTextNode` (which implements `IScrollable`) automatically handles mouse wheel scrolling, and `TextInputNode` (which implements `IPasteReceiver`) automatically handles paste — no manual wiring needed.
 
 ## Keyboard Input Details
 
@@ -317,6 +330,45 @@ Input.OfType<ResizeEvent>()
     .DisposeWith(Subscriptions);
 ```
 
+## Mouse Wheel Scrolling
+
+Mouse wheel events are detected via SGR mouse escape sequences and emitted as `MouseScrollEvent`:
+
+```csharp
+Input.OfType<MouseScrollEvent>()
+    .Subscribe(scroll =>
+    {
+        // scroll.Delta: +1 = scroll up, -1 = scroll down
+        if (scroll.Delta > 0)
+            ScrollContentUp();
+        else
+            ScrollContentDown();
+    })
+    .DisposeWith(Subscriptions);
+```
+
+::: tip Automatic Routing
+If the focused component implements `IScrollable` (like `StreamingTextNode`), mouse scroll events are routed directly to it — each tick scrolls 3 lines. The event only reaches `ViewModel.Input` if no `IScrollable` component has focus.
+:::
+
+## Paste Events
+
+Termina automatically enables [bracketed paste mode](https://en.wikipedia.org/wiki/Bracketed-paste) so multi-line pastes are received as a single `PasteEvent` instead of individual key presses:
+
+```csharp
+Input.OfType<PasteEvent>()
+    .Subscribe(paste =>
+    {
+        // paste.Content contains the full text including newlines
+        var lines = paste.Content.Split('\n');
+    })
+    .DisposeWith(Subscriptions);
+```
+
+::: tip Automatic Routing
+If the focused component implements `IPasteReceiver` (like `TextInputNode`), paste events are routed directly to it. `TextInputNode` shows a summary placeholder and submits the full content on Enter. The event only reaches `ViewModel.Input` if no `IPasteReceiver` component has focus.
+:::
+
 ## Input Filtering with Rx
 
 ### Filter by Type
@@ -412,4 +464,20 @@ Input.OfType<KeyPressed>()
 
 ::: details View ResizeEvent
 <<< @/../src/Termina/Input/ResizeEvent.cs{csharp}
+:::
+
+::: details View MouseScrollEvent
+<<< @/../src/Termina/Input/MouseScrollEvent.cs{csharp}
+:::
+
+::: details View PasteEvent
+<<< @/../src/Termina/Input/PasteEvent.cs{csharp}
+:::
+
+::: details View IPasteReceiver
+<<< @/../src/Termina/Input/IPasteReceiver.cs{csharp}
+:::
+
+::: details View IScrollable
+<<< @/../src/Termina/Layout/IScrollable.cs{csharp}
 :::

--- a/src/Termina/Components/Streaming/PersistedStreamBuffer.cs
+++ b/src/Termina/Components/Streaming/PersistedStreamBuffer.cs
@@ -342,7 +342,15 @@ public class PersistedStreamBuffer : IStreamingTextBuffer
         }
     }
 
-    private int GetMaxScrollOffset(int viewportWidth)
+    /// <summary>
+    /// Returns the maximum scroll offset for the given viewport width.
+    /// At maximum offset, the oldest content is visible at the bottom of the viewport.
+    /// </summary>
+    /// <param name="viewportWidth">
+    /// The width of the content area in columns, used for word-wrap calculations.
+    /// This should be the content width excluding any prefix or scrollbar columns.
+    /// </param>
+    public int GetMaxScrollOffset(int viewportWidth)
     {
         var totalWrapped = GetWrappedLineCount(viewportWidth);
         return Math.Max(0, totalWrapped - 1); // Can scroll up to see first line at bottom

--- a/src/Termina/Input/ConsoleInputSource.cs
+++ b/src/Termina/Input/ConsoleInputSource.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Threading.Channels;
 
 namespace Termina.Input;
@@ -6,23 +5,13 @@ namespace Termina.Input;
 /// <summary>
 /// Real console input source that reads from Console.ReadKey and detects terminal resize.
 /// Runs on a background thread since ReadKey is blocking.
-/// Also handles bracketed paste mode sequences and SGR mouse scroll events.
+/// Escape sequences are decoded by <see cref="EscapeSequenceParser"/>.
 /// </summary>
 public sealed class ConsoleInputSource : IInputSource
 {
     private int _lastWidth;
     private int _lastHeight;
-
-    // Paste / escape-sequence detection state machine
-    private enum PasteDetectionState { Normal, AfterEscape, InBracketSequence, PasteBuffering }
-    private PasteDetectionState _pasteState = PasteDetectionState.Normal;
-    private readonly StringBuilder _seqBuffer = new();
-    private readonly StringBuilder _pasteBuffer = new();
-    private long _escapeReceivedAt;   // Environment.TickCount64 when ESC was seen
-    private int _pendingEndSeqPos;    // how many chars of _pasteEndSeq we've matched so far
-
-    // The bracketed-paste end sentinel: ESC [ 2 0 1 ~
-    private const string PasteEndSeq = "\x1b[201~";
+    private readonly EscapeSequenceParser _parser = new();
 
     /// <inheritdoc />
     public async Task RunAsync(ChannelWriter<object> writer, CancellationToken cancellationToken)
@@ -35,21 +24,15 @@ public sealed class ConsoleInputSource : IInputSource
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                // Flush a lone ESC if 50 ms have passed with no follow-up character
-                if (_pasteState == PasteDetectionState.AfterEscape &&
-                    Environment.TickCount64 - _escapeReceivedAt > 50)
-                {
-                    await writer.WriteAsync(
-                        new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)),
-                        cancellationToken);
-                    _pasteState = PasteDetectionState.Normal;
-                }
+                var escEvent = _parser.CheckEscapeTimeout();
+                if (escEvent is not null)
+                    await writer.WriteAsync(escEvent, cancellationToken);
 
                 // Check if key available to avoid blocking forever on cancellation
                 if (Console.KeyAvailable)
                 {
                     var key = Console.ReadKey(intercept: true);
-                    await ProcessKeyAsync(key, writer, cancellationToken);
+                    await EmitParsedEventsAsync(key, writer, cancellationToken);
                 }
                 else
                 {
@@ -63,149 +46,13 @@ public sealed class ConsoleInputSource : IInputSource
         }, cancellationToken);
     }
 
-    private async Task ProcessKeyAsync(ConsoleKeyInfo key, ChannelWriter<object> writer, CancellationToken ct)
+    private async Task EmitParsedEventsAsync(ConsoleKeyInfo key, ChannelWriter<object> writer, CancellationToken ct)
     {
-        switch (_pasteState)
+        var events = _parser.Process(key);
+        foreach (var inputEvent in events)
         {
-            case PasteDetectionState.Normal:
-                if (key.Key == ConsoleKey.Escape)
-                {
-                    _escapeReceivedAt = Environment.TickCount64;
-                    _pasteState = PasteDetectionState.AfterEscape;
-                }
-                else
-                {
-                    await writer.WriteAsync(new KeyPressed(key), ct);
-                }
-                break;
-
-            case PasteDetectionState.AfterEscape:
-                if (key.KeyChar == '[')
-                {
-                    _seqBuffer.Clear();
-                    _seqBuffer.Append('[');
-                    _pasteState = PasteDetectionState.InBracketSequence;
-                }
-                else
-                {
-                    // Not a CSI sequence — flush ESC and re-process the current key
-                    await writer.WriteAsync(
-                        new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)),
-                        ct);
-                    _pasteState = PasteDetectionState.Normal;
-                    await ProcessKeyAsync(key, writer, ct);
-                }
-                break;
-
-            case PasteDetectionState.InBracketSequence:
-                _seqBuffer.Append(key.KeyChar);
-                var seq = _seqBuffer.ToString();
-
-                // Detected bracketed paste start: ESC[200~
-                if (seq == "[200~")
-                {
-                    _pasteBuffer.Clear();
-                    _pendingEndSeqPos = 0;
-                    _pasteState = PasteDetectionState.PasteBuffering;
-                    break;
-                }
-
-                // Detected SGR mouse event: ESC[<button;x;yM or ESC[<button;x;ym
-                if (seq.Length >= 2 && seq[1] == '<' && (key.KeyChar == 'M' || key.KeyChar == 'm'))
-                {
-                    EmitMouseSgrEvent(seq, writer);
-                    _seqBuffer.Clear();
-                    _pasteState = PasteDetectionState.Normal;
-                    break;
-                }
-
-                // Check whether the accumulated sequence could still match a known pattern
-                if (!CouldLeadToRecognizedSequence(seq))
-                {
-                    // Unrecognized — flush ESC and the accumulated sequence characters as key presses
-                    await writer.WriteAsync(
-                        new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)),
-                        ct);
-                    foreach (var c in seq)
-                    {
-                        await writer.WriteAsync(
-                            new KeyPressed(new ConsoleKeyInfo(c, ConsoleKey.None, false, false, false)),
-                            ct);
-                    }
-                    _seqBuffer.Clear();
-                    _pasteState = PasteDetectionState.Normal;
-                }
-                break;
-
-            case PasteDetectionState.PasteBuffering:
-                // Detect the end sentinel ESC[201~ one character at a time
-                var isEscChar = key.Key == ConsoleKey.Escape || key.KeyChar == '\x1b';
-                var expectedChar = _pendingEndSeqPos == 0 ? '\x1b' : PasteEndSeq[_pendingEndSeqPos];
-                var charMatches = _pendingEndSeqPos == 0 ? isEscChar : key.KeyChar == expectedChar;
-
-                if (charMatches)
-                {
-                    _pendingEndSeqPos++;
-                    if (_pendingEndSeqPos == PasteEndSeq.Length)
-                    {
-                        // Paste complete
-                        await writer.WriteAsync(new PasteEvent(_pasteBuffer.ToString()), ct);
-                        _pasteBuffer.Clear();
-                        _pendingEndSeqPos = 0;
-                        _pasteState = PasteDetectionState.Normal;
-                    }
-                }
-                else if (_pendingEndSeqPos > 0)
-                {
-                    // Partial end-sequence match failed — those chars belong to the paste content
-                    _pasteBuffer.Append(PasteEndSeq[.._pendingEndSeqPos]);
-                    _pendingEndSeqPos = 0;
-                    _pasteBuffer.Append(key.KeyChar);
-                }
-                else
-                {
-                    _pasteBuffer.Append(key.KeyChar);
-                }
-                break;
+            await writer.WriteAsync(inputEvent, ct);
         }
-    }
-
-    /// <summary>
-    /// Returns true if the accumulated bracket sequence could still lead to a recognized escape sequence.
-    /// </summary>
-    private static bool CouldLeadToRecognizedSequence(string seq)
-    {
-        // Could be the paste start "[200~"
-        const string pasteStart = "[200~";
-        if (seq.Length <= pasteStart.Length && pasteStart.StartsWith(seq, StringComparison.Ordinal))
-            return true;
-
-        // Could be an SGR mouse event starting with "[<"
-        if (seq.Length >= 2 && seq[1] == '<' && seq.Length <= 20)
-            return true;
-
-        return false;
-    }
-
-    /// <summary>
-    /// Parses an SGR mouse scroll sequence and emits a <see cref="MouseScrollEvent"/> if applicable.
-    /// </summary>
-    private static void EmitMouseSgrEvent(string seq, ChannelWriter<object> writer)
-    {
-        // seq is "[<button;x;yM" or "[<button;x;ym"
-        // strip the leading "[<" and trailing 'M'/'m'
-        if (seq.Length < 3) return;
-        var inner = seq[2..^1]; // "button;x;y"
-        var semicolon = inner.IndexOf(';');
-        if (semicolon < 0) return;
-        if (!int.TryParse(inner[..semicolon], out var button)) return;
-
-        // SGR button 64 = scroll up, 65 = scroll down
-        if (button == 64)
-            writer.TryWrite(new MouseScrollEvent(+1));
-        else if (button == 65)
-            writer.TryWrite(new MouseScrollEvent(-1));
-        // All other mouse events are silently consumed
     }
 
     private void InitializeDimensions()

--- a/src/Termina/Input/ConsoleInputSource.cs
+++ b/src/Termina/Input/ConsoleInputSource.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Threading.Channels;
 
 namespace Termina.Input;
@@ -5,11 +6,23 @@ namespace Termina.Input;
 /// <summary>
 /// Real console input source that reads from Console.ReadKey and detects terminal resize.
 /// Runs on a background thread since ReadKey is blocking.
+/// Also handles bracketed paste mode sequences and SGR mouse scroll events.
 /// </summary>
 public sealed class ConsoleInputSource : IInputSource
 {
     private int _lastWidth;
     private int _lastHeight;
+
+    // Paste / escape-sequence detection state machine
+    private enum PasteDetectionState { Normal, AfterEscape, InBracketSequence, PasteBuffering }
+    private PasteDetectionState _pasteState = PasteDetectionState.Normal;
+    private readonly StringBuilder _seqBuffer = new();
+    private readonly StringBuilder _pasteBuffer = new();
+    private long _escapeReceivedAt;   // Environment.TickCount64 when ESC was seen
+    private int _pendingEndSeqPos;    // how many chars of _pasteEndSeq we've matched so far
+
+    // The bracketed-paste end sentinel: ESC [ 2 0 1 ~
+    private const string PasteEndSeq = "\x1b[201~";
 
     /// <inheritdoc />
     public async Task RunAsync(ChannelWriter<object> writer, CancellationToken cancellationToken)
@@ -22,11 +35,21 @@ public sealed class ConsoleInputSource : IInputSource
         {
             while (!cancellationToken.IsCancellationRequested)
             {
+                // Flush a lone ESC if 50 ms have passed with no follow-up character
+                if (_pasteState == PasteDetectionState.AfterEscape &&
+                    Environment.TickCount64 - _escapeReceivedAt > 50)
+                {
+                    await writer.WriteAsync(
+                        new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)),
+                        cancellationToken);
+                    _pasteState = PasteDetectionState.Normal;
+                }
+
                 // Check if key available to avoid blocking forever on cancellation
                 if (Console.KeyAvailable)
                 {
                     var key = Console.ReadKey(intercept: true);
-                    await writer.WriteAsync(new KeyPressed(key), cancellationToken);
+                    await ProcessKeyAsync(key, writer, cancellationToken);
                 }
                 else
                 {
@@ -38,6 +61,151 @@ public sealed class ConsoleInputSource : IInputSource
                 await CheckForResizeAsync(writer, cancellationToken);
             }
         }, cancellationToken);
+    }
+
+    private async Task ProcessKeyAsync(ConsoleKeyInfo key, ChannelWriter<object> writer, CancellationToken ct)
+    {
+        switch (_pasteState)
+        {
+            case PasteDetectionState.Normal:
+                if (key.Key == ConsoleKey.Escape)
+                {
+                    _escapeReceivedAt = Environment.TickCount64;
+                    _pasteState = PasteDetectionState.AfterEscape;
+                }
+                else
+                {
+                    await writer.WriteAsync(new KeyPressed(key), ct);
+                }
+                break;
+
+            case PasteDetectionState.AfterEscape:
+                if (key.KeyChar == '[')
+                {
+                    _seqBuffer.Clear();
+                    _seqBuffer.Append('[');
+                    _pasteState = PasteDetectionState.InBracketSequence;
+                }
+                else
+                {
+                    // Not a CSI sequence — flush ESC and re-process the current key
+                    await writer.WriteAsync(
+                        new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)),
+                        ct);
+                    _pasteState = PasteDetectionState.Normal;
+                    await ProcessKeyAsync(key, writer, ct);
+                }
+                break;
+
+            case PasteDetectionState.InBracketSequence:
+                _seqBuffer.Append(key.KeyChar);
+                var seq = _seqBuffer.ToString();
+
+                // Detected bracketed paste start: ESC[200~
+                if (seq == "[200~")
+                {
+                    _pasteBuffer.Clear();
+                    _pendingEndSeqPos = 0;
+                    _pasteState = PasteDetectionState.PasteBuffering;
+                    break;
+                }
+
+                // Detected SGR mouse event: ESC[<button;x;yM or ESC[<button;x;ym
+                if (seq.Length >= 2 && seq[1] == '<' && (key.KeyChar == 'M' || key.KeyChar == 'm'))
+                {
+                    EmitMouseSgrEvent(seq, writer);
+                    _seqBuffer.Clear();
+                    _pasteState = PasteDetectionState.Normal;
+                    break;
+                }
+
+                // Check whether the accumulated sequence could still match a known pattern
+                if (!CouldLeadToRecognizedSequence(seq))
+                {
+                    // Unrecognized — flush ESC and the accumulated sequence characters as key presses
+                    await writer.WriteAsync(
+                        new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)),
+                        ct);
+                    foreach (var c in seq)
+                    {
+                        await writer.WriteAsync(
+                            new KeyPressed(new ConsoleKeyInfo(c, ConsoleKey.None, false, false, false)),
+                            ct);
+                    }
+                    _seqBuffer.Clear();
+                    _pasteState = PasteDetectionState.Normal;
+                }
+                break;
+
+            case PasteDetectionState.PasteBuffering:
+                // Detect the end sentinel ESC[201~ one character at a time
+                var isEscChar = key.Key == ConsoleKey.Escape || key.KeyChar == '\x1b';
+                var expectedChar = _pendingEndSeqPos == 0 ? '\x1b' : PasteEndSeq[_pendingEndSeqPos];
+                var charMatches = _pendingEndSeqPos == 0 ? isEscChar : key.KeyChar == expectedChar;
+
+                if (charMatches)
+                {
+                    _pendingEndSeqPos++;
+                    if (_pendingEndSeqPos == PasteEndSeq.Length)
+                    {
+                        // Paste complete
+                        await writer.WriteAsync(new PasteEvent(_pasteBuffer.ToString()), ct);
+                        _pasteBuffer.Clear();
+                        _pendingEndSeqPos = 0;
+                        _pasteState = PasteDetectionState.Normal;
+                    }
+                }
+                else if (_pendingEndSeqPos > 0)
+                {
+                    // Partial end-sequence match failed — those chars belong to the paste content
+                    _pasteBuffer.Append(PasteEndSeq[.._pendingEndSeqPos]);
+                    _pendingEndSeqPos = 0;
+                    _pasteBuffer.Append(key.KeyChar);
+                }
+                else
+                {
+                    _pasteBuffer.Append(key.KeyChar);
+                }
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the accumulated bracket sequence could still lead to a recognized escape sequence.
+    /// </summary>
+    private static bool CouldLeadToRecognizedSequence(string seq)
+    {
+        // Could be the paste start "[200~"
+        const string pasteStart = "[200~";
+        if (seq.Length <= pasteStart.Length && pasteStart.StartsWith(seq, StringComparison.Ordinal))
+            return true;
+
+        // Could be an SGR mouse event starting with "[<"
+        if (seq.Length >= 2 && seq[1] == '<' && seq.Length <= 20)
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Parses an SGR mouse scroll sequence and emits a <see cref="MouseScrollEvent"/> if applicable.
+    /// </summary>
+    private static void EmitMouseSgrEvent(string seq, ChannelWriter<object> writer)
+    {
+        // seq is "[<button;x;yM" or "[<button;x;ym"
+        // strip the leading "[<" and trailing 'M'/'m'
+        if (seq.Length < 3) return;
+        var inner = seq[2..^1]; // "button;x;y"
+        var semicolon = inner.IndexOf(';');
+        if (semicolon < 0) return;
+        if (!int.TryParse(inner[..semicolon], out var button)) return;
+
+        // SGR button 64 = scroll up, 65 = scroll down
+        if (button == 64)
+            writer.TryWrite(new MouseScrollEvent(+1));
+        else if (button == 65)
+            writer.TryWrite(new MouseScrollEvent(-1));
+        // All other mouse events are silently consumed
     }
 
     private void InitializeDimensions()

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Termina.Input;
+
+/// <summary>
+/// Parses escape sequences from individual <see cref="ConsoleKeyInfo"/> values returned by
+/// <see cref="Console.ReadKey(bool)"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Console.ReadKey</c> does not parse terminal mouse or paste escape sequences — it returns
+/// each byte of the sequence as a separate <see cref="ConsoleKeyInfo"/>. This parser buffers
+/// those individual key events and detects:
+/// </para>
+/// <list type="bullet">
+///   <item><description>Bracketed paste: <c>ESC[200~</c>…content…<c>ESC[201~</c> → <see cref="PasteEvent"/></description></item>
+///   <item><description>SGR mouse scroll up: <c>ESC[&lt;64;x;yM</c> → <see cref="MouseScrollEvent"/>(<c>+1</c>)</description></item>
+///   <item><description>SGR mouse scroll down: <c>ESC[&lt;65;x;yM</c> → <see cref="MouseScrollEvent"/>(<c>-1</c>)</description></item>
+///   <item><description>Other SGR mouse events (clicks, releases): silently consumed — prevents spurious <c>ESC</c> keypresses.</description></item>
+///   <item><description>Standalone <c>ESC</c>: emitted as <see cref="KeyPressed"/> after a 50 ms timeout with no follow-up character.</description></item>
+/// </list>
+/// <para>
+/// Call <see cref="Process"/> for each key received. When <see cref="IsBufferingEscape"/> is
+/// <c>true</c>, the caller should use a short read timeout (≈50 ms) and call
+/// <see cref="CheckEscapeTimeout"/> when no key arrives in time.
+/// </para>
+/// </remarks>
+internal sealed class EscapeSequenceParser
+{
+    private enum State { Normal, AfterEscape, InBracketSequence, PasteBuffering }
+
+    private State _state = State.Normal;
+    private readonly StringBuilder _seqBuffer = new();
+    private readonly StringBuilder _pasteBuffer = new();
+    private long _escapeReceivedAt;
+    private int _pendingEndSeqPos;
+
+    private const string PasteEndSeq = "\x1b[201~";
+
+    // Injected clock for testing; defaults to Environment.TickCount64
+    private readonly Func<long> _getTick;
+
+    /// <summary>
+    /// Creates a parser using the system clock.
+    /// </summary>
+    public EscapeSequenceParser() : this(null) { }
+
+    /// <summary>
+    /// Creates a parser with an injectable clock function.
+    /// Pass a custom <paramref name="getTick"/> for deterministic unit tests.
+    /// </summary>
+    /// <param name="getTick">Returns the current tick in milliseconds. If null, uses <see cref="Environment.TickCount64"/>.</param>
+    internal EscapeSequenceParser(Func<long>? getTick)
+    {
+        _getTick = getTick ?? (() => Environment.TickCount64);
+    }
+
+    /// <summary>
+    /// Whether the parser is currently buffering an incomplete escape sequence.
+    /// When <c>true</c>, the caller should use a short read timeout so that a standalone
+    /// <c>ESC</c> key (with no follow-up) can be flushed via <see cref="CheckEscapeTimeout"/>.
+    /// </summary>
+    public bool IsBufferingEscape =>
+        _state == State.AfterEscape || _state == State.InBracketSequence;
+
+    /// <summary>
+    /// If 50 ms have elapsed since an <c>ESC</c> was buffered with no follow-up character,
+    /// resets state and returns a <see cref="KeyPressed"/> for the standalone <c>ESC</c>.
+    /// Returns <c>null</c> if no timeout has occurred.
+    /// </summary>
+    public KeyPressed? CheckEscapeTimeout()
+    {
+        if (_state == State.AfterEscape && _getTick() - _escapeReceivedAt > 50)
+        {
+            _state = State.Normal;
+            return new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false));
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Processes one key from <see cref="Console.ReadKey(bool)"/> and returns the application
+    /// events that should be emitted as a result. The list may be empty (e.g., while buffering
+    /// a multi-character escape sequence or silently consuming a mouse click event).
+    /// </summary>
+    /// <param name="key">The key to process.</param>
+    /// <returns>Zero or more <see cref="IInputEvent"/> instances to emit.</returns>
+    public IReadOnlyList<IInputEvent> Process(ConsoleKeyInfo key)
+    {
+        var results = new List<IInputEvent>(2);
+        ProcessCore(key, results);
+        return results;
+    }
+
+    private void ProcessCore(ConsoleKeyInfo key, List<IInputEvent> results)
+    {
+        switch (_state)
+        {
+            case State.Normal:
+                if (key.Key == ConsoleKey.Escape)
+                {
+                    _escapeReceivedAt = _getTick();
+                    _state = State.AfterEscape;
+                }
+                else
+                {
+                    results.Add(new KeyPressed(key));
+                }
+                break;
+
+            case State.AfterEscape:
+                if (key.KeyChar == '[')
+                {
+                    _seqBuffer.Clear();
+                    _seqBuffer.Append('[');
+                    _state = State.InBracketSequence;
+                }
+                else
+                {
+                    // Not a CSI sequence — flush ESC, then re-process this key as Normal
+                    results.Add(new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)));
+                    _state = State.Normal;
+                    ProcessCore(key, results);
+                }
+                break;
+
+            case State.InBracketSequence:
+                _seqBuffer.Append(key.KeyChar);
+                var seq = _seqBuffer.ToString();
+
+                // Bracketed paste start: ESC[200~
+                if (seq == "[200~")
+                {
+                    _pasteBuffer.Clear();
+                    _pendingEndSeqPos = 0;
+                    _state = State.PasteBuffering;
+                    break;
+                }
+
+                // SGR mouse event: ESC[<button;x;yM (press) or ESC[<button;x;ym (release)
+                if (seq.Length >= 2 && seq[1] == '<' && (key.KeyChar == 'M' || key.KeyChar == 'm'))
+                {
+                    EmitMouseSgrEvent(seq, results);
+                    _seqBuffer.Clear();
+                    _state = State.Normal;
+                    break;
+                }
+
+                // If this sequence can no longer match any recognized pattern, flush as raw keys
+                if (!CouldLeadToRecognizedSequence(seq))
+                {
+                    results.Add(new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)));
+                    foreach (var c in seq)
+                    {
+                        results.Add(new KeyPressed(new ConsoleKeyInfo(c, ConsoleKey.None, false, false, false)));
+                    }
+                    _seqBuffer.Clear();
+                    _state = State.Normal;
+                }
+                break;
+
+            case State.PasteBuffering:
+                // Detect ESC[201~ end sentinel one character at a time
+                var expectedChar = _pendingEndSeqPos == 0 ? '\x1b' : PasteEndSeq[_pendingEndSeqPos];
+                var isEscChar = key.Key == ConsoleKey.Escape || key.KeyChar == '\x1b';
+                var charMatches = _pendingEndSeqPos == 0 ? isEscChar : key.KeyChar == expectedChar;
+
+                if (charMatches)
+                {
+                    _pendingEndSeqPos++;
+                    if (_pendingEndSeqPos == PasteEndSeq.Length)
+                    {
+                        results.Add(new PasteEvent(_pasteBuffer.ToString()));
+                        _pasteBuffer.Clear();
+                        _pendingEndSeqPos = 0;
+                        _state = State.Normal;
+                    }
+                }
+                else if (_pendingEndSeqPos > 0)
+                {
+                    // Partial end-sequence match failed — the buffered chars belong to paste content
+                    _pasteBuffer.Append(PasteEndSeq[.._pendingEndSeqPos]);
+                    _pendingEndSeqPos = 0;
+                    _pasteBuffer.Append(key.KeyChar);
+                }
+                else
+                {
+                    _pasteBuffer.Append(key.KeyChar);
+                }
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the accumulated bracket sequence could still lead to a recognized
+    /// escape sequence. Used to decide whether to keep buffering or flush the sequence as raw keys.
+    /// </summary>
+    private static bool CouldLeadToRecognizedSequence(string seq)
+    {
+        // Could still be paste start "[200~"
+        const string pasteStart = "[200~";
+        if (seq.Length <= pasteStart.Length && pasteStart.StartsWith(seq, StringComparison.Ordinal))
+            return true;
+
+        // Could be an SGR mouse event "[<button;x;yM" — open-ended length up to ~30 chars
+        if (seq.Length >= 2 && seq[1] == '<' && seq.Length <= 30)
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Parses an SGR mouse sequence and appends a <see cref="MouseScrollEvent"/> to <paramref name="results"/>
+    /// when the button code indicates a scroll event (64 = up, 65 = down).
+    /// Other mouse events (clicks, releases) are silently consumed — no event is appended.
+    /// </summary>
+    /// <param name="seq">The buffered sequence string, e.g. <c>[&lt;64;5;10M</c>.</param>
+    /// <param name="results">List to append events into.</param>
+    private static void EmitMouseSgrEvent(string seq, List<IInputEvent> results)
+    {
+        // seq = "[<button;x;yM" or "[<button;x;ym"
+        // Strip leading "[<" and trailing terminator char
+        if (seq.Length < 3) return;
+        var inner = seq[2..^1]; // "button;x;y"
+        var semicolon = inner.IndexOf(';');
+        if (semicolon < 0) return;
+        if (!int.TryParse(inner[..semicolon], out var button)) return;
+
+        // SGR button 64 = wheel up, 65 = wheel down
+        if (button == 64)
+            results.Add(new MouseScrollEvent(+1));
+        else if (button == 65)
+            results.Add(new MouseScrollEvent(-1));
+        // All other buttons (clicks, releases, drags) are silently consumed
+    }
+}

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
 using System.Text;
+using Termina.Diagnostics;
 
 namespace Termina.Input;
 
@@ -97,6 +98,9 @@ internal sealed class EscapeSequenceParser
 
     private void ProcessCore(ConsoleKeyInfo key, List<IInputEvent> results)
     {
+        TerminaTrace.Input.Trace(this, "ESP: state={0} KeyChar=0x{1:X4} Key={2}",
+            _state, (int)key.KeyChar, key.Key);
+
         switch (_state)
         {
             case State.Normal:
@@ -104,6 +108,7 @@ internal sealed class EscapeSequenceParser
                 {
                     _escapeReceivedAt = _getTick();
                     _state = State.AfterEscape;
+                    TerminaTrace.Input.Debug(this, "ESP: ESC received → AfterEscape");
                 }
                 else
                 {
@@ -137,6 +142,7 @@ internal sealed class EscapeSequenceParser
                     _pasteBuffer.Clear();
                     _pendingEndSeqPos = 0;
                     _state = State.PasteBuffering;
+                    TerminaTrace.Input.Debug(this, "ESP: Paste start detected → PasteBuffering");
                     break;
                 }
 
@@ -173,6 +179,7 @@ internal sealed class EscapeSequenceParser
                     _pendingEndSeqPos++;
                     if (_pendingEndSeqPos == PasteEndSeq.Length)
                     {
+                        TerminaTrace.Input.Debug(this, "ESP: Paste end detected, {0} chars", _pasteBuffer.Length);
                         results.Add(new PasteEvent(_pasteBuffer.ToString()));
                         _pasteBuffer.Clear();
                         _pendingEndSeqPos = 0;

--- a/src/Termina/Input/IPasteReceiver.cs
+++ b/src/Termina/Input/IPasteReceiver.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Interface for components that can accept pasted content from the terminal.
+/// </summary>
+/// <remarks>
+/// Implement this interface on focusable layout nodes (such as <c>TextInputNode</c>)
+/// to receive bracketed paste events. When a focused component implements this interface,
+/// <c>TerminaApplication</c> routes <see cref="PasteEvent"/>s directly to it rather
+/// than broadcasting them through the input observable.
+/// </remarks>
+public interface IPasteReceiver
+{
+    /// <summary>
+    /// Handle a paste event from the terminal.
+    /// </summary>
+    /// <param name="paste">The paste event containing the pasted text.</param>
+    /// <returns>
+    /// <see langword="true"/> if the paste was handled; <see langword="false"/> otherwise.
+    /// </returns>
+    bool HandlePaste(PasteEvent paste);
+}

--- a/src/Termina/Input/MouseScrollEvent.cs
+++ b/src/Termina/Input/MouseScrollEvent.cs
@@ -7,8 +7,8 @@ namespace Termina.Input;
 /// Input event fired when the user scrolls the mouse wheel.
 /// </summary>
 /// <remarks>
-/// This event is only emitted when mouse button tracking mode is active
-/// (<c>ESC[?1002h</c> combined with SGR mode <c>ESC[?1006h</c>).
+/// This event is emitted when mouse reporting is active
+/// (<c>ESC[?1000h</c> combined with SGR mode <c>ESC[?1006h</c>).
 /// The terminal reports scroll wheel events using SGR button codes 64 (up) and 65 (down).
 /// </remarks>
 /// <param name="Delta">

--- a/src/Termina/Input/MouseScrollEvent.cs
+++ b/src/Termina/Input/MouseScrollEvent.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Input event fired when the user scrolls the mouse wheel.
+/// </summary>
+/// <remarks>
+/// This event is only emitted when mouse button tracking mode is active
+/// (<c>ESC[?1002h</c> combined with SGR mode <c>ESC[?1006h</c>).
+/// The terminal reports scroll wheel events using SGR button codes 64 (up) and 65 (down).
+/// </remarks>
+/// <param name="Delta">
+/// The scroll direction and magnitude.
+/// Positive values indicate scrolling up (toward older/earlier content).
+/// Negative values indicate scrolling down (toward newer/later content).
+/// Each wheel tick typically has a magnitude of 1.
+/// </param>
+public sealed record MouseScrollEvent(int Delta) : IInputEvent;

--- a/src/Termina/Input/PasteEvent.cs
+++ b/src/Termina/Input/PasteEvent.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Input event fired when the user pastes text via the terminal's bracketed paste mode.
+/// </summary>
+/// <remarks>
+/// This event is only emitted when bracketed paste mode is active
+/// (<c>ESC[?2004h</c> has been sent to the terminal). In that mode the terminal
+/// wraps pasted content between <c>ESC[200~</c> and <c>ESC[201~</c>, allowing the
+/// application to receive the entire paste as a single event rather than individual
+/// key presses.
+/// </remarks>
+/// <param name="Content">The full pasted text, including any newlines present in the paste.</param>
+public sealed record PasteEvent(string Content) : IInputEvent;

--- a/src/Termina/Input/PlatformInputSource.cs
+++ b/src/Termina/Input/PlatformInputSource.cs
@@ -91,7 +91,11 @@ public sealed class PlatformInputSource : IInputSource
                         TerminaTrace.Input.Trace(this, "KeyEvent: {0}", keyEvent.KeyInfo.Key);
                         var events = _parser.Process(keyEvent.KeyInfo);
                         foreach (var e in events)
+                        {
+                            if (e is PasteEvent pe)
+                                TerminaTrace.Input.Debug(this, "PasteEvent emitted: {0} chars", pe.Content.Length);
                             await writer.WriteAsync(e, cancellationToken);
+                        }
                         break;
 
                     case ConsoleResizeEvent resizeEvent:

--- a/src/Termina/Input/PlatformInputSource.cs
+++ b/src/Termina/Input/PlatformInputSource.cs
@@ -17,12 +17,15 @@ namespace Termina.Input;
 /// input with no polling delay.
 /// </para>
 /// <para>
-/// This replaces <see cref="ConsoleInputSource"/> which used a 10ms polling loop.
+/// Escape sequences (mouse events, bracketed paste) are transparently decoded by
+/// <see cref="EscapeSequenceParser"/> before being emitted as application events.
+/// This prevents terminal mouse click sequences from appearing as spurious ESC keypresses.
 /// </para>
 /// </remarks>
 public sealed class PlatformInputSource : IInputSource
 {
     private readonly IPlatformConsole _console;
+    private readonly EscapeSequenceParser _parser;
     private IDisposable? _resizeSubscription;
 
     /// <summary>
@@ -32,6 +35,7 @@ public sealed class PlatformInputSource : IInputSource
     public PlatformInputSource(IPlatformConsole console)
     {
         _console = console ?? throw new ArgumentNullException(nameof(console));
+        _parser = new EscapeSequenceParser();
     }
 
     /// <inheritdoc />
@@ -40,11 +44,8 @@ public sealed class PlatformInputSource : IInputSource
         TerminaTrace.Input.Debug(this, "PlatformInputSource.RunAsync starting");
 
         // Subscribe to resize events from the platform console
-        // These come through the observable for signal-based notifications (Unix)
-        // or through ReadInputAsync for Windows (WINDOW_BUFFER_SIZE_EVENT)
         _resizeSubscription = _console.Resized.Subscribe(evt =>
         {
-            // Convert platform resize event to application resize event
             writer.TryWrite(new ResizeEvent(evt.Width, evt.Height));
         });
 
@@ -54,42 +55,62 @@ public sealed class PlatformInputSource : IInputSource
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                var inputEvent = await _console.ReadInputAsync(cancellationToken).ConfigureAwait(false);
+                IConsoleInputEvent? inputEvent;
 
-                if (inputEvent is null)
+                // When buffering an incomplete escape sequence, use a short timeout so a
+                // standalone ESC key (e.g., user pressing Esc) can be flushed after 50 ms.
+                if (_parser.IsBufferingEscape)
                 {
-                    // Cancelled or no event
-                    continue;
+                    inputEvent = await ReadInputWithTimeoutAsync(50, cancellationToken);
+                    if (inputEvent is null)
+                    {
+                        if (cancellationToken.IsCancellationRequested) break;
+
+                        // Timed out — check if the buffered ESC should be flushed
+                        var escEvent = _parser.CheckEscapeTimeout();
+                        if (escEvent is not null)
+                            await writer.WriteAsync(escEvent, cancellationToken);
+                        continue;
+                    }
+                }
+                else
+                {
+                    inputEvent = await _console.ReadInputAsync(cancellationToken);
+                    if (inputEvent is null)
+                    {
+                        if (cancellationToken.IsCancellationRequested) break;
+                        continue;
+                    }
                 }
 
                 TerminaTrace.Input.Debug(this, "Received input event: {0}", inputEvent.GetType().Name);
 
-                // Convert platform events to application events
                 switch (inputEvent)
                 {
                     case ConsoleKeyEvent keyEvent:
                         TerminaTrace.Input.Trace(this, "KeyEvent: {0}", keyEvent.KeyInfo.Key);
-                        await writer.WriteAsync(new KeyPressed(keyEvent.KeyInfo), cancellationToken)
-                            .ConfigureAwait(false);
+                        var events = _parser.Process(keyEvent.KeyInfo);
+                        foreach (var e in events)
+                            await writer.WriteAsync(e, cancellationToken);
                         break;
 
                     case ConsoleResizeEvent resizeEvent:
                         // Resize events are also returned from ReadInputAsync on Windows
-                        // We emit them here too in case the observable subscription missed them
                         TerminaTrace.Input.Debug(this, "ResizeEvent: {0}x{1}", resizeEvent.Width, resizeEvent.Height);
                         await writer.WriteAsync(new ResizeEvent(resizeEvent.Width, resizeEvent.Height), cancellationToken)
                             .ConfigureAwait(false);
                         break;
 
-                    case ConsoleMouseEvent mouseEvent:
-                        // TODO: Convert to MouseEvent when mouse support is added
+                    case ConsoleMouseEvent:
+                        // Silently consume raw platform mouse events (Windows).
+                        // On Unix, mouse events arrive as SGR escape sequences handled by EscapeSequenceParser.
                         break;
                 }
             }
 
             TerminaTrace.Input.Debug(this, "PlatformInputSource loop exited (cancellation requested)");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             TerminaTrace.Input.Error(this, "PlatformInputSource exception: {0}", ex.Message);
             throw;
@@ -99,6 +120,26 @@ public sealed class PlatformInputSource : IInputSource
             TerminaTrace.Input.Debug(this, "PlatformInputSource cleaning up");
             _resizeSubscription?.Dispose();
             _resizeSubscription = null;
+        }
+    }
+
+    /// <summary>
+    /// Reads the next input event, returning <c>null</c> if <paramref name="timeoutMs"/> elapses
+    /// before any input arrives. Used to detect standalone ESC keys that are not followed
+    /// by a CSI sequence.
+    /// </summary>
+    private async ValueTask<IConsoleInputEvent?> ReadInputWithTimeoutAsync(int timeoutMs, CancellationToken outerCt)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(outerCt);
+        timeoutCts.CancelAfter(timeoutMs);
+        try
+        {
+            return await _console.ReadInputAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!outerCt.IsCancellationRequested)
+        {
+            // Timed out (not cancelled by the outer token)
+            return null;
         }
     }
 }

--- a/src/Termina/Layout/IScrollable.cs
+++ b/src/Termina/Layout/IScrollable.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Interface for layout nodes that support programmatic scrolling.
+/// </summary>
+/// <remarks>
+/// The scroll direction convention used here matches the reading direction:
+/// <list type="bullet">
+///   <item><see cref="ScrollUp"/> moves toward older/earlier content (upward in the buffer).</item>
+///   <item><see cref="ScrollDown"/> moves toward newer/later content (downward toward the bottom).</item>
+/// </list>
+/// Implementations should use cached viewport dimensions when the viewport size is not
+/// otherwise available (e.g., outside of a <c>Render</c> call).
+/// </remarks>
+public interface IScrollable
+{
+    /// <summary>
+    /// Gets whether scrolling upward (toward older content) is possible.
+    /// </summary>
+    bool CanScrollUp { get; }
+
+    /// <summary>
+    /// Gets whether scrolling downward (toward newer content) is possible.
+    /// </summary>
+    bool CanScrollDown { get; }
+
+    /// <summary>
+    /// Scrolls upward toward older content by the specified number of lines.
+    /// </summary>
+    /// <param name="lines">Number of lines to scroll. Defaults to 1.</param>
+    void ScrollUp(int lines = 1);
+
+    /// <summary>
+    /// Scrolls downward toward newer content by the specified number of lines.
+    /// </summary>
+    /// <param name="lines">Number of lines to scroll. Defaults to 1.</param>
+    void ScrollDown(int lines = 1);
+}

--- a/src/Termina/Layout/ScrollbarOptions.cs
+++ b/src/Termina/Layout/ScrollbarOptions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Configuration options for the visual scrollbar drawn alongside scrollable content.
+/// </summary>
+/// <param name="TrackChar">
+/// Character used for the scrollbar track (the non-thumb area).
+/// Defaults to '░' (light shade).
+/// </param>
+/// <param name="ThumbChar">
+/// Character used for the scrollbar thumb (the draggable indicator).
+/// Defaults to '█' (full block).
+/// </param>
+/// <param name="TrackColor">
+/// Foreground color for the track character.
+/// Defaults to <see cref="Color.BrightBlack"/> when <see langword="null"/>.
+/// </param>
+/// <param name="ThumbColor">
+/// Foreground color for the thumb character.
+/// Defaults to <see cref="Color.White"/> when <see langword="null"/>.
+/// </param>
+/// <param name="AutoHide">
+/// When <see langword="true"/> (default), the scrollbar is hidden if all content fits
+/// within the viewport. When <see langword="false"/>, the scrollbar is always drawn.
+/// </param>
+public sealed record ScrollbarOptions(
+    char TrackChar = '░',
+    char ThumbChar = '█',
+    Color? TrackColor = null,
+    Color? ThumbColor = null,
+    bool AutoHide = true);

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -664,11 +664,17 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
     {
         if (_scrollbarOptions == null || _buffer is not PersistedStreamBuffer persisted)
             return false;
+
+        var prefixLen = Prefix?.Length ?? 0;
+        var contentWidthWithScrollbar = bounds.Width - prefixLen - 1;
+        if (contentWidthWithScrollbar <= 0)
+            return false;
+
         if (!_scrollbarOptions.AutoHide)
             return true;
-        var prefixLen = Prefix?.Length ?? 0;
+
         // Show scrollbar only when wrapped line count exceeds the visible viewport height
-        return persisted.GetWrappedLineCount(bounds.Width - prefixLen - 1) > bounds.Height;
+        return persisted.GetWrappedLineCount(contentWidthWithScrollbar) > bounds.Height;
     }
 
     private void DrawScrollbar(IRenderContext context, Rect bounds, int contentWidth)

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -16,10 +16,17 @@ namespace Termina.Layout;
 /// StreamingTextNode wraps an IStreamingTextBuffer (either PersistedStreamBuffer or WindowedStreamBuffer)
 /// and renders the content with automatic word wrapping and optional scrolling.
 /// </remarks>
-public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
+public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollable
 {
     private readonly IStreamingTextBuffer _buffer;
     private readonly Subject<Unit> _invalidated = new();
+
+    // Scrollbar
+    private ScrollbarOptions? _scrollbarOptions;
+
+    // Cached viewport dimensions, updated during Render() and used by IScrollable
+    private int _lastViewportWidth = 80;
+    private int _lastViewportHeight = 24;
 
     // Tracked segment infrastructure
     private readonly List<ContentElement> _content = new();  // Ordered list of all content
@@ -537,6 +544,43 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
         return this;
     }
 
+    /// <summary>
+    /// Enable the visual scrollbar with default options.
+    /// The scrollbar occupies the rightmost column of the node's bounds.
+    /// It is hidden automatically when all content fits within the viewport.
+    /// </summary>
+    public StreamingTextNode WithScrollbar() => WithScrollbar(new ScrollbarOptions());
+
+    /// <summary>
+    /// Enable the visual scrollbar with the specified options.
+    /// The scrollbar occupies the rightmost column of the node's bounds.
+    /// </summary>
+    /// <param name="options">Scrollbar appearance and behavior options.</param>
+    public StreamingTextNode WithScrollbar(ScrollbarOptions options)
+    {
+        _scrollbarOptions = options;
+        return this;
+    }
+
+    /// <inheritdoc cref="IScrollable.CanScrollUp"/>
+    /// <remarks>
+    /// Depends on cached viewport dimensions updated during <see cref="Render"/>.
+    /// Returns <see langword="false"/> before the first render.
+    /// </remarks>
+    public bool CanScrollUp => _buffer is PersistedStreamBuffer p &&
+        p.ScrollOffset < p.GetMaxScrollOffset(_lastViewportWidth);
+
+    /// <inheritdoc cref="IScrollable.CanScrollDown"/>
+    /// <remarks>
+    /// Depends on cached viewport dimensions updated during <see cref="Render"/>.
+    /// Returns <see langword="false"/> before the first render.
+    /// </remarks>
+    public bool CanScrollDown => _buffer is PersistedStreamBuffer p && p.ScrollOffset > 0;
+
+    void IScrollable.ScrollUp(int lines) => ScrollUp(lines, _lastViewportWidth);
+
+    void IScrollable.ScrollDown(int lines) => ScrollDown(lines);
+
     /// <inheritdoc />
     public override Size Measure(Size available)
     {
@@ -552,9 +596,14 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
             return;
 
         var prefixLen = Prefix?.Length ?? 0;
-        var contentWidth = bounds.Width - prefixLen;
+        var scrollbarWidth = ShouldDrawScrollbar(bounds) ? 1 : 0;
+        var contentWidth = bounds.Width - prefixLen - scrollbarWidth;
         if (contentWidth <= 0)
             return;
+
+        // Update cached viewport dimensions for IScrollable
+        _lastViewportWidth = contentWidth;
+        _lastViewportHeight = bounds.Height;
 
         // Get styled lines from buffer
         var styledLines = _buffer.GetVisibleStyledLines(bounds.Height, contentWidth);
@@ -603,6 +652,55 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode
                 context.WriteAt(x, i, text);
                 x += text.Length;
             }
+        }
+
+        context.ResetColors();
+
+        if (scrollbarWidth > 0)
+            DrawScrollbar(context, bounds, contentWidth);
+    }
+
+    private bool ShouldDrawScrollbar(Rect bounds)
+    {
+        if (_scrollbarOptions == null || _buffer is not PersistedStreamBuffer persisted)
+            return false;
+        if (!_scrollbarOptions.AutoHide)
+            return true;
+        var prefixLen = Prefix?.Length ?? 0;
+        // Show scrollbar only when wrapped line count exceeds the visible viewport height
+        return persisted.GetWrappedLineCount(bounds.Width - prefixLen - 1) > bounds.Height;
+    }
+
+    private void DrawScrollbar(IRenderContext context, Rect bounds, int contentWidth)
+    {
+        if (_buffer is not PersistedStreamBuffer persisted) return;
+
+        var scrollOffset = persisted.ScrollOffset;
+        var maxScroll = persisted.GetMaxScrollOffset(contentWidth);
+        if (maxScroll <= 0) return;
+
+        var x = bounds.Width - 1;
+        var trackHeight = bounds.Height;
+        var totalLines = trackHeight + maxScroll;
+        var thumbHeight = Math.Max(1, (int)((float)trackHeight / totalLines * trackHeight));
+        var maxThumbTop = trackHeight - thumbHeight;
+
+        // PersistedStreamBuffer uses 0 = bottom convention, so invert the thumb position:
+        // scrollOffset=0       → bottom → thumbTop = maxThumbTop
+        // scrollOffset=maxScroll → top  → thumbTop = 0
+        var thumbTop = maxScroll > 0
+            ? (int)((1f - (float)scrollOffset / maxScroll) * maxThumbTop)
+            : maxThumbTop;
+
+        var opts = _scrollbarOptions!;
+        var trackColor = opts.TrackColor ?? Color.BrightBlack;
+        var thumbColor = opts.ThumbColor ?? Color.White;
+
+        for (var y = 0; y < trackHeight; y++)
+        {
+            var isThumb = y >= thumbTop && y < thumbTop + thumbHeight;
+            context.SetForeground(isThumb ? thumbColor : trackColor);
+            context.WriteAt(x, y, isThumb ? opts.ThumbChar : opts.TrackChar);
         }
 
         context.ResetColors();

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -5,6 +5,7 @@ using System.Reactive;
 using System.Reactive.Subjects;
 using System.Timers;
 using Termina.Diagnostics;
+using Termina.Input;
 using Termina.Rendering;
 using Termina.Terminal;
 using Timer = System.Timers.Timer;
@@ -20,7 +21,7 @@ namespace Termina.Layout;
 /// which can decide whether to enable history, how many entries to keep, and whether to
 /// persist it across sessions.
 /// </remarks>
-public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode, IFocusable
+public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode, IFocusable, IPasteReceiver
 {
     private readonly Timer _cursorTimer;
     private readonly Subject<Unit> _invalidated = new();
@@ -507,6 +508,38 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Handles pasted text from the terminal's bracketed paste mode.
+    /// Newlines in the pasted content are silently skipped — this is a single-line input.
+    /// The <see cref="Submitted"/> observable is NOT fired; only <see cref="TextChanged"/> is emitted.
+    /// Respects <see cref="MaxLength"/> when set.
+    /// </summary>
+    /// <param name="paste">The paste event containing the text to insert.</param>
+    /// <returns><see langword="true"/> if the paste was handled; <see langword="false"/> if empty.</returns>
+    public bool HandlePaste(PasteEvent paste)
+    {
+        if (string.IsNullOrEmpty(paste.Content))
+            return false;
+
+        foreach (var c in paste.Content)
+        {
+            // Single-line input: skip all line-ending characters
+            if (c == '\r' || c == '\n')
+                continue;
+
+            // Respect MaxLength (0 means unlimited)
+            if (MaxLength > 0 && _text.Length >= MaxLength)
+                break;
+
+            _text = _text.Insert(_cursorPosition, c.ToString());
+            _cursorPosition++;
+        }
+
+        _textChanged.OnNext(_text);
+        _invalidated.OnNext(Unit.Default);
+        return true;
     }
 
     private void SelectAll()

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -523,19 +523,30 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         if (string.IsNullOrEmpty(paste.Content))
             return false;
 
+        // Build the filtered paste content in one pass (avoids O(n²) string.Insert per char)
+        var sb = new System.Text.StringBuilder(paste.Content.Length);
         foreach (var c in paste.Content)
         {
-            // Single-line input: skip all line-ending characters
             if (c == '\r' || c == '\n')
                 continue;
-
-            // Respect MaxLength (0 means unlimited)
-            if (MaxLength > 0 && _text.Length >= MaxLength)
-                break;
-
-            _text = _text.Insert(_cursorPosition, c.ToString());
-            _cursorPosition++;
+            sb.Append(c);
         }
+
+        var filtered = sb.ToString();
+        if (filtered.Length == 0)
+            return false;
+
+        // Respect MaxLength (0 means unlimited)
+        if (MaxLength > 0)
+        {
+            var available = MaxLength - _text.Length;
+            if (available <= 0) return false;
+            if (filtered.Length > available)
+                filtered = filtered[..available];
+        }
+
+        _text = _text.Insert(_cursorPosition, filtered);
+        _cursorPosition += filtered.Length;
 
         _textChanged.OnNext(_text);
         _invalidated.OnNext(Unit.Default);

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -28,6 +28,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     private readonly Subject<string> _textChanged = new();
     private readonly Subject<string> _submitted = new();
     private string _text = "";
+    private string? _pasteContent;  // full paste content (with newlines preserved)
     private int _cursorPosition;
     private int _selectionStart = -1;
     private int _scrollOffset;
@@ -91,6 +92,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         {
             if (_text != value)
             {
+                _pasteContent = null;
                 _text = value ?? "";
                 _cursorPosition = Math.Min(_cursorPosition, _text.Length);
                 _selectionStart = -1;
@@ -321,6 +323,9 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             return true;
         }
 
+        // Any character input clears paste mode — return to normal editing
+        ClearPasteContent();
+
         // Check max length
         var addLength = HasSelection ? 1 - SelectedText.Length : 1;
         if (MaxLength > 0 && _text.Length + addLength > MaxLength)
@@ -341,6 +346,13 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     private bool HandleBackspace(ConsoleModifiers modifiers)
     {
+        // Backspace clears paste mode — return to normal editing with empty input
+        if (_pasteContent != null)
+        {
+            ClearPasteContent();
+            return true;
+        }
+
         if (HasSelection)
         {
             DeleteSelection();
@@ -371,6 +383,13 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     private bool HandleDelete(ConsoleModifiers modifiers)
     {
+        // Delete clears paste mode — return to normal editing with empty input
+        if (_pasteContent != null)
+        {
+            ClearPasteContent();
+            return true;
+        }
+
         if (HasSelection)
         {
             DeleteSelection();
@@ -471,9 +490,13 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     private bool HandleEnter()
     {
-        TerminaTrace.Input.Debug(this, "HandleEnter: submitting text length={0}", _text.Length);
+        // When paste content is stored, submit the full paste (with newlines) instead of the summary
+        var content = _pasteContent ?? _text;
+        TerminaTrace.Input.Debug(this, "HandleEnter: submitting text length={0} (paste={1})",
+            content.Length, _pasteContent != null);
+        _pasteContent = null;
         // Emit to observable - ViewModel decides what to do (add to history, clear text, etc.)
-        _submitted.OnNext(_text);
+        _submitted.OnNext(content);
         return true;
     }
 
@@ -483,6 +506,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// </summary>
     public void Clear()
     {
+        _pasteContent = null;
         _text = "";
         _cursorPosition = 0;
         _selectionStart = -1;
@@ -493,6 +517,13 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     private bool HandleEscape()
     {
+        // Escape clears paste mode
+        if (_pasteContent != null)
+        {
+            ClearPasteContent();
+            return true;
+        }
+
         if (HasSelection)
         {
             _selectionStart = -1;
@@ -512,10 +543,19 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     /// <summary>
     /// Handles pasted text from the terminal's bracketed paste mode.
-    /// Newlines in the pasted content are silently skipped — this is a single-line input.
-    /// The <see cref="Submitted"/> observable is NOT fired; only <see cref="TextChanged"/> is emitted.
-    /// Respects <see cref="MaxLength"/> when set.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The full paste content (including newlines) is preserved and will be submitted
+    /// verbatim when the user presses Enter. The input displays a summary placeholder
+    /// (e.g., <c>[Pasted 500 lines, 12345 chars]</c>) instead of the raw content.
+    /// </para>
+    /// <para>
+    /// Any subsequent character input, backspace, or delete clears the paste and returns
+    /// the input to normal editing mode. This matches the behavior of CLI tools like
+    /// Claude Code and OpenCode.
+    /// </para>
+    /// </remarks>
     /// <param name="paste">The paste event containing the text to insert.</param>
     /// <returns><see langword="true"/> if the paste was handled; <see langword="false"/> if empty.</returns>
     public bool HandlePaste(PasteEvent paste)
@@ -523,34 +563,44 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         if (string.IsNullOrEmpty(paste.Content))
             return false;
 
-        // Build the filtered paste content in one pass (avoids O(n²) string.Insert per char)
-        var sb = new System.Text.StringBuilder(paste.Content.Length);
+        // Store the full paste content (newlines preserved) for submission
+        _pasteContent = paste.Content;
+
+        // Count lines for the summary display
+        var lineCount = 1;
         foreach (var c in paste.Content)
         {
-            if (c == '\r' || c == '\n')
-                continue;
-            sb.Append(c);
+            if (c == '\n') lineCount++;
         }
 
-        var filtered = sb.ToString();
-        if (filtered.Length == 0)
-            return false;
+        // Show a summary in the input instead of the raw content
+        var summary = lineCount > 1
+            ? $"[Pasted {lineCount} lines, {paste.Content.Length} chars]"
+            : $"[Pasted {paste.Content.Length} chars]";
 
-        // Respect MaxLength (0 means unlimited)
-        if (MaxLength > 0)
-        {
-            var available = MaxLength - _text.Length;
-            if (available <= 0) return false;
-            if (filtered.Length > available)
-                filtered = filtered[..available];
-        }
-
-        _text = _text.Insert(_cursorPosition, filtered);
-        _cursorPosition += filtered.Length;
+        _text = summary;
+        _cursorPosition = _text.Length;
+        _selectionStart = -1;
+        _scrollOffset = 0;
 
         _textChanged.OnNext(_text);
         _invalidated.OnNext(Unit.Default);
         return true;
+    }
+
+    /// <summary>
+    /// Clears paste content and resets the input to an empty state.
+    /// Called when the user starts editing (typing, backspace, delete, escape) after a paste.
+    /// </summary>
+    private void ClearPasteContent()
+    {
+        if (_pasteContent == null) return;
+        _pasteContent = null;
+        _text = "";
+        _cursorPosition = 0;
+        _selectionStart = -1;
+        _scrollOffset = 0;
+        _textChanged.OnNext(_text);
     }
 
     private void SelectAll()

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -378,6 +378,10 @@ public sealed class TerminaApplication
             _terminal.Flush();
             TerminaTrace.Render.Debug(this, "Entered alternate screen, cursor hidden, flushed");
 
+            // Enable bracketed paste mode and mouse button tracking (with SGR for scroll events)
+            Console.Write(AnsiCodes.EnableBracketedPaste);
+            Console.Write(AnsiCodes.EnableMouseButtonTracking + AnsiCodes.EnableMouseSgr);
+
             // Initial render
             TerminaTrace.Render.Debug(this, "Starting initial render");
             RenderCurrentPage();
@@ -398,6 +402,10 @@ public sealed class TerminaApplication
         }
         finally
         {
+            // Disable bracketed paste mode and mouse button tracking before restoring terminal
+            Console.Write(AnsiCodes.DisableBracketedPaste);
+            Console.Write(AnsiCodes.DisableMouseButtonTracking);
+
             // Restore terminal state fully to avoid artifacts
             _terminal.DisableMouse();
             _terminal.SetCursorVisible(true);
@@ -461,6 +469,25 @@ public sealed class TerminaApplication
                 // Force full refresh on resize since terminal dimensions changed
                 _diffingTerminal?.ForceFullRefresh();
                 return;
+
+            case PasteEvent pasteEvent:
+                if (_focusManager.CurrentFocus is IPasteReceiver pasteReceiver)
+                    pasteReceiver.HandlePaste(pasteEvent);
+                else
+                    _inputSubject.OnNext(pasteEvent);
+                return;
+
+            case MouseScrollEvent mouseScroll:
+                const int linesPerTick = 3;
+                if (_focusManager.CurrentFocus is IScrollable scrollable)
+                {
+                    if (mouseScroll.Delta > 0)
+                        scrollable.ScrollUp(linesPerTick);
+                    else
+                        scrollable.ScrollDown(linesPerTick);
+                    return; // Handled by focused scrollable
+                }
+                break; // No focused scrollable — fall through to ViewModel input observable
         }
 
         // Route input events: Page (capture) -> Focus Manager (bubble) -> ViewModel

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -382,6 +382,15 @@ public sealed class TerminaApplication
             // Use ?1000h (normal mode) + ?1006h (SGR encoding) - sufficient for scroll events
             // without the noisy button/drag events that ?1002h generates in tmux.
             Console.Write(AnsiCodes.EnableBracketedPaste);
+
+            // When running inside tmux, the inner-pane ESC[?2004h above is intercepted by tmux
+            // and never reaches the outer terminal. The outer terminal therefore does not know
+            // to wrap Ctrl+Shift+V pastes with ESC[200~...ESC[201~. Use a DCS passthrough to
+            // also enable bracketed paste in the outer terminal.
+            // Requires: set -g allow-passthrough on  in ~/.tmux.conf (tmux 3.3+).
+            if (Environment.GetEnvironmentVariable("TMUX") is not null)
+                Console.Write(AnsiCodes.TmuxPassthrough(AnsiCodes.EnableBracketedPaste));
+
             _terminal.EnableMouse();
             _terminal.Flush();
 
@@ -407,6 +416,8 @@ public sealed class TerminaApplication
         {
             // Disable bracketed paste mode before restoring terminal
             Console.Write(AnsiCodes.DisableBracketedPaste);
+            if (Environment.GetEnvironmentVariable("TMUX") is not null)
+                Console.Write(AnsiCodes.TmuxPassthrough(AnsiCodes.DisableBracketedPaste));
 
             // Restore terminal state fully to avoid artifacts
             // DisableMouse() handles ?1000h and ?1006h cleanup

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -378,9 +378,12 @@ public sealed class TerminaApplication
             _terminal.Flush();
             TerminaTrace.Render.Debug(this, "Entered alternate screen, cursor hidden, flushed");
 
-            // Enable bracketed paste mode and mouse button tracking (with SGR for scroll events)
+            // Enable bracketed paste mode; enable mouse tracking for scroll wheel events.
+            // Use ?1000h (normal mode) + ?1006h (SGR encoding) - sufficient for scroll events
+            // without the noisy button/drag events that ?1002h generates in tmux.
             Console.Write(AnsiCodes.EnableBracketedPaste);
-            Console.Write(AnsiCodes.EnableMouseButtonTracking + AnsiCodes.EnableMouseSgr);
+            _terminal.EnableMouse();
+            _terminal.Flush();
 
             // Initial render
             TerminaTrace.Render.Debug(this, "Starting initial render");
@@ -402,11 +405,11 @@ public sealed class TerminaApplication
         }
         finally
         {
-            // Disable bracketed paste mode and mouse button tracking before restoring terminal
+            // Disable bracketed paste mode before restoring terminal
             Console.Write(AnsiCodes.DisableBracketedPaste);
-            Console.Write(AnsiCodes.DisableMouseButtonTracking);
 
             // Restore terminal state fully to avoid artifacts
+            // DisableMouse() handles ?1000h and ?1006h cleanup
             _terminal.DisableMouse();
             _terminal.SetCursorVisible(true);
             _terminal.ResetColors();

--- a/src/Termina/Terminal/AnsiCodes.cs
+++ b/src/Termina/Terminal/AnsiCodes.cs
@@ -207,6 +207,21 @@ public static class AnsiCodes
     /// </summary>
     public const string ResetStrikethrough = $"{Csi}29m";
 
+    // Bracketed paste mode
+
+    /// <summary>
+    /// Enable bracketed paste mode. Format: CSI ?2004h
+    /// When enabled, the terminal wraps pasted text with <c>ESC[200~</c> ... <c>ESC[201~</c>,
+    /// allowing the application to distinguish pasted content from typed input.
+    /// </summary>
+    public const string EnableBracketedPaste = $"{Csi}?2004h";
+
+    /// <summary>
+    /// Disable bracketed paste mode. Format: CSI ?2004l
+    /// Should be sent before exiting the application to restore normal paste behavior.
+    /// </summary>
+    public const string DisableBracketedPaste = $"{Csi}?2004l";
+
     // Mouse tracking
 
     /// <summary>
@@ -238,6 +253,19 @@ public static class AnsiCodes
     /// Disable mouse tracking (SGR extended mode). Format: CSI ?1006l
     /// </summary>
     public const string DisableMouseSgr = $"{Csi}?1006l";
+
+    /// <summary>
+    /// Enable button event tracking mode, which reports mouse button presses and scroll wheel events.
+    /// Format: CSI ?1002h
+    /// Use together with <see cref="EnableMouseSgr"/> to receive scroll wheel events.
+    /// </summary>
+    public const string EnableMouseButtonTracking = $"{Csi}?1002h";
+
+    /// <summary>
+    /// Disable button event tracking mode. Format: CSI ?1002l
+    /// Should be sent before exiting the application to restore normal mouse behavior.
+    /// </summary>
+    public const string DisableMouseButtonTracking = $"{Csi}?1002l";
 
     // Alternate screen buffer
 

--- a/src/Termina/Terminal/AnsiCodes.cs
+++ b/src/Termina/Terminal/AnsiCodes.cs
@@ -222,6 +222,31 @@ public static class AnsiCodes
     /// </summary>
     public const string DisableBracketedPaste = $"{Csi}?2004l";
 
+    /// <summary>
+    /// Wraps an ANSI escape sequence in a tmux DCS passthrough, allowing it to reach the
+    /// outer terminal when the application runs inside a tmux session.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// tmux intercepts most ANSI sequences from inner applications and handles them itself.
+    /// To send a sequence to the <em>outer</em> terminal (e.g., to enable bracketed paste at
+    /// the outer level so Ctrl+Shift+V pastes are wrapped with <c>ESC[200~</c>), wrap the
+    /// sequence with this passthrough.
+    /// </para>
+    /// <para>
+    /// Requires <c>set -g allow-passthrough on</c> in <c>~/.tmux.conf</c> (tmux 3.3+).
+    /// Without that setting, tmux silently drops the DCS sequence.
+    /// </para>
+    /// </remarks>
+    /// <param name="seq">The escape sequence to forward. All <c>ESC</c> bytes are automatically doubled as required by the DCS passthrough format.</param>
+    /// <returns>The wrapped DCS passthrough sequence ready to write to stdout.</returns>
+    public static string TmuxPassthrough(string seq)
+    {
+        // DCS passthrough syntax: ESC P tmux; ESC <seq-with-doubled-ESCs> ESC \
+        var doubled = seq.Replace("\x1b", "\x1b\x1b");
+        return $"\x1bPtmux;\x1b{doubled}\x1b\\";
+    }
+
     // Mouse tracking
 
     /// <summary>

--- a/src/Termina/Terminal/AnsiCodes.cs
+++ b/src/Termina/Terminal/AnsiCodes.cs
@@ -255,9 +255,14 @@ public static class AnsiCodes
     public const string DisableMouseSgr = $"{Csi}?1006l";
 
     /// <summary>
-    /// Enable button event tracking mode, which reports mouse button presses and scroll wheel events.
+    /// Enable button event tracking mode, which reports mouse button presses, releases, and drag events.
     /// Format: CSI ?1002h
-    /// Use together with <see cref="EnableMouseSgr"/> to receive scroll wheel events.
+    /// <para>
+    /// NOTE: <see cref="EnableMouseNormal"/> (<c>?1000h</c>) combined with <see cref="EnableMouseSgr"/>
+    /// is sufficient for scroll wheel events. <c>?1002h</c> additionally reports click and drag events,
+    /// which can produce spurious escape sequences in multiplexers like tmux when switching panes.
+    /// Prefer <see cref="EnableMouseNormal"/> + <see cref="EnableMouseSgr"/> for scroll-only use cases.
+    /// </para>
     /// </summary>
     public const string EnableMouseButtonTracking = $"{Csi}?1002h";
 

--- a/src/Termina/Terminal/AnsiCodes.cs
+++ b/src/Termina/Terminal/AnsiCodes.cs
@@ -279,24 +279,6 @@ public static class AnsiCodes
     /// </summary>
     public const string DisableMouseSgr = $"{Csi}?1006l";
 
-    /// <summary>
-    /// Enable button event tracking mode, which reports mouse button presses, releases, and drag events.
-    /// Format: CSI ?1002h
-    /// <para>
-    /// NOTE: <see cref="EnableMouseNormal"/> (<c>?1000h</c>) combined with <see cref="EnableMouseSgr"/>
-    /// is sufficient for scroll wheel events. <c>?1002h</c> additionally reports click and drag events,
-    /// which can produce spurious escape sequences in multiplexers like tmux when switching panes.
-    /// Prefer <see cref="EnableMouseNormal"/> + <see cref="EnableMouseSgr"/> for scroll-only use cases.
-    /// </para>
-    /// </summary>
-    public const string EnableMouseButtonTracking = $"{Csi}?1002h";
-
-    /// <summary>
-    /// Disable button event tracking mode. Format: CSI ?1002l
-    /// Should be sent before exiting the application to restore normal mouse behavior.
-    /// </summary>
-    public const string DisableMouseButtonTracking = $"{Csi}?1002l";
-
     // Alternate screen buffer
 
     /// <summary>

--- a/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+/// <summary>
+/// Tests for <see cref="EscapeSequenceParser"/> — the component that detects bracketed paste,
+/// SGR mouse events, and standalone ESC keys from raw Console.ReadKey output.
+/// </summary>
+public class EscapeSequenceParserTests
+{
+    // Helper: create ConsoleKeyInfo for a regular character
+    private static ConsoleKeyInfo Key(char c, ConsoleKey key = ConsoleKey.None, bool ctrl = false, bool shift = false, bool alt = false)
+        => new(c, key, shift, alt, ctrl);
+
+    private static ConsoleKeyInfo EscKey()
+        => new('\x1b', ConsoleKey.Escape, false, false, false);
+
+    // Feed a string of characters through the parser as individual keys
+    private static List<IInputEvent> FeedString(EscapeSequenceParser parser, string chars)
+    {
+        var all = new List<IInputEvent>();
+        foreach (var c in chars)
+            all.AddRange(parser.Process(Key(c)));
+        return all;
+    }
+
+    // Build a full SGR mouse sequence: ESC [ < button ; x ; y M
+    private static IEnumerable<ConsoleKeyInfo> SgrMouseSequence(int button, int x, int y, char terminator = 'M')
+    {
+        yield return EscKey();
+        foreach (var c in $"[<{button};{x};{y}{terminator}")
+            yield return Key(c);
+    }
+
+    private static List<IInputEvent> FeedSequence(EscapeSequenceParser parser, IEnumerable<ConsoleKeyInfo> keys)
+    {
+        var all = new List<IInputEvent>();
+        foreach (var k in keys)
+            all.AddRange(parser.Process(k));
+        return all;
+    }
+
+    // --- Regular key handling ---
+
+    [Fact]
+    public void RegularCharacter_EmitsKeyPressed()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = parser.Process(Key('a', ConsoleKey.A));
+        var pressed = Assert.Single(events);
+        var kp = Assert.IsType<KeyPressed>(pressed);
+        Assert.Equal('a', kp.KeyInfo.KeyChar);
+    }
+
+    [Fact]
+    public void ArrowKey_EmitsKeyPressed()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = parser.Process(Key('\0', ConsoleKey.UpArrow));
+        Assert.Single(events);
+        Assert.IsType<KeyPressed>(events[0]);
+    }
+
+    // --- Mouse scroll up (button 64) ---
+
+    [Fact]
+    public void SgrScrollUp_EmitsMouseScrollEventPositive()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = FeedSequence(parser, SgrMouseSequence(64, 5, 10));
+
+        var scroll = Assert.Single(events);
+        var mse = Assert.IsType<MouseScrollEvent>(scroll);
+        Assert.Equal(+1, mse.Delta);
+    }
+
+    [Fact]
+    public void SgrScrollUp_WithLargeCoordinates_EmitsMouseScrollEvent()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = FeedSequence(parser, SgrMouseSequence(64, 200, 50));
+
+        var scroll = Assert.Single(events);
+        Assert.IsType<MouseScrollEvent>(scroll);
+        Assert.Equal(+1, ((MouseScrollEvent)scroll).Delta);
+    }
+
+    // --- Mouse scroll down (button 65) ---
+
+    [Fact]
+    public void SgrScrollDown_EmitsMouseScrollEventNegative()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = FeedSequence(parser, SgrMouseSequence(65, 5, 10));
+
+        var scroll = Assert.Single(events);
+        var mse = Assert.IsType<MouseScrollEvent>(scroll);
+        Assert.Equal(-1, mse.Delta);
+    }
+
+    // --- Mouse click events silently consumed ---
+
+    [Fact]
+    public void SgrMouseClickPress_IsSilentlyConsumed()
+    {
+        var parser = new EscapeSequenceParser();
+        // Button 0 + 'M' = left button press
+        var events = FeedSequence(parser, SgrMouseSequence(0, 5, 10, 'M'));
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void SgrMouseClickRelease_IsSilentlyConsumed()
+    {
+        var parser = new EscapeSequenceParser();
+        // Button 0 + 'm' = left button release
+        var events = FeedSequence(parser, SgrMouseSequence(0, 5, 10, 'm'));
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void SgrMouseRightClick_IsSilentlyConsumed()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = FeedSequence(parser, SgrMouseSequence(2, 10, 20, 'M'));
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void MultipleClicks_AllSilentlyConsumed()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+        // Press + release
+        events.AddRange(FeedSequence(parser, SgrMouseSequence(0, 5, 10, 'M')));
+        events.AddRange(FeedSequence(parser, SgrMouseSequence(0, 5, 10, 'm')));
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void ClickThenScroll_ClickConsumed_ScrollEmitted()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+        events.AddRange(FeedSequence(parser, SgrMouseSequence(0, 5, 10, 'M'))); // click
+        events.AddRange(FeedSequence(parser, SgrMouseSequence(64, 5, 10)));      // scroll up
+
+        var single = Assert.Single(events);
+        var mse = Assert.IsType<MouseScrollEvent>(single);
+        Assert.Equal(+1, mse.Delta);
+    }
+
+    // --- Parser state: not buffering after processing a complete sequence ---
+
+    [Fact]
+    public void AfterMouseEvent_ParserNotBuffering()
+    {
+        var parser = new EscapeSequenceParser();
+        FeedSequence(parser, SgrMouseSequence(0, 5, 10, 'M'));
+        Assert.False(parser.IsBufferingEscape);
+    }
+
+    [Fact]
+    public void AfterScrollEvent_ParserNotBuffering()
+    {
+        var parser = new EscapeSequenceParser();
+        FeedSequence(parser, SgrMouseSequence(64, 5, 10));
+        Assert.False(parser.IsBufferingEscape);
+    }
+
+    // --- ESC timeout ---
+
+    [Fact]
+    public void StandaloneEsc_IsBuffering_UntilTimeout()
+    {
+        var parser = new EscapeSequenceParser();
+        parser.Process(EscKey());
+
+        // Before timeout: buffering, CheckEscapeTimeout returns null
+        Assert.True(parser.IsBufferingEscape);
+        Assert.Null(parser.CheckEscapeTimeout());
+    }
+
+    [Fact]
+    public void StandaloneEsc_AfterTimeout_EmitsKeyPressed()
+    {
+        var tick = 0L;
+        var parser = new EscapeSequenceParser(() => tick);
+
+        parser.Process(EscKey());
+        Assert.True(parser.IsBufferingEscape);
+
+        tick += 60; // advance 60ms — past the 50ms threshold
+        var flushed = parser.CheckEscapeTimeout();
+
+        Assert.NotNull(flushed);
+        Assert.Equal(ConsoleKey.Escape, flushed!.KeyInfo.Key);
+        Assert.False(parser.IsBufferingEscape);
+    }
+
+    [Fact]
+    public void StandaloneEsc_BeforeTimeout_CheckReturnsNull()
+    {
+        var tick = 0L;
+        var parser = new EscapeSequenceParser(() => tick);
+
+        parser.Process(EscKey());
+        tick += 30; // only 30ms — below the 50ms threshold
+
+        Assert.Null(parser.CheckEscapeTimeout());
+        Assert.True(parser.IsBufferingEscape);
+    }
+
+    // --- Esc followed by non-bracket flushes both ---
+
+    [Fact]
+    public void EscThenNonBracket_FlushesEscAndProcessesKey()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(parser.Process(Key('x', ConsoleKey.X)));
+
+        Assert.Equal(2, events.Count);
+        Assert.Equal(ConsoleKey.Escape, ((KeyPressed)events[0]).KeyInfo.Key);
+        Assert.Equal('x', ((KeyPressed)events[1]).KeyInfo.KeyChar);
+    }
+
+    // --- Bracketed paste ---
+
+    [Fact]
+    public void BracketedPaste_EmitsPasteEvent()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+
+        // Start: ESC[200~
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[200~"));
+
+        // Paste content
+        events.AddRange(FeedString(parser, "hello world"));
+
+        // End: ESC[201~
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[201~"));
+
+        var paste = Assert.Single(events);
+        var pe = Assert.IsType<PasteEvent>(paste);
+        Assert.Equal("hello world", pe.Content);
+    }
+
+    [Fact]
+    public void BracketedPaste_WithNewlines_PreservesContent()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[200~"));
+        events.AddRange(FeedString(parser, "line1\nline2"));
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[201~"));
+
+        var pe = Assert.IsType<PasteEvent>(Assert.Single(events));
+        Assert.Equal("line1\nline2", pe.Content);
+    }
+
+    // --- Normal sequence followed by keys works ---
+
+    [Fact]
+    public void AfterConsumedMouseEvent_RegularKeysWorkNormally()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+
+        // Mouse click (consumed)
+        events.AddRange(FeedSequence(parser, SgrMouseSequence(0, 5, 10, 'M')));
+        events.AddRange(FeedSequence(parser, SgrMouseSequence(0, 5, 10, 'm')));
+
+        // Regular key after
+        events.AddRange(parser.Process(Key('a', ConsoleKey.A)));
+
+        var single = Assert.Single(events);
+        Assert.Equal('a', ((KeyPressed)single).KeyInfo.KeyChar);
+    }
+}

--- a/tests/Termina.Tests/MouseScrollRoutingTests.cs
+++ b/tests/Termina.Tests/MouseScrollRoutingTests.cs
@@ -119,18 +119,6 @@ public class MouseScrollRoutingTests
     }
 
     [Fact]
-    public void EnableMouseButtonTracking_HasCorrectValue()
-    {
-        Assert.Equal("\x1b[?1002h", AnsiCodes.EnableMouseButtonTracking);
-    }
-
-    [Fact]
-    public void DisableMouseButtonTracking_HasCorrectValue()
-    {
-        Assert.Equal("\x1b[?1002l", AnsiCodes.DisableMouseButtonTracking);
-    }
-
-    [Fact]
     public void MouseScrollEvent_PositiveDelta_MeansScrollUp()
     {
         // Verify that positive Delta represents scroll up (toward older content)

--- a/tests/Termina.Tests/MouseScrollRoutingTests.cs
+++ b/tests/Termina.Tests/MouseScrollRoutingTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests;
+
+/// <summary>
+/// Tests for mouse wheel scroll support via <see cref="IScrollable"/> and <see cref="MouseScrollEvent"/>.
+/// </summary>
+public class MouseScrollRoutingTests
+{
+    [Fact]
+    public void StreamingTextNode_ImplementsIScrollable()
+    {
+        var node = StreamingTextNode.Create();
+        Assert.IsAssignableFrom<IScrollable>(node);
+    }
+
+    [Fact]
+    public void CanScrollUp_False_BeforeFirstRender_WithNoContent()
+    {
+        var node = StreamingTextNode.Create();
+        Assert.False(node.CanScrollUp);
+    }
+
+    [Fact]
+    public void CanScrollDown_False_WhenAtBottom()
+    {
+        var node = StreamingTextNode.Create();
+        for (var i = 0; i < 30; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        // At the bottom (scrollOffset=0) → cannot scroll further down
+        Assert.False(node.CanScrollDown);
+    }
+
+    [Fact]
+    public void CanScrollUp_True_WhenContentExceedsViewport()
+    {
+        var node = StreamingTextNode.Create();
+        for (var i = 0; i < 30; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        // 30 lines in a 10-row viewport → can scroll up to older content
+        Assert.True(node.CanScrollUp);
+    }
+
+    [Fact]
+    public void CanScrollDown_True_AfterScrollingUp()
+    {
+        var node = StreamingTextNode.Create();
+        for (var i = 0; i < 30; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        // Scroll up first
+        node.ScrollUp(5, 40);
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        // After scrolling up, can scroll back down
+        Assert.True(node.CanScrollDown);
+    }
+
+    [Fact]
+    public void IScrollable_ScrollUp_UsesLastViewportWidth()
+    {
+        var node = StreamingTextNode.Create();
+        for (var i = 0; i < 30; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        // ScrollUp via IScrollable interface
+        IScrollable scrollable = node;
+        scrollable.ScrollUp(3);
+
+        // Verify we scrolled (CanScrollDown should now be true)
+        node.Render(context, new Rect(0, 0, 40, 10));
+        Assert.True(node.CanScrollDown);
+    }
+
+    [Fact]
+    public void IScrollable_ScrollDown_DecreasesScrollOffset()
+    {
+        var node = StreamingTextNode.Create();
+        for (var i = 0; i < 30; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        // Scroll up then back down via interface
+        IScrollable scrollable = node;
+        scrollable.ScrollUp(5);
+        node.Render(context, new Rect(0, 0, 40, 10));
+        Assert.True(node.CanScrollDown);
+
+        scrollable.ScrollDown(5);
+        node.Render(context, new Rect(0, 0, 40, 10));
+        Assert.False(node.CanScrollDown);
+    }
+
+    [Fact]
+    public void EnableMouseButtonTracking_HasCorrectValue()
+    {
+        Assert.Equal("\x1b[?1002h", AnsiCodes.EnableMouseButtonTracking);
+    }
+
+    [Fact]
+    public void DisableMouseButtonTracking_HasCorrectValue()
+    {
+        Assert.Equal("\x1b[?1002l", AnsiCodes.DisableMouseButtonTracking);
+    }
+
+    [Fact]
+    public void MouseScrollEvent_PositiveDelta_MeansScrollUp()
+    {
+        // Verify that positive Delta represents scroll up (toward older content)
+        var evt = new MouseScrollEvent(+1);
+        Assert.True(evt.Delta > 0);
+    }
+
+    [Fact]
+    public void MouseScrollEvent_NegativeDelta_MeansScrollDown()
+    {
+        var evt = new MouseScrollEvent(-1);
+        Assert.True(evt.Delta < 0);
+    }
+}

--- a/tests/Termina.Tests/StreamingTextNodeScrollbarTests.cs
+++ b/tests/Termina.Tests/StreamingTextNodeScrollbarTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests;
+
+/// <summary>
+/// Tests for the visual scrollbar feature on <see cref="StreamingTextNode"/>.
+/// </summary>
+public class StreamingTextNodeScrollbarTests
+{
+    private static (StreamingTextNode Node, VirtualTerminal Terminal, RegionRenderContext Context, Rect Bounds)
+        SetupWithContent(int width, int height, int lineCount, bool withScrollbar = true)
+    {
+        var node = StreamingTextNode.Create();
+        if (withScrollbar)
+            node.WithScrollbar();
+
+        for (var i = 0; i < lineCount; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(width, height);
+        var context = new RegionRenderContext(terminal, 0, 0, width, height);
+        var bounds = new Rect(0, 0, width, height);
+        return (node, terminal, context, bounds);
+    }
+
+    [Fact]
+    public void Scrollbar_DrawsAtLastColumn_WhenContentExceedsViewport()
+    {
+        // 30 lines into a 10-row viewport → content overflows → scrollbar visible
+        var (node, terminal, context, bounds) = SetupWithContent(40, 10, 30);
+        node.Render(context, bounds);
+
+        // At least one cell in the last column should contain a scrollbar character
+        var foundScrollbarChar = false;
+        for (var y = 0; y < 10; y++)
+        {
+            var c = terminal.GetChar(39, y);
+            if (c == '░' || c == '█')
+            {
+                foundScrollbarChar = true;
+                break;
+            }
+        }
+
+        Assert.True(foundScrollbarChar, "Expected scrollbar character in column 39 (bounds.Width - 1)");
+    }
+
+    [Fact]
+    public void Scrollbar_AutoHide_HidesScrollbar_WhenContentFitsViewport()
+    {
+        // Only 3 lines in a 10-row viewport → no overflow → scrollbar hidden
+        var (node, terminal, context, bounds) = SetupWithContent(40, 10, 3);
+        node.Render(context, bounds);
+
+        // Last column should not contain any scrollbar characters
+        for (var y = 0; y < 10; y++)
+        {
+            var c = terminal.GetChar(39, y);
+            Assert.False(c == '░' || c == '█',
+                $"Unexpected scrollbar character '{c}' at column 39, row {y} when content fits viewport");
+        }
+    }
+
+    [Fact]
+    public void Scrollbar_NotDrawn_WhenWithScrollbarNotCalled()
+    {
+        // Create without calling WithScrollbar()
+        var (node, terminal, context, bounds) = SetupWithContent(40, 10, 30, withScrollbar: false);
+        node.Render(context, bounds);
+
+        // Last column should not contain scrollbar characters
+        for (var y = 0; y < 10; y++)
+        {
+            var c = terminal.GetChar(39, y);
+            Assert.False(c == '░' || c == '█',
+                $"Unexpected scrollbar character at column 39, row {y} — WithScrollbar() was not called");
+        }
+    }
+
+    [Fact]
+    public void Scrollbar_AutoHideFalse_AlwaysDraws_EvenWhenContentFits()
+    {
+        var node = StreamingTextNode.Create()
+            .WithScrollbar(new ScrollbarOptions(AutoHide: false));
+        node.AppendLine("Only one line");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        // When AutoHide is false the scrollbar column is always reserved.
+        // With only 1 line and maxScroll=0 the DrawScrollbar method returns early
+        // (no thumb to draw), so the column stays blank — but the content area
+        // is still narrowed by 1. Verify content does NOT reach column 39.
+        // (This just confirms the width reservation happens.)
+        // Content "Only one line" is 14 chars wide, so last content char is at col 13.
+        // Column 39 should be blank (space).
+        Assert.Equal(' ', terminal.GetChar(39, 0));
+    }
+
+    [Fact]
+    public void Scrollbar_ThumbAtBottom_WhenScrollOffsetIsZero()
+    {
+        // 30 lines, 10-row viewport → buffer at bottom (scrollOffset=0)
+        var (node, terminal, context, bounds) = SetupWithContent(40, 10, 30);
+        node.Render(context, bounds);
+
+        // The thumb should appear at the bottom of the scrollbar track
+        // (because 0 = bottom in PersistedStreamBuffer convention)
+        // The last row of the scrollbar column (y=9) should be the thumb
+        Assert.Equal('█', terminal.GetChar(39, 9));
+    }
+
+    [Fact]
+    public void Scrollbar_ThumbAtTop_WhenScrolledToMax()
+    {
+        var node = StreamingTextNode.Create().WithScrollbar();
+        for (var i = 0; i < 30; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        var bounds = new Rect(0, 0, 40, 10);
+
+        // First render to populate cached viewport dimensions
+        node.Render(context, bounds);
+
+        // Scroll to the top (oldest content)
+        node.ScrollUp(100, 39); // large value to reach max
+
+        // Re-render after scrolling
+        terminal.Clear();
+        node.Render(context, bounds);
+
+        // Thumb should now be at the top of the scrollbar track (y=0)
+        Assert.Equal('█', terminal.GetChar(39, 0));
+    }
+}

--- a/tests/Termina.Tests/TextInputNodePasteTests.cs
+++ b/tests/Termina.Tests/TextInputNodePasteTests.cs
@@ -13,28 +13,34 @@ namespace Termina.Tests;
 public class TextInputNodePasteTests
 {
     [Fact]
-    public void HandlePaste_InsertsTextIntoInput()
+    public void HandlePaste_ShowsSummary_SingleLine()
     {
         var node = new TextInputNode();
         var result = node.HandlePaste(new PasteEvent("hello world"));
         Assert.True(result);
-        Assert.Equal("hello world", node.Text);
+        Assert.Equal("[Pasted 11 chars]", node.Text);
     }
 
     [Fact]
-    public void HandlePaste_SkipsNewlines_InPastedContent()
+    public void HandlePaste_ShowsSummary_MultiLine()
     {
         var node = new TextInputNode();
-        node.HandlePaste(new PasteEvent("hello\nworld"));
-        Assert.Equal("helloworld", node.Text);
+        node.HandlePaste(new PasteEvent("hello\nworld\nthird"));
+        Assert.Equal("[Pasted 3 lines, 17 chars]", node.Text);
     }
 
     [Fact]
-    public void HandlePaste_SkipsCarriageReturns_InPastedContent()
+    public void HandlePaste_PreservesNewlinesInContent()
     {
         var node = new TextInputNode();
         node.HandlePaste(new PasteEvent("hello\r\nworld"));
-        Assert.Equal("helloworld", node.Text);
+
+        // Summary is shown, but Enter submits the full content with newlines preserved
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("hello\r\nworld", submitted);
     }
 
     [Fact]
@@ -50,6 +56,95 @@ public class TextInputNodePasteTests
     }
 
     [Fact]
+    public void HandlePaste_EnterSubmitsFullPasteContent()
+    {
+        var node = new TextInputNode();
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+
+        var pasteContent = "line 1\nline 2\nline 3";
+        node.HandlePaste(new PasteEvent(pasteContent));
+
+        // Press Enter to submit
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal(pasteContent, submitted);
+    }
+
+    [Fact]
+    public void HandlePaste_TypingClearsPaste_ReturnsToNormalEditing()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("pasted content\nwith newlines"));
+
+        // Type a character — should clear paste and start fresh
+        node.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false));
+
+        Assert.Equal("a", node.Text);
+
+        // Now Enter submits "a", not the paste content
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("a", submitted);
+    }
+
+    [Fact]
+    public void HandlePaste_BackspaceClearsPaste()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("pasted stuff"));
+
+        // Backspace should clear paste and return to empty
+        node.HandleInput(new ConsoleKeyInfo('\b', ConsoleKey.Backspace, false, false, false));
+
+        Assert.Equal("", node.Text);
+    }
+
+    [Fact]
+    public void HandlePaste_DeleteClearsPaste()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("pasted stuff"));
+
+        // Delete should clear paste and return to empty
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false));
+
+        Assert.Equal("", node.Text);
+    }
+
+    [Fact]
+    public void HandlePaste_EscapeClearsPaste()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("pasted stuff"));
+
+        // Escape should clear paste and return to empty
+        node.HandleInput(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false));
+
+        Assert.Equal("", node.Text);
+    }
+
+    [Fact]
+    public void HandlePaste_ClearMethodResetsPaste()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("pasted stuff"));
+
+        node.Clear();
+
+        Assert.Equal("", node.Text);
+
+        // Enter after Clear submits empty, not paste content
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("", submitted);
+    }
+
+    [Fact]
     public void HandlePaste_FiresTextChanged()
     {
         var node = new TextInputNode();
@@ -58,15 +153,8 @@ public class TextInputNodePasteTests
 
         node.HandlePaste(new PasteEvent("test"));
 
-        Assert.Equal("test", lastText);
-    }
-
-    [Fact]
-    public void HandlePaste_RespectsMaxLength()
-    {
-        var node = new TextInputNode().WithMaxLength(5);
-        node.HandlePaste(new PasteEvent("hello world"));
-        Assert.Equal("hello", node.Text);
+        // TextChanged gets the summary, not the raw content
+        Assert.Equal("[Pasted 4 chars]", lastText);
     }
 
     [Fact]
@@ -79,15 +167,40 @@ public class TextInputNodePasteTests
     }
 
     [Fact]
-    public void HandlePaste_InsertsAtCursorPosition()
+    public void HandlePaste_ReplacesExistingText()
     {
         var node = new TextInputNode();
-        // Pre-populate with "world", cursor at position 0
-        node.Text = "world";
-        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false));
+        node.Text = "existing text";
 
-        node.HandlePaste(new PasteEvent("hello "));
-        Assert.Equal("hello world", node.Text);
+        node.HandlePaste(new PasteEvent("new paste"));
+
+        Assert.Equal("[Pasted 9 chars]", node.Text);
+
+        // Enter submits the paste content
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("new paste", submitted);
+    }
+
+    [Fact]
+    public void HandlePaste_TextPropertySetterClearsPaste()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("pasted stuff"));
+
+        // Setting Text property programmatically should clear paste
+        node.Text = "manual text";
+
+        Assert.Equal("manual text", node.Text);
+
+        // Enter submits the manual text, not paste
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("manual text", submitted);
     }
 
     [Fact]

--- a/tests/Termina.Tests/TextInputNodePasteTests.cs
+++ b/tests/Termina.Tests/TextInputNodePasteTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+using Termina.Layout;
+using Termina.Terminal;
+
+namespace Termina.Tests;
+
+/// <summary>
+/// Tests for bracketed paste mode support on <see cref="TextInputNode"/> and related infrastructure.
+/// </summary>
+public class TextInputNodePasteTests
+{
+    [Fact]
+    public void HandlePaste_InsertsTextIntoInput()
+    {
+        var node = new TextInputNode();
+        var result = node.HandlePaste(new PasteEvent("hello world"));
+        Assert.True(result);
+        Assert.Equal("hello world", node.Text);
+    }
+
+    [Fact]
+    public void HandlePaste_SkipsNewlines_InPastedContent()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("hello\nworld"));
+        Assert.Equal("helloworld", node.Text);
+    }
+
+    [Fact]
+    public void HandlePaste_SkipsCarriageReturns_InPastedContent()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("hello\r\nworld"));
+        Assert.Equal("helloworld", node.Text);
+    }
+
+    [Fact]
+    public void HandlePaste_DoesNotFireSubmitted()
+    {
+        var node = new TextInputNode();
+        var submittedCount = 0;
+        node.Submitted.Subscribe(_ => submittedCount++);
+
+        node.HandlePaste(new PasteEvent("hello\nworld\nanother line"));
+
+        Assert.Equal(0, submittedCount);
+    }
+
+    [Fact]
+    public void HandlePaste_FiresTextChanged()
+    {
+        var node = new TextInputNode();
+        string? lastText = null;
+        node.TextChanged.Subscribe(t => lastText = t);
+
+        node.HandlePaste(new PasteEvent("test"));
+
+        Assert.Equal("test", lastText);
+    }
+
+    [Fact]
+    public void HandlePaste_RespectsMaxLength()
+    {
+        var node = new TextInputNode().WithMaxLength(5);
+        node.HandlePaste(new PasteEvent("hello world"));
+        Assert.Equal("hello", node.Text);
+    }
+
+    [Fact]
+    public void HandlePaste_ReturnsFalse_WhenContentIsEmpty()
+    {
+        var node = new TextInputNode();
+        var result = node.HandlePaste(new PasteEvent(""));
+        Assert.False(result);
+        Assert.Equal("", node.Text);
+    }
+
+    [Fact]
+    public void HandlePaste_InsertsAtCursorPosition()
+    {
+        var node = new TextInputNode();
+        // Pre-populate with "world", cursor at position 0
+        node.Text = "world";
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false));
+
+        node.HandlePaste(new PasteEvent("hello "));
+        Assert.Equal("hello world", node.Text);
+    }
+
+    [Fact]
+    public void EnableBracketedPaste_HasCorrectValue()
+    {
+        Assert.Equal("\x1b[?2004h", AnsiCodes.EnableBracketedPaste);
+    }
+
+    [Fact]
+    public void DisableBracketedPaste_HasCorrectValue()
+    {
+        Assert.Equal("\x1b[?2004l", AnsiCodes.DisableBracketedPaste);
+    }
+
+    [Fact]
+    public void TextInputNode_ImplementsIPasteReceiver()
+    {
+        var node = new TextInputNode();
+        Assert.IsAssignableFrom<IPasteReceiver>(node);
+    }
+}

--- a/tests/Termina.Tests/TextInputNodePasteTests.cs
+++ b/tests/Termina.Tests/TextInputNodePasteTests.cs
@@ -3,7 +3,6 @@
 
 using Termina.Input;
 using Termina.Layout;
-using Termina.Terminal;
 
 namespace Termina.Tests;
 
@@ -201,18 +200,6 @@ public class TextInputNodePasteTests
         node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
 
         Assert.Equal("manual text", submitted);
-    }
-
-    [Fact]
-    public void EnableBracketedPaste_HasCorrectValue()
-    {
-        Assert.Equal("\x1b[?2004h", AnsiCodes.EnableBracketedPaste);
-    }
-
-    [Fact]
-    public void DisableBracketedPaste_HasCorrectValue()
-    {
-        Assert.Equal("\x1b[?2004l", AnsiCodes.DisableBracketedPaste);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements three input/display enhancements to Termina:

- Scrollbar for `StreamingTextNode` showing scroll position
- Bracketed paste mode with Claude Code-style UX (summary placeholder, submit on Enter)
- Mouse wheel scrolling support for `IScrollable` components

## Changes

### Scrollbar
- `ScrollbarOptions` record for customization (track/thumb chars and colors, AutoHide)
- `WithScrollbar()` fluent methods on `StreamingTextNode`
- `GetMaxScrollOffset()` exposed in `PersistedStreamBuffer`
- Visual scrollbar renders on right edge when content exceeds viewport

### Paste Mode
- `PasteEvent` and `IPasteReceiver` interfaces
- `TextInputNode` implements `IPasteReceiver`
- Paste shows summary: `[Pasted 500 lines, 12345 chars]`
- Full content submitted on Enter (with newlines preserved)
- Any edit action clears paste and returns to normal mode
- `AnsiCodes.EnableBracketedPaste` / `DisableBracketedPaste` constants
- Multi-line pastes no longer trigger individual submissions

### Mouse Wheel Scroll
- `MouseScrollEvent` input event
- `IScrollable` interface for scrollable components
- Automatic routing of mouse scroll to focused `IScrollable`
- `EscapeSequenceParser` detects SGR mouse scroll sequences

### Documentation
- Updated `streaming-text-node.md` with scrollbar and mouse scroll sections
- Updated `text-input-node.md` with paste handling documentation
- Updated `input-handling.md` with `PasteEvent` and `MouseScrollEvent` details

Closes #135
Closes #134
Closes #136