### PR TITLE
Prepare release 0.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,13 +10,30 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.5.1</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fixes**:
-- **Fix nullability propagation in [Reactive] source generator** ([#112](https://github.com/Aaronontheweb/Termina/pull/112))
-  - Source generator now preserves nullable reference type annotations (e.g., `string?`, `int?`) in generated properties
-  - Added custom `SymbolDisplayFormat` with `IncludeNullableReferenceTypeModifier` option
-  - Nullable fields now generate properties with matching nullability annotations, providing correct nullability hints in consuming code
-  - Previously, nullable fields like `string? _field` would generate non-nullable properties, losing nullability information
+    <VersionPrefix>0.6.0</VersionPrefix>
+    <PackageReleaseNotes>**New Features**:
+- **Scrollbar for StreamingTextNode** ([#138](https://github.com/Aaronontheweb/Termina/pull/138))
+  - Visual scrollbar renders on the right edge of `StreamingTextNode` when content exceeds the viewport
+  - `ScrollbarOptions` record for customizing track/thumb characters and colors, with `AutoHide` support
+  - `WithScrollbar()` fluent method on `StreamingTextNode` for opt-in configuration
+  - `GetMaxScrollOffset()` exposed on `PersistedStreamBuffer` for programmatic scroll position access
+  - Closes [#135](https://github.com/Aaronontheweb/Termina/issues/135)
+
+- **Bracketed paste mode for TextInputNode** ([#138](https://github.com/Aaronontheweb/Termina/pull/138))
+  - `TextInputNode` now implements `IPasteReceiver` and handles terminal bracketed paste sequences
+  - Multi-line pastes are captured as a single unit and displayed as a summary placeholder (e.g., `[Pasted 500 lines, 12345 chars]`)
+  - Full pasted content (with newlines preserved) is submitted on Enter
+  - Any edit action clears the paste and returns to normal input mode
+  - Prevents multi-line pastes from triggering individual per-line submissions
+  - `AnsiCodes.EnableBracketedPaste` / `DisableBracketedPaste` ANSI escape constants added
+  - Closes [#134](https://github.com/Aaronontheweb/Termina/issues/134)
+
+- **Mouse wheel scrolling for scrollable components** ([#138](https://github.com/Aaronontheweb/Termina/pull/138))
+  - New `MouseScrollEvent` input event for mouse wheel up/down
+  - New `IScrollable` interface for components that support scroll input
+  - Mouse scroll events are automatically routed to the currently focused `IScrollable` component
+  - `EscapeSequenceParser` detects SGR mouse scroll sequences
+  - Closes [#136](https://github.com/Aaronontheweb/Termina/issues/136)
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,31 @@
+#### 0.6.0 February 23rd 2026 ####
+
+**New Features**:
+- **Scrollbar for StreamingTextNode** ([#138](https://github.com/Aaronontheweb/Termina/pull/138))
+  - Visual scrollbar renders on the right edge of `StreamingTextNode` when content exceeds the viewport
+  - `ScrollbarOptions` record for customizing track/thumb characters and colors, with `AutoHide` support
+  - `WithScrollbar()` fluent method on `StreamingTextNode` for opt-in configuration
+  - `GetMaxScrollOffset()` exposed on `PersistedStreamBuffer` for programmatic scroll position access
+  - Closes [#135](https://github.com/Aaronontheweb/Termina/issues/135)
+
+- **Bracketed paste mode for TextInputNode** ([#138](https://github.com/Aaronontheweb/Termina/pull/138))
+  - `TextInputNode` now implements `IPasteReceiver` and handles terminal bracketed paste sequences
+  - Multi-line pastes are captured as a single unit and displayed as a summary placeholder (e.g., `[Pasted 500 lines, 12345 chars]`)
+  - Full pasted content (with newlines preserved) is submitted on Enter
+  - Any edit action clears the paste and returns to normal input mode
+  - Prevents multi-line pastes from triggering individual per-line submissions
+  - `AnsiCodes.EnableBracketedPaste` / `DisableBracketedPaste` ANSI escape constants added
+  - Closes [#134](https://github.com/Aaronontheweb/Termina/issues/134)
+
+- **Mouse wheel scrolling for scrollable components** ([#138](https://github.com/Aaronontheweb/Termina/pull/138))
+  - New `MouseScrollEvent` input event for mouse wheel up/down
+  - New `IScrollable` interface for components that support scroll input
+  - Mouse scroll events are automatically routed to the currently focused `IScrollable` component
+  - `EscapeSequenceParser` detects SGR mouse scroll sequences
+  - Closes [#136](https://github.com/Aaronontheweb/Termina/issues/136)
+
+---
+
 #### 0.5.1 December 19th 2025 ####
 
 **Bug Fixes**:


### PR DESCRIPTION
## Summary

- Updates `RELEASE_NOTES.md` with 0.6.0 release notes
- Updates `Directory.Build.props` version to `0.6.0` and injects release notes into `PackageReleaseNotes`

## Changes in this release

**New Features** (all via [#138](https://github.com/Aaronontheweb/Termina/pull/138)):

- **Scrollbar for `StreamingTextNode`** - Visual scrollbar on the right edge when content exceeds the viewport; `WithScrollbar()` fluent API; `ScrollbarOptions` for customization. Closes #135
- **Bracketed paste mode for `TextInputNode`** - Multi-line pastes captured as a single unit with a summary placeholder; full content submitted on Enter; `IPasteReceiver` interface and `PasteEvent` type added. Closes #134
- **Mouse wheel scrolling** - `MouseScrollEvent` and `IScrollable` interface; automatic routing of mouse scroll to the focused scrollable component. Closes #136

## Test plan

- [ ] Verify `RELEASE_NOTES.md` header reads `0.6.0 February 23rd 2026`
- [ ] Verify `Directory.Build.props` `VersionPrefix` is `0.6.0`
- [ ] Verify CI passes