### PR TITLE
Migrates to R3 reactive framework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,11 +7,11 @@
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
-    <PackageVersion Include="System.Reactive" Version="$(SystemReactiveVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Akka.Hosting" Version="1.5.60" />
+    <PackageVersion Include="R3" Version="1.3.0" />
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>

--- a/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryPage.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Extensions;
 using Termina.Layout;

--- a/demos/Termina.Demo.Gallery/Pages/GalleryMenuPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GalleryMenuPage.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Extensions;
 using Termina.Layout;

--- a/demos/Termina.Demo.Gallery/Pages/LayoutGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/LayoutGalleryPage.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
 using Termina.Extensions;
 using Termina.Input;
 using Termina.Layout;

--- a/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Extensions;
 using Termina.Layout;
@@ -185,7 +185,7 @@ public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewMod
         return Layouts.Horizontal()
             .WithChild(
                 ViewModel.StatusMessageChanged
-                    .Select(msg => new TextNode(msg).WithForeground(Color.White))
+                    .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
                     .Fill())
             .WithChild(

--- a/demos/Termina.Demo.Gallery/Pages/TextInputGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/TextInputGalleryPage.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Extensions;
 using Termina.Layout;
 using Termina.Reactive;
@@ -91,7 +91,7 @@ public class TextInputGalleryPage : ReactivePage<TextInputGalleryViewModel>
                     .Height(1))
             .WithChild(
                 ViewModel.StatusMessageChanged
-                    .Select(msg => new TextNode(msg).WithForeground(Color.White))
+                    .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
                     .Height(1));
     }

--- a/demos/Termina.Demo.Grid/DashboardPage.cs
+++ b/demos/Termina.Demo.Grid/DashboardPage.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Extensions;
 using Termina.Layout;
 using Termina.Reactive;
@@ -78,28 +78,28 @@ public class DashboardPage : ReactivePage<DashboardViewModel>
         metricsGrid.AddRow(
             new TextNode("CPU:").WithForeground(Color.Gray),
             ViewModel.CpuUsageChanged
-                .Select(cpu => BuildProgressBar(cpu, GetMetricColor(cpu)))
+                .Select<int, ILayoutNode>(cpu => BuildProgressBar(cpu, GetMetricColor(cpu)))
                 .AsLayout());
 
         // Memory row
         metricsGrid.AddRow(
             new TextNode("Memory:").WithForeground(Color.Gray),
             ViewModel.MemoryUsageChanged
-                .Select(mem => BuildProgressBar(mem, GetMetricColor(mem)))
+                .Select<int, ILayoutNode>(mem => BuildProgressBar(mem, GetMetricColor(mem)))
                 .AsLayout());
 
         // Disk row
         metricsGrid.AddRow(
             new TextNode("Disk:").WithForeground(Color.Gray),
             ViewModel.DiskUsageChanged
-                .Select(disk => BuildProgressBar(disk, GetMetricColor(disk)))
+                .Select<int, ILayoutNode>(disk => BuildProgressBar(disk, GetMetricColor(disk)))
                 .AsLayout());
 
         // Network row
         metricsGrid.AddRow(
             new TextNode("Network:").WithForeground(Color.Gray),
             ViewModel.NetworkUsageChanged
-                .Select(net => BuildProgressBar(net, GetMetricColor(net)))
+                .Select<int, ILayoutNode>(net => BuildProgressBar(net, GetMetricColor(net)))
                 .AsLayout());
 
         return metricsGrid;
@@ -203,7 +203,7 @@ public class DashboardPage : ReactivePage<DashboardViewModel>
         var statusBar = Layouts.Horizontal()
             .WithChild(
                 ViewModel.StatusMessageChanged
-                    .Select(status => new TextNode(status)
+                    .Select<string, ILayoutNode>(status => new TextNode(status)
                         .WithForeground(Color.BrightYellow)
                         .NoWrap())
                     .AsLayout()

--- a/demos/Termina.Demo.Grid/DashboardViewModel.cs
+++ b/demos/Termina.Demo.Grid/DashboardViewModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Input;
 using Termina.Reactive;
 
@@ -37,7 +37,7 @@ public partial class DashboardViewModel : ReactiveViewModel
         };
 
         // Subscribe to keyboard input
-        Input.OfType<KeyPressed>()
+        Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
 

--- a/demos/Termina.Demo.RegionBased/CounterPage.cs
+++ b/demos/Termina.Demo.RegionBased/CounterPage.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Extensions;
 using Termina.Layout;
 using Termina.Reactive;
@@ -38,7 +38,7 @@ public class CounterPage : ReactivePage<CounterViewModel>
                     .WithBorderColor(Color.Green)
                     .WithContent(
                         ViewModel.CountChanged
-                            .Select(count => new TextNode($"Count: {count}")
+                            .Select<int, ILayoutNode>(count => new TextNode($"Count: {count}")
                                 .WithForeground(Color.BrightCyan))
                             .AsLayout())
                     .Height(3))
@@ -50,7 +50,7 @@ public class CounterPage : ReactivePage<CounterViewModel>
                     .WithBorderColor(Color.Yellow)
                     .WithContent(
                         ViewModel.InputTextChanged
-                            .Select(text => new TextNode($"> {text}_")
+                            .Select<string, ILayoutNode>(text => new TextNode($"> {text}_")
                                 .WithForeground(Color.White)
                                 .NoWrap())
                             .AsLayout())
@@ -63,7 +63,7 @@ public class CounterPage : ReactivePage<CounterViewModel>
                     .WithBorderColor(Color.Magenta)
                     .WithContent(
                         ViewModel.MessagesChanged
-                            .Select(messages => new TextNode(messages.Count > 0
+                            .Select<List<string>, ILayoutNode>(messages => new TextNode(messages.Count > 0
                                 ? string.Join("\n", messages)
                                 : "(no messages yet)")
                                 .WithForeground(Color.Gray))
@@ -75,7 +75,7 @@ public class CounterPage : ReactivePage<CounterViewModel>
                 Layouts.Horizontal()
                     .WithChild(
                         ViewModel.StatusMessageChanged
-                            .Select(status => new TextNode(status)
+                            .Select<string, ILayoutNode>(status => new TextNode(status)
                                 .WithForeground(Color.BrightYellow)
                                 .NoWrap())  // Status should truncate, not wrap
                             .AsLayout()

--- a/demos/Termina.Demo.RegionBased/CounterViewModel.cs
+++ b/demos/Termina.Demo.RegionBased/CounterViewModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Input;
 using Termina.Reactive;
 
@@ -21,7 +21,7 @@ public partial class CounterViewModel : ReactiveViewModel
     public override void OnActivated()
     {
         // Subscribe to keyboard input
-        Input.OfType<KeyPressed>()
+        Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
     }

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Demo.Streaming.Actors;
 using Termina.Extensions;
@@ -90,12 +88,12 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
             .DisposeWith(Subscriptions);
 
         // Handle keyboard input - Page routes to interactive layout nodes
-        ViewModel.Input.OfType<KeyPressed>()
+        ViewModel.Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
 
         // Route mouse scroll events to chat history (when no focused IScrollable captures them)
-        ViewModel.Input.OfType<MouseScrollEvent>()
+        ViewModel.Input.OfType<IInputEvent, MouseScrollEvent>()
             .Subscribe(scroll =>
             {
                 IScrollable scrollable = _chatHistory;
@@ -147,6 +145,7 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
             {
                 ViewModel.RequestShutdown();
             }
+
             return;
         }
 
@@ -246,7 +245,7 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
             // Decision list - appears between chat history and input when active
             .WithChild(
                 _decisionListChanged
-                    .StartWith((ILayoutNode?)null)
+                    .Prepend((ILayoutNode?)null)
                     .Select(decisionList => decisionList == null
                         ? (ILayoutNode)new EmptyNode().Height(0)
                         : Layouts.Vertical()
@@ -266,21 +265,20 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
             // Status bar
             .WithChild(
                 Observable.CombineLatest(
-                    ViewModel.IsGeneratingChanged,
-                    ViewModel.ShowDecisionListChanged.StartWith(false),
-                    (isGenerating, showDecision) => showDecision
-                        ? "[↑/↓] Navigate [Enter] Select [1-4] Quick Select [Esc] Skip"
-                        : isGenerating
-                            ? "[Esc] Cancel  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit"
-                            : "[Enter] Send  [Ctrl+Shift+V] Paste  [↑/↓] History  [PgUp/PgDn/Wheel] Scroll  [Esc] Clear/Quit  [Ctrl+Q] Quit")
-                    .Select(text => new TextNode(text).WithForeground(Color.BrightBlack).NoWrap())
+                        ViewModel.IsGeneratingChanged,
+                        ViewModel.ShowDecisionListChanged.Prepend(false),
+                        (isGenerating, showDecision) => showDecision
+                            ? "[↑/↓] Navigate [Enter] Select [1-4] Quick Select [Esc] Skip"
+                            : isGenerating
+                                ? "[Esc] Cancel  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit"
+                                : "[Enter] Send  [Ctrl+Shift+V] Paste  [↑/↓] History  [PgUp/PgDn/Wheel] Scroll  [Esc] Clear/Quit  [Ctrl+Q] Quit")
+                    .Select<string, ILayoutNode>(text => new TextNode(text).WithForeground(Color.BrightBlack).NoWrap())
                     .AsLayout()
                     .Height(1))
             .WithChild(
                 ViewModel.StatusMessageChanged
-                    .Select(msg => new TextNode(msg).WithForeground(Color.White))
+                    .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
                     .Height(1));
     }
-
 }

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatViewModel.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Akka.Actor;
 using Akka.Hosting;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Demo.Streaming.Actors;
 using Termina.Layout;
@@ -41,12 +39,14 @@ public sealed record RemoveTrackedSegment(SegmentId Id) : IChatMessage;
 /// <summary>
 /// Replace a tracked segment with new content.
 /// </summary>
-public sealed record ReplaceTrackedSegment(SegmentId Id, ITextSegment NewSegment, bool KeepTracked = false) : IChatMessage;
+public sealed record ReplaceTrackedSegment(SegmentId Id, ITextSegment NewSegment, bool KeepTracked = false)
+    : IChatMessage;
 
 /// <summary>
 /// Show a decision point with choices for the user.
 /// </summary>
-public sealed record ShowDecisionPoint(string Question, IReadOnlyList<LlmMessages.DecisionChoice> Choices) : IChatMessage;
+public sealed record ShowDecisionPoint(string Question, IReadOnlyList<LlmMessages.DecisionChoice> Choices)
+    : IChatMessage;
 
 /// <summary>
 /// Hide the decision list (after selection or cancellation).
@@ -77,7 +77,7 @@ public partial class StreamingChatViewModel : ReactiveViewModel
     /// Observable for chat messages.
     /// Includes text appends and tracked segment operations.
     /// </summary>
-    public IObservable<IChatMessage> ChatOutput => _chatOutput.AsObservable();
+    public Observable<IChatMessage> ChatOutput => _chatOutput.AsObservable();
 
     // Reactive properties for UI state
     [Reactive] private bool _isGenerating = false;
@@ -101,7 +101,8 @@ public partial class StreamingChatViewModel : ReactiveViewModel
         _chatOutput.OnNext(new AppendText("🤖 ", Color.Yellow));
         _chatOutput.OnNext(new AppendText("Assistant: ", Color.Green, TextDecoration.Bold));
         _chatOutput.OnNext(new AppendText("Hello! I'm a simulated LLM demo.", Color.White, IsNewLine: true));
-        _chatOutput.OnNext(new AppendText("   Ask me anything and watch the streaming response!", Color.BrightBlack, IsNewLine: true));
+        _chatOutput.OnNext(new AppendText("   Ask me anything and watch the streaming response!", Color.BrightBlack,
+            IsNewLine: true));
         _chatOutput.OnNext(new AppendText("", IsNewLine: true));
     }
 

--- a/demos/Termina.Demo/Pages/CounterPage.cs
+++ b/demos/Termina.Demo/Pages/CounterPage.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Extensions;
 using Termina.Layout;
 using Termina.Reactive;
@@ -26,7 +26,7 @@ public class CounterPage : ReactivePage<CounterViewModel>
                     .WithBorderColor(Color.Blue)
                     .WithContent(
                         ViewModel.CountChanged
-                            .Select(count => new TextNode($"\n  Count: {count}\n")
+                            .Select<int, ILayoutNode>(count => new TextNode($"\n  Count: {count}\n")
                                 .WithForeground(Color.Cyan)
                                 .Bold())
                             .AsLayout())
@@ -37,7 +37,7 @@ public class CounterPage : ReactivePage<CounterViewModel>
                     .Height(1))
             .WithChild(
                 ViewModel.StatusMessageChanged
-                    .Select(msg => new TextNode(msg).WithForeground(Color.White))
+                    .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
                     .Height(1))
             .WithChild(

--- a/demos/Termina.Demo/Pages/CounterViewModel.cs
+++ b/demos/Termina.Demo/Pages/CounterViewModel.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Linq;
+using R3;
 using Termina.Input;
 using Termina.Reactive;
 
@@ -28,7 +28,7 @@ public partial class CounterViewModel : ReactiveViewModel
     public override void OnActivated()
     {
         // Subscribe to keyboard input
-        Input.OfType<KeyPressed>()
+        Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
     }

--- a/demos/Termina.Demo/Pages/TodoListPage.cs
+++ b/demos/Termina.Demo/Pages/TodoListPage.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Extensions;
-using Termina.Input;
 using Termina.Layout;
 using Termina.Reactive;
 using Termina.Rendering;
@@ -148,7 +147,7 @@ public class TodoListPage : ReactivePage<TodoListViewModel>
                     .Height(1))
             .WithChild(
                 ViewModel.StatusMessageChanged
-                    .Select(msg => new TextNode(msg).WithForeground(Color.White))
+                    .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.White))
                     .AsLayout()
                     .Height(1))
             .WithChild(
@@ -161,7 +160,8 @@ public class TodoListPage : ReactivePage<TodoListViewModel>
             .WithChild(mainContent)
             .WithChild(
                 ViewModel.IsAddingItemChanged
-                    .CombineLatest(ViewModel.ShowPriorityModalChanged, (adding, showPriority) => adding && !showPriority)
+                    .CombineLatest(ViewModel.ShowPriorityModalChanged,
+                        (adding, showPriority) => adding && !showPriority)
                     .Select(showModal => showModal
                         ? (ILayoutNode)_addModal
                         : Layouts.Empty())

--- a/demos/Termina.Demo/Pages/TodoListViewModel.cs
+++ b/demos/Termina.Demo/Pages/TodoListViewModel.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Linq;
+using R3;
 using Termina.Input;
 using Termina.Reactive;
 
@@ -39,7 +39,7 @@ public partial class TodoListViewModel : ReactiveViewModel
     public override void OnActivated()
     {
         // Subscribe to keyboard input
-        Input.OfType<KeyPressed>()
+        Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
     }

--- a/src/Termina.Generators/ReactivePropertyGenerator.cs
+++ b/src/Termina.Generators/ReactivePropertyGenerator.cs
@@ -295,8 +295,7 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
         sb.AppendLine("using System;");
         if (reactiveFields.Count > 0)
         {
-            sb.AppendLine("using System.Reactive.Linq;");
-            sb.AppendLine("using System.Reactive.Subjects;");
+            sb.AppendLine("using R3;");
         }
         if (hasFromRouteFields)
         {
@@ -377,7 +376,7 @@ public class ReactivePropertyGenerator : IIncrementalGenerator
         sb.AppendLine($"        set => {subjectFieldName}.OnNext(value);");
         sb.AppendLine("    }");
         sb.AppendLine();
-        sb.AppendLine($"    public IObservable<{field.FieldType}> {propertyName}Changed => {subjectFieldName}.AsObservable();");
+        sb.AppendLine($"    public Observable<{field.FieldType}> {propertyName}Changed => {subjectFieldName}.AsObservable();");
     }
 
     private static void GenerateRouteProperty(StringBuilder sb, FieldInfo field)

--- a/src/Termina/Component.cs
+++ b/src/Termina/Component.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Layout;
 
 namespace Termina;
@@ -39,7 +38,7 @@ public abstract class Component
     /// that the UI needs to be updated, similar to Control.Invoke in WinForms or
     /// Dispatcher.Invoke in WPF.
     /// </remarks>
-    public IObservable<Unit> ContentChanged => _contentChanged;
+    public Observable<Unit> ContentChanged => _contentChanged;
 
     /// <summary>
     /// Marks this component as needing a redraw.

--- a/src/Termina/Components/Streaming/BlockSegment.cs
+++ b/src/Termina/Components/Streaming/BlockSegment.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
+using R3;
 
 namespace Termina.Components.Streaming;
 
@@ -42,7 +41,7 @@ public sealed class BlockSegment : ITextSegment, IAnimatedTextSegment
     public StyledSegment GetCurrentSegment() => _inner.GetCurrentSegment();
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated =>
+    public Observable<Unit> Invalidated =>
         _inner is IAnimatedTextSegment animated
             ? animated.Invalidated
             : Observable.Empty<Unit>();

--- a/src/Termina/Components/Streaming/CompositeTextSegment.cs
+++ b/src/Termina/Components/Streaming/CompositeTextSegment.cs
@@ -1,12 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Text;
-using Termina.Terminal;
+using R3;
 
 namespace Termina.Components.Streaming;
 
@@ -70,7 +66,7 @@ public sealed class CompositeTextSegment : ICompositeTextSegment, IAnimatedTextS
     public IReadOnlyList<ITextSegment> Children => _children.AsReadOnly();
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
     /// <inheritdoc />
     public bool IsAnimating => _isAnimating && _children.OfType<IAnimatedTextSegment>().Any(a => a.IsAnimating);

--- a/src/Termina/Components/Streaming/IAnimatedTextSegment.cs
+++ b/src/Termina/Components/Streaming/IAnimatedTextSegment.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
+using R3;
 
 namespace Termina.Components.Streaming;
 
@@ -15,7 +15,7 @@ public interface IAnimatedTextSegment : ITextSegment
     /// Observable that fires when the segment's display text changes and needs re-rendering.
     /// Subscribe to this to trigger redraws when animation frames change.
     /// </summary>
-    IObservable<Unit> Invalidated { get; }
+    Observable<Unit> Invalidated { get; }
 
     /// <summary>
     /// Start the animation.

--- a/src/Termina/Components/Streaming/SpinnerSegment.cs
+++ b/src/Termina/Components/Streaming/SpinnerSegment.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Timers;
+using R3;
 using Termina.Terminal;
 using Timer = System.Timers.Timer;
 
@@ -74,7 +72,7 @@ public sealed class SpinnerSegment : IAnimatedTextSegment
     }
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
     /// <inheritdoc />
     public bool IsAnimating => _timer.Enabled;

--- a/src/Termina/Extensions/ObservableLayoutExtensions.cs
+++ b/src/Termina/Extensions/ObservableLayoutExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using R3;
 using Termina.Layout;
 
 namespace Termina.Extensions;
@@ -16,7 +17,7 @@ public static class ObservableLayoutExtensions
     /// </summary>
     /// <param name="source">Observable that emits layout nodes.</param>
     /// <returns>A layout node that updates when the observable emits.</returns>
-    public static ReactiveLayoutNode AsLayout(this IObservable<ILayoutNode> source)
+    public static ReactiveLayoutNode AsLayout(this Observable<ILayoutNode> source)
     {
         return new ReactiveLayoutNode(source);
     }
@@ -29,7 +30,7 @@ public static class ObservableLayoutExtensions
     /// <param name="transform">Function to transform values into layout nodes.</param>
     /// <returns>A layout node that updates when the observable emits.</returns>
     public static ReactiveLayoutNode<T> AsLayout<T>(
-        this IObservable<T> source,
+        this Observable<T> source,
         Func<T, ILayoutNode> transform)
     {
         return new ReactiveLayoutNode<T>(source, transform);
@@ -40,7 +41,7 @@ public static class ObservableLayoutExtensions
     /// </summary>
     /// <param name="source">Observable that emits strings.</param>
     /// <returns>A layout node that displays the current string.</returns>
-    public static ReactiveLayoutNode<string> AsTextLayout(this IObservable<string> source)
+    public static ReactiveLayoutNode<string> AsTextLayout(this Observable<string> source)
     {
         return new ReactiveLayoutNode<string>(source, text => new TextNode(text));
     }

--- a/src/Termina/Input/FocusManager.cs
+++ b/src/Termina/Input/FocusManager.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Diagnostics;
 using Termina.Layout;
 
@@ -23,7 +22,7 @@ public sealed class FocusManager : IFocusManager, IDisposable
     private bool _disposed;
 
     /// <inheritdoc />
-    public IObservable<IFocusable?> FocusChanged => _focusChanged.AsObservable();
+    public Observable<IFocusable?> FocusChanged => _focusChanged.AsObservable();
 
     /// <inheritdoc />
     public IFocusable? CurrentFocus => _focusStack.Count > 0 ? _focusStack.Peek() : null;

--- a/src/Termina/Input/IFocusManager.cs
+++ b/src/Termina/Input/IFocusManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using R3;
 using Termina.Layout;
 
 namespace Termina.Input;
@@ -18,7 +19,7 @@ public interface IFocusManager
     /// <summary>
     /// Observable that emits when focus changes.
     /// </summary>
-    IObservable<IFocusable?> FocusChanged { get; }
+    Observable<IFocusable?> FocusChanged { get; }
 
     /// <summary>
     /// Gets the currently focused component, or null if nothing has focus.

--- a/src/Termina/Input/PlatformInputSource.cs
+++ b/src/Termina/Input/PlatformInputSource.cs
@@ -4,6 +4,7 @@
 using System.Threading.Channels;
 using Termina.Diagnostics;
 using Termina.Platform;
+using R3;
 
 namespace Termina.Input;
 

--- a/src/Termina/Layout/ConditionalNode.cs
+++ b/src/Termina/Layout/ConditionalNode.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Rendering;
 
 namespace Termina.Layout;
@@ -12,7 +11,7 @@ namespace Termina.Layout;
 /// </summary>
 public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
 {
-    private readonly IObservable<bool> _source;
+    private readonly Observable<bool> _source;
     private IDisposable? _subscription;
     private readonly Subject<Unit> _invalidated = new();
     private bool _condition;
@@ -21,7 +20,7 @@ public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
     private bool _isActive = true;
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Create a conditional node that shows/hides based on an observable condition.
@@ -29,7 +28,7 @@ public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
     /// <param name="condition">Observable that emits true/false.</param>
     /// <param name="thenNode">Node to show when condition is true.</param>
     /// <param name="elseNode">Node to show when condition is false (optional).</param>
-    public ConditionalNode(IObservable<bool> condition, ILayoutNode thenNode, ILayoutNode? elseNode = null)
+    public ConditionalNode(Observable<bool> condition, ILayoutNode thenNode, ILayoutNode? elseNode = null)
     {
         _source = condition;
         _thenNode = thenNode;
@@ -44,8 +43,8 @@ public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
                     _invalidated.OnNext(Unit.Default);
                 }
             },
-            onError: _ => { },
-            onCompleted: () => { });
+            onErrorResume: _ => { },
+            onCompleted: _ => { });
     }
 
     private ILayoutNode ActiveNode => _condition ? _thenNode : _elseNode;
@@ -71,7 +70,10 @@ public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
         _isActive = true;
 
         // If subscription was disposed during deactivation, recreate it
-        if (_subscription == null || _subscription is System.Reactive.Disposables.BooleanDisposable { IsDisposed: true })
+        if (_subscription == null || _subscription is BooleanDisposable
+            {
+                IsDisposed: true
+            })
         {
             _subscription = _source.Subscribe(
                 onNext: value =>
@@ -82,8 +84,8 @@ public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
                         _invalidated.OnNext(Unit.Default);
                     }
                 },
-                onError: _ => { },
-                onCompleted: () => { });
+                onErrorResume: _ => { },
+                onCompleted: _ => { });
         }
 
         // Activate both branches (both are always kept in memory)
@@ -141,7 +143,7 @@ public static class When
     /// <summary>
     /// Show content when condition is true.
     /// </summary>
-    public static ConditionalNode True(IObservable<bool> condition, ILayoutNode content)
+    public static ConditionalNode True(Observable<bool> condition, ILayoutNode content)
     {
         return new ConditionalNode(condition, content);
     }
@@ -150,7 +152,7 @@ public static class When
     /// Show content when condition is true, otherwise show else content.
     /// </summary>
     public static ConditionalNode TrueElse(
-        IObservable<bool> condition,
+        Observable<bool> condition,
         ILayoutNode thenContent,
         ILayoutNode elseContent)
     {
@@ -160,10 +162,10 @@ public static class When
     /// <summary>
     /// Show content when condition is false.
     /// </summary>
-    public static ConditionalNode False(IObservable<bool> condition, ILayoutNode content)
+    public static ConditionalNode False(Observable<bool> condition, ILayoutNode content)
     {
         return new ConditionalNode(
-            System.Reactive.Linq.Observable.Select(condition, c => !c),
+            condition.Select(c => !c),
             content);
     }
 }

--- a/src/Termina/Layout/GridNode.cs
+++ b/src/Termina/Layout/GridNode.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -103,17 +101,17 @@ public sealed class GridNode : LayoutNode, IFocusable, IInvalidatingNode
     public bool ShowFocusHighlight { get; private set; } = true;
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
     /// <summary>
     /// Observable that emits when the focused cell changes.
     /// </summary>
-    public IObservable<(int Row, int Col)> FocusedCellChanged => _focusedCellChanged.AsObservable();
+    public Observable<(int Row, int Col)> FocusedCellChanged => _focusedCellChanged.AsObservable();
 
     /// <summary>
     /// Observable that emits when a cell is activated (Enter pressed).
     /// </summary>
-    public IObservable<(int Row, int Col, ILayoutNode? Cell)> CellActivated => _cellActivated.AsObservable();
+    public Observable<(int Row, int Col, ILayoutNode? Cell)> CellActivated => _cellActivated.AsObservable();
 
     /// <summary>
     /// Gets the number of rows in the grid.

--- a/src/Termina/Layout/ILayoutNode.cs
+++ b/src/Termina/Layout/ILayoutNode.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
+using R3;
 using Termina.Rendering;
 
 namespace Termina.Layout;
@@ -58,7 +58,7 @@ public interface IInvalidatingNode : ILayoutNode
     /// <summary>
     /// Observable that emits when this node's content has changed and needs re-rendering.
     /// </summary>
-    IObservable<Unit> Invalidated { get; }
+    Observable<Unit> Invalidated { get; }
 }
 
 /// <summary>

--- a/src/Termina/Layout/LayoutNode.cs
+++ b/src/Termina/Layout/LayoutNode.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Rendering;
 
 namespace Termina.Layout;
@@ -156,7 +155,7 @@ public abstract class ContainerNode : LayoutNode, IContainerNode, IInvalidatingN
     private readonly Subject<Unit> _invalidated = new();
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <inheritdoc />
     public IReadOnlyList<ILayoutNode> Children => _children;

--- a/src/Termina/Layout/ModalNode.cs
+++ b/src/Termina/Layout/ModalNode.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -58,12 +56,12 @@ public sealed class ModalNode : LayoutNode, IFocusable, IInvalidatingNode
     };
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
     /// <summary>
     /// Observable that emits when the modal is dismissed (e.g., Escape pressed).
     /// </summary>
-    public IObservable<Unit> Dismissed => _dismissed.AsObservable();
+    public Observable<Unit> Dismissed => _dismissed.AsObservable();
 
     /// <inheritdoc />
     public new SizeConstraint WidthConstraint => SizeConstraint.FillRemaining();

--- a/src/Termina/Layout/PanelNode.cs
+++ b/src/Termina/Layout/PanelNode.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -18,7 +17,7 @@ public sealed class PanelNode : LayoutNode, IInvalidatingNode
     private readonly Subject<Unit> _invalidated = new();
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Panel title (displayed in top border).

--- a/src/Termina/Layout/ReactiveLayoutNode.cs
+++ b/src/Termina/Layout/ReactiveLayoutNode.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Rendering;
 
 namespace Termina.Layout;
@@ -14,7 +12,7 @@ namespace Termina.Layout;
 /// </summary>
 public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
 {
-    private readonly IObservable<ILayoutNode> _source;
+    private readonly Observable<ILayoutNode> _source;
     private IDisposable? _subscription;
     private IDisposable? _childInvalidationSubscription;
     private readonly Subject<Unit> _invalidated = new();
@@ -23,12 +21,12 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
     private bool _isActive = false;
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Create a reactive layout node from an observable of layout nodes.
     /// </summary>
-    public ReactiveLayoutNode(IObservable<ILayoutNode> source, ILayoutNode? initialChild = null)
+    public ReactiveLayoutNode(Observable<ILayoutNode> source, ILayoutNode? initialChild = null)
     {
         _source = source;
         _currentChild = initialChild ?? new EmptyNode();
@@ -53,8 +51,8 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
 
                 _invalidated.OnNext(Unit.Default);
             },
-            onError: _ => { },
-            onCompleted: () => { });
+            onErrorResume: _ => { },
+            onCompleted: _ => { });
     }
 
     /// <summary>
@@ -121,8 +119,8 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
 
                     _invalidated.OnNext(Unit.Default);
                 },
-                onError: _ => { },
-                onCompleted: () => { });
+                onErrorResume: _ => { },
+                onCompleted: _ => { });
         }
 
         // Re-subscribe to current child's invalidation events (might have been disposed)
@@ -172,7 +170,7 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
 /// </summary>
 public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
 {
-    private readonly IObservable<T> _source;
+    private readonly Observable<T> _source;
     private readonly Func<T, ILayoutNode> _transform;
     private IDisposable? _subscription;
     private IDisposable? _childInvalidationSubscription;
@@ -181,12 +179,12 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
     private bool _isActive = false;
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Create a reactive layout node from an observable with a transform function.
     /// </summary>
-    public ReactiveLayoutNode(IObservable<T> source, Func<T, ILayoutNode> transform)
+    public ReactiveLayoutNode(Observable<T> source, Func<T, ILayoutNode> transform)
     {
         _source = source;
         _transform = transform;
@@ -211,8 +209,8 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
 
                 _invalidated.OnNext(Unit.Default);
             },
-            onError: _ => { },
-            onCompleted: () => { });
+            onErrorResume: _ => { },
+            onCompleted: _ => { });
     }
 
     /// <summary>
@@ -277,8 +275,8 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
 
                     _invalidated.OnNext(Unit.Default);
                 },
-                onError: _ => { },
-                onCompleted: () => { });
+                onErrorResume: _ => { },
+                onCompleted: _ => { });
         }
 
         // Re-subscribe to current child's invalidation events (might have been disposed)

--- a/src/Termina/Layout/ScrollableContainerNode.cs
+++ b/src/Termina/Layout/ScrollableContainerNode.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -46,7 +44,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     private IDisposable? _contentSubscription;
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Gets or sets the automatic scroll policy.

--- a/src/Termina/Layout/SelectionItem.cs
+++ b/src/Termina/Layout/SelectionItem.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using Termina.Components.Streaming;
+using R3;
 
 namespace Termina.Layout;
 

--- a/src/Termina/Layout/SelectionItemContent.cs
+++ b/src/Termina/Layout/SelectionItemContent.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Terminal;
 
@@ -46,7 +43,7 @@ public sealed class SelectionItemContent : IDisposable
     /// <summary>
     /// Observable that fires when any animated segment in this content changes.
     /// </summary>
-    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
     /// <summary>
     /// Gets whether this content contains any animated segments.

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using Termina.Components.Streaming;
+using R3;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -104,22 +101,22 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     }
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
     /// <summary>
     /// Observable that emits the selected items when Enter is pressed.
     /// </summary>
-    public IObservable<IReadOnlyList<T>> SelectionConfirmed => _selectionConfirmed.AsObservable();
+    public Observable<IReadOnlyList<T>> SelectionConfirmed => _selectionConfirmed.AsObservable();
 
     /// <summary>
     /// Observable that emits the custom text when "Other" is selected and confirmed.
     /// </summary>
-    public IObservable<string> OtherSelected => _otherSelected.AsObservable();
+    public Observable<string> OtherSelected => _otherSelected.AsObservable();
 
     /// <summary>
     /// Observable that emits when Escape is pressed.
     /// </summary>
-    public IObservable<Unit> Cancelled => _cancelled.AsObservable();
+    public Observable<Unit> Cancelled => _cancelled.AsObservable();
 
     /// <inheritdoc />
     public SizeConstraint WidthConstraint => SizeConstraint.FillRemaining();

--- a/src/Termina/Layout/SpinnerNode.cs
+++ b/src/Termina/Layout/SpinnerNode.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
 using System.Timers;
+using R3;
 using Termina.Rendering;
 using Termina.Terminal;
 using Timer = System.Timers.Timer;
@@ -83,7 +82,7 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     public Color? LabelColor { get; private set; }
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <inheritdoc />
     public bool IsAnimating { get; private set; }

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Rendering;
 using Termina.Terminal;
@@ -40,12 +39,12 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
     private record TrackedElement(SegmentId Id, ITextSegment Segment) : ContentElement;  // Tracked segment
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Observable that emits when content changes. Alias for Invalidated.
     /// </summary>
-    public IObservable<Unit> ContentChanged => _invalidated;
+    public Observable<Unit> ContentChanged => _invalidated;
 
     /// <summary>
     /// Gets or sets the foreground color.

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
 using System.Timers;
+using R3;
 using Termina.Diagnostics;
 using Termina.Input;
 using Termina.Rendering;
@@ -38,17 +37,17 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     private int _maxHistoryEntries;
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidated => _invalidated;
+    public Observable<Unit> Invalidated => _invalidated;
 
     /// <summary>
     /// Observable that emits when the text value changes.
     /// </summary>
-    public IObservable<string> TextChanged => _textChanged;
+    public Observable<string> TextChanged => _textChanged;
 
     /// <summary>
     /// Observable that emits when Enter is pressed.
     /// </summary>
-    public IObservable<string> Submitted => _submitted;
+    public Observable<string> Submitted => _submitted;
 
     /// <inheritdoc />
     public bool IsAnimating { get; private set; }

--- a/src/Termina/Platform/FallbackConsole.cs
+++ b/src/Termina/Platform/FallbackConsole.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Subjects;
+using R3;
 
 namespace Termina.Platform;
 
@@ -30,7 +30,7 @@ public sealed class FallbackConsole : IPlatformConsole
     public bool SupportsEventDrivenInput => false;
 
     /// <inheritdoc />
-    public IObservable<ConsoleResizeEvent> Resized => _resized;
+    public Observable<ConsoleResizeEvent> Resized => _resized;
 
     /// <inheritdoc />
     public void Initialize()

--- a/src/Termina/Platform/IPlatformConsole.cs
+++ b/src/Termina/Platform/IPlatformConsole.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using R3;
+
 namespace Termina.Platform;
 
 /// <summary>
@@ -78,7 +80,7 @@ public interface IPlatformConsole : IDisposable
     /// The fallback implementation polls Console.WindowWidth/Height.
     /// </para>
     /// </remarks>
-    IObservable<ConsoleResizeEvent> Resized { get; }
+    Observable<ConsoleResizeEvent> Resized { get; }
 
     /// <summary>
     /// Gets whether this platform console supports true event-driven input.

--- a/src/Termina/Platform/UnixConsole.cs
+++ b/src/Termina/Platform/UnixConsole.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Subjects;
 using System.Runtime.Versioning;
+using R3;
 
 namespace Termina.Platform;
 
@@ -38,7 +38,7 @@ public sealed class UnixConsole : IPlatformConsole
     public bool SupportsEventDrivenInput => true;
 
     /// <inheritdoc />
-    public IObservable<ConsoleResizeEvent> Resized => _resized;
+    public Observable<ConsoleResizeEvent> Resized => _resized;
 
     /// <inheritdoc />
     public void Initialize()

--- a/src/Termina/Platform/WindowsConsole.cs
+++ b/src/Termina/Platform/WindowsConsole.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Subjects;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Threading.Channels;
+using R3;
 using Termina.Diagnostics;
 
 namespace Termina.Platform;
@@ -196,7 +195,7 @@ public sealed class WindowsConsole : IPlatformConsole
     public bool SupportsEventDrivenInput => true;
 
     /// <inheritdoc />
-    public IObservable<ConsoleResizeEvent> Resized => _resized;
+    public Observable<ConsoleResizeEvent> Resized => _resized;
 
     /// <inheritdoc />
     public void Initialize()

--- a/src/Termina/Reactive/ReactiveAttribute.cs
+++ b/src/Termina/Reactive/ReactiveAttribute.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using R3;
 
 namespace Termina.Reactive;
 
@@ -14,9 +15,9 @@ namespace Termina.Reactive;
 /// The source generator will create:
 /// </para>
 /// <list type="bullet">
-///   <item>A <see cref="System.Reactive.Subjects.BehaviorSubject{T}"/> backing field (<c>_fieldNameSubject</c>)</item>
+///   <item>A <see cref="BehaviorSubject{T}"/> backing field (<c>_fieldNameSubject</c>)</item>
 ///   <item>A public property with get/set that reads/writes to the subject</item>
-///   <item>A public <c>IObservable{T}</c> property (<c>PropertyNameChanged</c>) for subscriptions</item>
+///   <item>A public <c>Observable{T}</c> property (<c>PropertyNameChanged</c>) for subscriptions</item>
 /// </list>
 /// <para>
 /// <b>Usage:</b>
@@ -40,7 +41,7 @@ namespace Termina.Reactive;
 ///     set => _nameSubject.OnNext(value);
 /// }
 ///
-/// public IObservable&lt;string&gt; NameChanged => _nameSubject.AsObservable();
+/// public Observable&lt;string&gt; NameChanged => _nameSubject.AsObservable();
 /// </code>
 /// <para>
 /// <b>Note:</b> The original field marked with [Reactive] is intentionally unused at runtime.

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
+using R3;
 using Termina.Input;
 using Termina.Layout;
 using Termina.Pages;

--- a/src/Termina/Reactive/ReactiveViewModel.cs
+++ b/src/Termina/Reactive/ReactiveViewModel.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Disposables;
+using R3;
 using Termina.Input;
 
 namespace Termina.Reactive;
@@ -106,7 +106,7 @@ public abstract class ReactiveViewModel : IDisposable
     /// Subscribe to this in the ViewModel to handle keyboard input,
     /// or access from the Page to route input to interactive layout nodes.
     /// </summary>
-    public IObservable<IInputEvent> Input { get; private set; } = null!;
+    public Observable<IInputEvent> Input { get; private set; } = null!;
 
     /// <summary>
     /// Request graceful application shutdown.
@@ -163,7 +163,7 @@ public abstract class ReactiveViewModel : IDisposable
         Action<string, object?> navigateWithParams,
         Action shutdown,
         Action requestRedraw,
-        IObservable<IInputEvent> input)
+        Observable<IInputEvent> input)
     {
         Navigate = navigate;
         NavigateWithParams = navigateWithParams;

--- a/src/Termina/Reactive/RxExtensions.cs
+++ b/src/Termina/Reactive/RxExtensions.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Disposables;
+using R3;
 
 namespace Termina.Reactive;
 

--- a/src/Termina/Rendering/ScrollableContent.cs
+++ b/src/Termina/Rendering/ScrollableContent.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Terminal;
 
 namespace Termina.Rendering;
@@ -75,7 +74,7 @@ public sealed class ScrollableContent : IRenderable, IDisposable
     /// <summary>
     /// Observable that emits when the component needs to be re-rendered.
     /// </summary>
-    public IObservable<Unit> Dirty => _dirty;
+    public Observable<Unit> Dirty => _dirty;
 
     /// <summary>
     /// Set the content as an array of text lines.

--- a/src/Termina/Rendering/TextInput.cs
+++ b/src/Termina/Rendering/TextInput.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Terminal;
 
 namespace Termina.Rendering;
@@ -31,12 +30,12 @@ public sealed class TextInput : IRenderable, IDisposable
     /// <summary>
     /// Observable that emits when Enter is pressed, providing the submitted text.
     /// </summary>
-    public IObservable<string> Submitted => _submitted;
+    public Observable<string> Submitted => _submitted;
 
     /// <summary>
     /// Observable that emits when the component needs to be re-rendered.
     /// </summary>
-    public IObservable<Unit> Dirty => _dirty;
+    public Observable<Unit> Dirty => _dirty;
 
     /// <summary>
     /// Gets or sets the label displayed before the input.

--- a/src/Termina/Termina.csproj
+++ b/src/Termina/Termina.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"/>
+    <PackageReference Include="R3" />
   </ItemGroup>
 
   <!--

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
+using R3;
 using Termina.Diagnostics;
 using Termina.Hosting;
 using Termina.Input;
@@ -101,7 +100,7 @@ public sealed class TerminaApplication
     /// <summary>
     /// Observable stream of input events. ViewModels subscribe to this.
     /// </summary>
-    public IObservable<IInputEvent> Input => _inputSubject.AsObservable();
+    public Observable<IInputEvent> Input => _inputSubject.AsObservable();
 
     /// <summary>
     /// Gets the focus manager for routing input to focused components.

--- a/tests/Termina.Tests/Components/Streaming/BlockSegmentTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/BlockSegmentTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Terminal;
 using Xunit;
@@ -52,7 +52,7 @@ public class BlockSegmentTests
         block.Invalidated.Subscribe(_ => invalidated = true);
 
         // Wait for spinner animation
-        await spinner.Invalidated.FirstAsync().Timeout(TimeSpan.FromSeconds(1));
+        await spinner.Invalidated.FirstAsync().WaitAsync(TimeSpan.FromSeconds(1));
 
         Assert.True(invalidated);
 

--- a/tests/Termina.Tests/Components/Streaming/CompositeTextSegmentTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/CompositeTextSegmentTests.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
 using Termina.Components.Streaming;
-using Termina.Terminal;
+using R3;
 
 namespace Termina.Tests.Components.Streaming;
 
@@ -82,7 +80,7 @@ public class CompositeTextSegmentTests
         // Wait for invalidation from spinner
         await composite.Invalidated
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(1));
+            .WaitAsync(TimeSpan.FromSeconds(1));
 
         // If we got here, invalidation was propagated
         Assert.True(true);
@@ -128,7 +126,7 @@ public class CompositeTextSegmentTests
         var invalidatedCompleted = false;
         composite.Invalidated.Subscribe(
             onNext: _ => { },
-            onCompleted: () => invalidatedCompleted = true);
+            onCompleted: _ => invalidatedCompleted = true);
 
         composite.Dispose();
 

--- a/tests/Termina.Tests/Input/FocusManagerTests.cs
+++ b/tests/Termina.Tests/Input/FocusManagerTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
 using Termina.Input;
 using Termina.Layout;
 using Termina.Rendering;
-using Termina.Terminal;
+using R3;
 
 namespace Termina.Tests.Input;
 

--- a/tests/Termina.Tests/Input/PageInputHandlerTests.cs
+++ b/tests/Termina.Tests/Input/PageInputHandlerTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
 using Termina.Input;
 using Termina.Layout;
 using Termina.Reactive;
 using Termina.Rendering;
-using Termina.Terminal;
 
 namespace Termina.Tests.Input;
 

--- a/tests/Termina.Tests/Layout/GridNodeTests.cs
+++ b/tests/Termina.Tests/Layout/GridNodeTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Layout;
 using Termina.Rendering;
 using Termina.Terminal;

--- a/tests/Termina.Tests/Layout/LayoutNodeLifecycleTests.cs
+++ b/tests/Termina.Tests/Layout/LayoutNodeLifecycleTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Layout;
 
 namespace Termina.Tests.Layout;
@@ -374,7 +372,7 @@ public class LayoutNodeLifecycleTests
 
         node.Submitted.Subscribe(
             _ => { },
-            () => completed = true);
+            _ => completed = true);
 
         // Act
         node.Dispose();

--- a/tests/Termina.Tests/Layout/ModalNodeTests.cs
+++ b/tests/Termina.Tests/Layout/ModalNodeTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
+using R3;
 using Termina.Layout;
 using Termina.Rendering;
 using Termina.Terminal;
@@ -167,10 +166,10 @@ public class ModalNodeTests
 
         modal.Invalidated.Subscribe(
             onNext: _ => { },
-            onCompleted: () => invalidatedCompleted = true);
+            onCompleted: _ => invalidatedCompleted = true);
         modal.Dismissed.Subscribe(
             onNext: _ => { },
-            onCompleted: () => dismissedCompleted = true);
+            onCompleted: _ => dismissedCompleted = true);
 
         modal.Dispose();
 

--- a/tests/Termina.Tests/Layout/ReactiveLayoutNodeInvalidationTests.cs
+++ b/tests/Termina.Tests/Layout/ReactiveLayoutNodeInvalidationTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Layout;
 using Termina.Rendering;
 

--- a/tests/Termina.Tests/Layout/SelectionItemContentTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionItemContentTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Layout;
 using Termina.Terminal;
@@ -155,7 +154,7 @@ public class SelectionItemContentTests
         // Wait for invalidation
         await content.Invalidated
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(1));
+            .WaitAsync(TimeSpan.FromSeconds(1));
 
         Assert.True(true); // Got here means invalidation was received
     }
@@ -169,7 +168,7 @@ public class SelectionItemContentTests
         var completed = false;
         content.Invalidated.Subscribe(
             onNext: _ => { },
-            onCompleted: () => completed = true);
+            onCompleted: _ => completed = true);
 
         content.Dispose();
 

--- a/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Layout;
-using Termina.Rendering;
 using Termina.Terminal;
 using Streaming = Termina.Components.Streaming;
 
@@ -290,16 +288,16 @@ public class SelectionListNodeTests
 
         list.SelectionConfirmed.Subscribe(
             onNext: _ => { },
-            onCompleted: () => completed++);
+            onCompleted: _ => completed++);
         list.OtherSelected.Subscribe(
             onNext: _ => { },
-            onCompleted: () => completed++);
+            onCompleted: _ => completed++);
         list.Cancelled.Subscribe(
             onNext: _ => { },
-            onCompleted: () => completed++);
+            onCompleted: _ => completed++);
         list.Invalidated.Subscribe(
             onNext: _ => { },
-            onCompleted: () => completed++);
+            onCompleted: _ => completed++);
 
         list.Dispose();
 
@@ -678,7 +676,7 @@ public class SelectionListNodeTests
         // Wait for invalidation from spinner
         await list.Invalidated
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(1));
+            .WaitAsync(TimeSpan.FromSeconds(1));
 
         Assert.True(true); // Got here means invalidation propagated
     }
@@ -693,7 +691,7 @@ public class SelectionListNodeTests
         var completed = 0;
         list.Invalidated.Subscribe(
             onNext: _ => { },
-            onCompleted: () => completed++);
+            onCompleted: _ => completed++);
 
         list.Dispose();
 

--- a/tests/Termina.Tests/Layout/StreamingTextNodeBlockSegmentTests.cs
+++ b/tests/Termina.Tests/Layout/StreamingTextNodeBlockSegmentTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Layout;
 using Termina.Terminal;
@@ -142,7 +142,7 @@ public class StreamingTextNodeBlockSegmentTests
         var frame1 = node.Buffer.GetAllStyledLines()[1].ToPlainText();
 
         // Wait for animation frame
-        await spinner.Invalidated.FirstAsync().Timeout(TimeSpan.FromSeconds(1));
+        await spinner.Invalidated.FirstAsync().WaitAsync(TimeSpan.FromSeconds(1));
 
         var frame2 = node.Buffer.GetAllStyledLines()[1].ToPlainText();
 

--- a/tests/Termina.Tests/Layout/StreamingTextNodeStyledTests.cs
+++ b/tests/Termina.Tests/Layout/StreamingTextNodeStyledTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using R3;
 using Termina.Components.Streaming;
 using Termina.Layout;
 using Termina.Rendering;

--- a/tests/Termina.Tests/Layout/StreamingTextNodeTrackedSegmentTests.cs
+++ b/tests/Termina.Tests/Layout/StreamingTextNodeTrackedSegmentTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Layout;
 using Termina.Terminal;
@@ -197,7 +196,7 @@ public class StreamingTextNodeTrackedSegmentTests
         // Wait for actual invalidation event instead of sleeping
         await spinner.Invalidated
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(1));
+            .WaitAsync(TimeSpan.FromSeconds(1));
 
         var frame2 = spinner.GetCurrentSegment().Text;
 
@@ -215,7 +214,7 @@ public class StreamingTextNodeTrackedSegmentTests
         // Wait for actual invalidation event instead of sleeping
         await spinner.Invalidated
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(1));
+            .WaitAsync(TimeSpan.FromSeconds(1));
 
         // If we get here without timeout, the event fired
         spinner.Dispose();
@@ -299,7 +298,7 @@ public class StreamingTextNodeTrackedSegmentTests
         // Wait for actual content change event instead of sleeping
         await node.ContentChanged
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(1));
+            .WaitAsync(TimeSpan.FromSeconds(1));
 
         // If we get here without timeout, the event fired
         newSpinner.Dispose();

--- a/tests/Termina.Tests/Layout/TextInputNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextInputNodeTests.cs
@@ -3,6 +3,7 @@
 
 using Termina.Layout;
 
+using R3;
 namespace Termina.Tests.Layout;
 
 /// <summary>

--- a/tests/Termina.Tests/Reactive/ReactivePageLifecycleTests.cs
+++ b/tests/Termina.Tests/Reactive/ReactivePageLifecycleTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Input;
 using Termina.Layout;
 using Termina.Pages;

--- a/tests/Termina.Tests/ReactiveViewModelTests.cs
+++ b/tests/Termina.Tests/ReactiveViewModelTests.cs
@@ -1,6 +1,4 @@
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Input;
 using Termina.Reactive;
 
@@ -81,7 +79,7 @@ public class ReactiveViewModelTests
             requestRedraw: () => { },
             input: inputSubject);
 
-        vm.TestInput.OfType<KeyPressed>()
+        vm.TestInput.OfType<IInputEvent, KeyPressed>()
             .Subscribe(k => receivedKeys.Add(k.KeyInfo.Key))
             .DisposeWith(vm.TestSubscriptions);
 
@@ -234,7 +232,7 @@ public class ReactiveViewModelTests
 
         // Expose protected members for testing
         public CompositeDisposable TestSubscriptions => Subscriptions;
-        public IObservable<IInputEvent> TestInput => Input;
+        public Observable<IInputEvent> TestInput => Input;
 
         public void TestNavigate(string pageKey) => Navigate(pageKey);
         public void TestShutdown() => Shutdown();

--- a/tests/Termina.Tests/Rendering/TextInputTests.cs
+++ b/tests/Termina.Tests/Rendering/TextInputTests.cs
@@ -3,6 +3,7 @@
 
 using Termina.Rendering;
 using Termina.Terminal;
+using R3;
 
 namespace Termina.Tests.Rendering;
 

--- a/tests/Termina.Tests/TextInputNodePasteTests.cs
+++ b/tests/Termina.Tests/TextInputNodePasteTests.cs
@@ -3,6 +3,7 @@
 
 using Termina.Input;
 using Termina.Layout;
+using R3;
 
 namespace Termina.Tests;
 


### PR DESCRIPTION
## Migrate from System.Reactive to R3

Replaces the `System.Reactive` dependency with [R3](https://github.com/Cysharp/R3) across the entire codebase.

### Key Changes

- Swap `System.Reactive` NuGet package for `R3` in project files and `Directory.Packages.props`
- Replace `IObservable<T>` with `Observable<T>` on all public APIs
- Update `Subscribe` call signatures:
  - `onCompleted: () =>` → `onCompleted: _ =>`
  - `onError` → `onErrorResume`
- Replace `StartWith(...)` with `Prepend(...)`
- Add explicit type parameters to `.Select<TIn, TOut>(...)` calls where R3 requires disambiguation
- Update `.OfType<T>()` calls to `.OfType<TSource, T>()` to match R3's generic constraints
- Replace `.Timeout(...)` with `.WaitAsync(...)` in tests
- Remove unused `System.Reactive.Subjects`, `System.Reactive.Linq`, and `System.Reactive.Disposables` using directives