### PR TITLE
Update docs and release notes for Termina 0.7.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.6.1</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <PackageReleaseNotes>**New Features**:
 - **Built-in input history for TextInputNode** ([#144](https://github.com/Aaronontheweb/Termina/pull/144))
   - New `WithHistory(maxEntries)` fluent API for enabling input history

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Termina)](https://www.nuget.org/packages/Termina) ![GitHub License](https://img.shields.io/github/license/Aaronontheweb/termina) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Aaronontheweb/termina/pr_validation.yml) ![GitHub Release](https://img.shields.io/github/v/release/Aaronontheweb/termina)
 
-**Termina** is a reactive terminal UI (TUI) framework for .NET with declarative layouts and surgical region-based rendering. It provides an MVVM architecture with source-generated reactive properties, ASP.NET Core-style routing, and seamless integration with Microsoft.Extensions.Hosting.
+**Termina** is a reactive terminal UI (TUI) framework for .NET with declarative layouts and surgical region-based rendering. It provides an MVVM architecture with reactive properties, ASP.NET Core-style routing, and seamless integration with Microsoft.Extensions.Hosting.
 
 ## Documentation
 
@@ -17,11 +17,11 @@
 
 ## Features
 
-- **Reactive MVVM Architecture** - ViewModels with `[Reactive]` attribute for source-generated observable properties
+- **Reactive MVVM Architecture** - ViewModels with `ReactiveProperty<T>` for observable state management
 - **Declarative Layouts** - Tree-based layout system with size constraints (Fixed, Fill, Auto, Percent)
 - **Surgical Rendering** - Only changed regions re-render, enabling smooth streaming updates
 - **ASP.NET Core-Style Routing** - Route templates with parameters (`/tasks/{id:int}`) and type constraints
-- **Source Generators** - AOT-compatible code generation for reactive properties and route parameters
+- **Source Generators** - AOT-compatible code generation for route parameters
 - **Streaming Support** - Native `StreamingTextNode` for real-time content like LLM output
 - **Dependency Injection** - Full integration with `Microsoft.Extensions.DependencyInjection`
 - **Hosting Integration** - Works with `Microsoft.Extensions.Hosting` for clean lifecycle management
@@ -38,18 +38,18 @@ dotnet add package Microsoft.Extensions.Hosting
 ### 1. Define a ViewModel
 
 ```csharp
-using System.Reactive.Linq;
+using R3;
 using Termina.Input;
 using Termina.Reactive;
 
-public partial class CounterViewModel : ReactiveViewModel
+public class CounterViewModel : ReactiveViewModel
 {
-    [Reactive] private int _count;
-    [Reactive] private string _message = "Press Up/Down to change count";
+    public ReactiveProperty<int> Count { get; } = new(0);
+    public ReactiveProperty<string> Message { get; } = new("Press Up/Down to change count");
 
     public override void OnActivated()
     {
-        Input.OfType<KeyPressed>()
+        Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKey)
             .DisposeWith(Subscriptions);
     }
@@ -59,30 +59,34 @@ public partial class CounterViewModel : ReactiveViewModel
         switch (key.KeyInfo.Key)
         {
             case ConsoleKey.UpArrow:
-                Count++;
-                Message = $"Count: {Count}";
+                Count.Value++;
+                Message.Value = $"Count: {Count.Value}";
                 break;
             case ConsoleKey.DownArrow:
-                Count--;
-                Message = $"Count: {Count}";
+                Count.Value--;
+                Message.Value = $"Count: {Count.Value}";
                 break;
             case ConsoleKey.Escape:
                 Shutdown();
                 break;
         }
     }
+
+    public override void Dispose()
+    {
+        Count.Dispose();
+        Message.Dispose();
+        base.Dispose();
+    }
 }
 ```
 
-The `[Reactive]` attribute generates:
-- A `BehaviorSubject<T>` backing field
-- A public property `Count` with get/set
-- An `IObservable<T>` property `CountChanged` for subscriptions
+`ReactiveProperty<T>` is both a value holder and an `Observable<T>` — subscribe directly in your Page for reactive UI bindings.
 
 ### 2. Define a Page
 
 ```csharp
-using System.Reactive.Linq;
+using R3;
 using Termina.Extensions;
 using Termina.Layout;
 using Termina.Reactive;
@@ -100,14 +104,14 @@ public class CounterPage : ReactivePage<CounterViewModel>
                     .WithBorder(BorderStyle.Rounded)
                     .WithBorderColor(Color.Cyan)
                     .WithContent(
-                        ViewModel.CountChanged
-                            .Select(count => new TextNode($"Count: {count}")
+                        ViewModel.Count
+                            .Select<int, ILayoutNode>(count => new TextNode($"Count: {count}")
                                 .WithForeground(Color.BrightCyan))
                             .AsLayout())
                     .Height(5))
             .WithChild(
-                ViewModel.MessageChanged
-                    .Select(msg => new TextNode(msg))
+                ViewModel.Message
+                    .Select<string, ILayoutNode>(msg => new TextNode(msg))
                     .AsLayout()
                     .Height(1));
     }
@@ -198,7 +202,7 @@ protected override void OnBound()
 }
 
 // In ViewModel
-public IObservable<string> StreamOutput => _streamOutput.AsObservable();
+public Observable<string> StreamOutput => _streamOutput;
 private readonly Subject<string> _streamOutput = new();
 
 private async Task StreamResponse()

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+#### 0.7.0 February 26th 2026 ####
+
+**Breaking Changes**:
+- **Migrate from System.Reactive to R3** ([#140](https://github.com/Aaronontheweb/Termina/pull/140))
+  - Replaced System.Reactive (Rx.NET) with [R3](https://github.com/Cysharp/R3) throughout the framework
+  - `IObservable<T>` → `Observable<T>` in all public APIs
+  - `OfType<T>()` → `OfType<TSrc, TDest>()` (R3 requires both type parameters)
+  - `Select(...)` may require explicit type parameters: `Select<TIn, TOut>(...)`
+  - `Subscribe` callbacks: `onError` → `onErrorResume`, `onCompleted` takes `Result` parameter
+  - `BehaviorSubject<T>` removed — use `ReactiveProperty<T>` instead
+  - `Subject<T>` now from R3 namespace
+  - See [Migration Guide](https://aaronontheweb.github.io/termina/guide/migration-0.7) for details
+
+- **Replace `[Reactive]` source generator with `ReactiveProperty<T>`** ([#149](https://github.com/Aaronontheweb/Termina/pull/149))
+  - Removed `[Reactive]` attribute and its source generator
+  - Use `ReactiveProperty<T>` for all ViewModel state: `public ReactiveProperty<int> Count { get; } = new(0);`
+  - Property access via `.Value`: `Count.Value++` instead of `Count++`
+  - Page bindings subscribe directly to property: `ViewModel.Count.Select(...)` instead of `ViewModel.CountChanged.Select(...)`
+  - ViewModels no longer need `partial` keyword (unless using `[FromRoute]`)
+  - Manual `Dispose()` override required to dispose all `ReactiveProperty<T>` instances
+  - Built-in `DistinctUntilChanged` — only emits when value actually changes
+
+- **Replace timers with `Observable.Interval` + `TimeProvider`** ([#140](https://github.com/Aaronontheweb/Termina/pull/140))
+  - All timer-based components now accept optional `TimeProvider` parameter
+  - Enables deterministic testing with `FakeTimeProvider`
+  - `System.Timers.Timer` and `System.Threading.Timer` no longer used
+
+**Bug Fixes**:
+- **Fix invalidation subscription lost after navigation round-trip** ([#150](https://github.com/Aaronontheweb/Termina/pull/150))
+  - Fixed rendering bug where leaf nodes lost their invalidation subscriptions after navigating away and back
+  - Custom `LayoutNode` subclasses should use `CreateSubContext(bounds)` in Render methods
+
+---
+
 #### 0.6.1 February 25th 2026 ####
 
 **New Features**:

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,7 +27,8 @@ export default defineConfig({
       '/guide/': [
         { text: 'Introduction', link: '/guide/' },
         { text: 'Getting Started', link: '/guide/getting-started' },
-        { text: 'Installation', link: '/guide/installation' }
+        { text: 'Installation', link: '/guide/installation' },
+        { text: 'Migrating to 0.7.0', link: '/guide/migration-0.7' }
       ],
       '/tutorials/': [
         { text: 'Overview', link: '/tutorials/' },

--- a/docs/concepts/observables.md
+++ b/docs/concepts/observables.md
@@ -1,14 +1,14 @@
-# Observables & Rx
+# Observables & R3
 
-Termina uses [System.Reactive (Rx.NET)](https://github.com/dotnet/reactive) for reactive programming. This page covers the basics needed to use Termina effectively.
+Termina uses [R3](https://github.com/Cysharp/R3) for reactive programming. R3 is a modern reimplementation of Reactive Extensions optimized for .NET, with better performance and AOT compatibility. This page covers the basics needed to use Termina effectively.
 
-## What is IObservable?
+## What is Observable?
 
-`IObservable<T>` represents a stream of values over time. Unlike `IEnumerable<T>` (pull-based), observables push values to subscribers.
+`Observable<T>` represents a stream of values over time. Unlike `IEnumerable<T>` (pull-based), observables push values to subscribers.
 
 ```csharp
 // Observable emits values over time
-IObservable<int> countChanges = ViewModel.CountChanged;
+Observable<int> countChanges = ViewModel.Count; // ReactiveProperty IS Observable<T>
 
 // Subscribe to receive values
 countChanges.Subscribe(count => Console.WriteLine($"Count is now: {count}"));
@@ -21,17 +21,21 @@ countChanges.Subscribe(count => Console.WriteLine($"Count is now: {count}"));
 Transform each value:
 
 ```csharp
-ViewModel.CountChanged
-    .Select(count => new TextNode($"Count: {count}"))
+ViewModel.Count
+    .Select<int, ILayoutNode>(count => new TextNode($"Count: {count}"))
     .AsLayout()
 ```
 
+::: tip
+R3 sometimes requires explicit type parameters on operators like `Select`. Use `Select<TIn, TOut>(...)` when the compiler can't infer the types.
+:::
+
 ### OfType (Filter by Type)
 
-Filter to specific event types:
+Filter to specific event types. R3 requires both source and target type parameters:
 
 ```csharp
-Input.OfType<KeyPressed>()
+Input.OfType<IInputEvent, KeyPressed>()
     .Subscribe(key => HandleKey(key));
 ```
 
@@ -40,7 +44,7 @@ Input.OfType<KeyPressed>()
 Filter values by condition:
 
 ```csharp
-ViewModel.CountChanged
+ViewModel.Count
     .Where(count => count > 0)
     .Subscribe(count => UpdatePositiveDisplay(count));
 ```
@@ -51,21 +55,10 @@ Combine multiple streams:
 
 ```csharp
 Observable.CombineLatest(
-    ViewModel.UserNameChanged,
-    ViewModel.IsLoggedInChanged,
+    ViewModel.UserName,
+    ViewModel.IsLoggedIn,
     (name, loggedIn) => loggedIn ? $"Welcome, {name}!" : "Please log in")
-    .Select(msg => new TextNode(msg))
-    .AsLayout()
-```
-
-### StartWith (Initial Value)
-
-Provide an initial value:
-
-```csharp
-ViewModel.StatusChanged
-    .StartWith("Ready")
-    .Select(s => new TextNode(s))
+    .Select<string, ILayoutNode>(msg => new TextNode(msg))
     .AsLayout()
 ```
 
@@ -78,7 +71,7 @@ The `DisposeWith` extension method adds subscriptions to a `CompositeDisposable`
 ```csharp
 public override void OnActivated()
 {
-    Input.OfType<KeyPressed>()
+    Input.OfType<IInputEvent, KeyPressed>()
         .Subscribe(HandleKey)
         .DisposeWith(Subscriptions);  // Auto-disposed on deactivation
 }
@@ -103,34 +96,34 @@ public override void Dispose()
 }
 ```
 
-## BehaviorSubject
+## ReactiveProperty
 
-`[Reactive]` properties use `BehaviorSubject<T>`, which:
+`ReactiveProperty<T>` is the primary state holder in Termina ViewModels. It combines:
 
-1. **Holds current value** - Can be read synchronously
-2. **Emits on subscribe** - New subscribers immediately get current value
-3. **Emits on change** - Existing subscribers get updates
+1. **Holds current value** — read/write via `.Value`
+2. **Is an Observable** — subscribers receive updates automatically
+3. **DistinctUntilChanged** — only emits when the value actually changes
 
 ```csharp
-// Generated from [Reactive] private int _count;
-private BehaviorSubject<int> _countSubject = new(default);
+public ReactiveProperty<int> Count { get; } = new(0);
 
-public int Count
-{
-    get => _countSubject.Value;           // Read current value
-    set => _countSubject.OnNext(value);   // Emit new value
-}
+// Read/write
+Count.Value = 42;
+var current = Count.Value;
 
-public IObservable<int> CountChanged => _countSubject.AsObservable();
+// Subscribe (ReactiveProperty IS Observable<T>)
+Count.Subscribe(value => Console.WriteLine(value));
 ```
+
+See [Reactive Properties](/concepts/reactive-properties) for full details.
 
 ## Hot vs Cold Observables
 
 ### Hot (Termina uses these)
 
 - Values are shared among all subscribers
-- New subscribers get future values (plus current for BehaviorSubject)
-- Examples: `CountChanged`, `Input`
+- New subscribers get future values (plus current for `ReactiveProperty`)
+- Examples: `Count`, `Input`
 
 ### Cold
 
@@ -143,8 +136,8 @@ public IObservable<int> CountChanged => _countSubject.AsObservable();
 ### Reactive UI Binding
 
 ```csharp
-ViewModel.ItemsChanged
-    .Select(items => Layouts.Vertical(
+ViewModel.Items
+    .Select<List<Item>, ILayoutNode>(items => Layouts.Vertical(
         items.Select(i => new TextNode(i.Name)).ToArray()))
     .AsLayout()
 ```
@@ -152,9 +145,9 @@ ViewModel.ItemsChanged
 ### Conditional Display
 
 ```csharp
-ViewModel.IsLoadingChanged
-    .Select(loading => loading
-        ? (ILayoutNode)new SpinnerNode()
+ViewModel.IsLoading
+    .Select<bool, ILayoutNode>(loading => loading
+        ? new SpinnerNode()
         : new TextNode("Ready"))
     .AsLayout()
 ```
@@ -162,14 +155,13 @@ ViewModel.IsLoadingChanged
 ### Debounce Input
 
 ```csharp
-ViewModel.SearchTermChanged
-    .Throttle(TimeSpan.FromMilliseconds(300))
+ViewModel.SearchTerm
+    .Debounce(TimeSpan.FromMilliseconds(300))
     .Subscribe(term => PerformSearch(term));
 ```
 
 ## Learning Resources
 
-- [ReactiveX Introduction](https://reactivex.io/intro.html) - Concepts and patterns
+- [R3 GitHub](https://github.com/Cysharp/R3) - R3 documentation and API reference
+- [ReactiveX Introduction](https://reactivex.io/intro.html) - Concepts and patterns (applicable to R3)
 - [Rx Marbles](https://rxmarbles.com/) - Interactive operator diagrams
-- [System.Reactive GitHub](https://github.com/dotnet/reactive) - Official documentation
-- [Introduction to Rx](http://introtorx.com/) - Free online book

--- a/docs/concepts/reactive-properties.md
+++ b/docs/concepts/reactive-properties.md
@@ -1,94 +1,105 @@
 # Reactive Properties
 
-The `[Reactive]` attribute is the foundation of Termina's reactive state management. It uses source generation to create observable properties from private fields.
+`ReactiveProperty<T>` is the foundation of Termina's reactive state management. It provides a value holder that is also an `Observable<T>`, enabling automatic UI updates when state changes.
 
 ## Basic Usage
 
 ```csharp
-public partial class MyViewModel : ReactiveViewModel
+public class MyViewModel : ReactiveViewModel
 {
-    [Reactive] private int _count;
-    [Reactive] private string _status = "Ready";
+    public ReactiveProperty<int> Count { get; } = new(0);
+    public ReactiveProperty<string> Status { get; } = new("Ready");
+
+    public override void Dispose()
+    {
+        Count.Dispose();
+        Status.Dispose();
+        base.Dispose();
+    }
 }
 ```
 
 ::: warning
-Your class **must** be `partial` for the source generator to work.
+You **must** dispose all `ReactiveProperty<T>` instances in your ViewModel's `Dispose()` method.
 :::
 
-## What Gets Generated
+## How It Works
 
-For each `[Reactive]` field, the source generator creates:
+`ReactiveProperty<T>` combines three capabilities:
+
+1. **Holds current value** — read/write via `.Value`
+2. **Is an Observable** — subscribers receive updates when `.Value` changes
+3. **DistinctUntilChanged** — only emits when the value actually changes (built-in)
 
 ```csharp
-// You write:
-[Reactive] private int _count;
+// Declare in ViewModel
+public ReactiveProperty<int> Count { get; } = new(0);
 
-// Generator creates:
-private readonly BehaviorSubject<int> _countSubject = new(default);
+// Read/write the value
+Count.Value++;
+var current = Count.Value;
 
-public int Count
-{
-    get => _countSubject.Value;
-    set => _countSubject.OnNext(value);
-}
-
-public IObservable<int> CountChanged => _countSubject.AsObservable();
+// Subscribe in a Page (ReactiveProperty IS Observable<T>)
+Count.Select<int, ILayoutNode>(c => new TextNode($"Count: {c}")).AsLayout()
 ```
 
 ## Naming Convention
 
-The field name determines the generated property name:
+Properties follow standard C# naming:
 
-| Field | Property | Observable |
-|-------|----------|------------|
-| `_count` | `Count` | `CountChanged` |
-| `_userName` | `UserName` | `UserNameChanged` |
-| `_isVisible` | `IsVisible` | `IsVisibleChanged` |
+| Declaration | Read/Write | Subscribe |
+|------------|-----------|-----------|
+| `ReactiveProperty<int> Count` | `Count.Value` | `Count.Select(...)` |
+| `ReactiveProperty<string> UserName` | `UserName.Value` | `UserName.Select(...)` |
+| `ReactiveProperty<bool> IsVisible` | `IsVisible.Value` | `IsVisible.Select(...)` |
 
-The `_` prefix is removed and the first letter is capitalized.
+Since `ReactiveProperty<T>` is itself an `Observable<T>`, you subscribe directly to the property — there is no separate `*Changed` observable.
 
 ## Default Values
 
-Set default values on the field:
+Set default values in the constructor:
 
 ```csharp
-[Reactive] private int _count = 10;
-[Reactive] private string _status = "Ready";
-[Reactive] private List<string> _items = new();
+public ReactiveProperty<int> Count { get; } = new(10);
+public ReactiveProperty<string> Status { get; } = new("Ready");
+public ReactiveProperty<List<string>> Items { get; } = new(new());
 ```
 
 ## Using in Pages
 
-Subscribe to the generated `*Changed` observable in your page:
+Subscribe directly to the `ReactiveProperty` in your page layout:
 
 ```csharp
 public class MyPage : ReactivePage<MyViewModel>
 {
-    protected override ILayoutNode BuildLayout()
+    public override ILayoutNode BuildLayout()
     {
-        return ViewModel.CountChanged
-            .Select(count => new TextNode($"Count: {count}"))
+        return ViewModel.Count
+            .Select<int, ILayoutNode>(count => new TextNode($"Count: {count}"))
             .AsLayout();
     }
 }
 ```
 
+::: tip
+R3 sometimes requires explicit type parameters on operators like `Select`. Use `Select<TIn, TOut>(...)` when the compiler can't infer the types.
+:::
+
 ## Using in ViewModel Logic
 
-Access the current value via the property:
+Access the current value via `.Value`:
 
 ```csharp
 private void HandleIncrement()
 {
-    Count++;  // Read current value, increment, set new value
+    Count.Value++;  // Read, increment, write
 }
 
 private void HandleReset()
 {
-    if (Count != 0)  // Read current value
+    if (Count.Value != 0)  // Read current value
     {
-        Count = 0;   // Set new value
+        Count.Value = 0;   // Set new value
     }
 }
 ```
@@ -98,35 +109,54 @@ private void HandleReset()
 For collections, replace the entire collection to trigger updates:
 
 ```csharp
-[Reactive] private List<string> _messages = new();
+public ReactiveProperty<List<string>> Messages { get; } = new(new());
 
 private void AddMessage(string msg)
 {
     // Create new list with added item
-    Messages = new List<string>(Messages) { msg };
+    Messages.Value = new List<string>(Messages.Value) { msg };
 
     // Or using LINQ
-    Messages = Messages.Append(msg).ToList();
+    Messages.Value = Messages.Value.Append(msg).ToList();
 }
 ```
 
 ::: tip
-Mutating a collection in-place (e.g., `Messages.Add(msg)`) won't trigger an update because the reference hasn't changed. Always assign a new collection.
+Mutating a collection in-place (e.g., `Messages.Value.Add(msg)`) won't trigger an update because the reference hasn't changed. Always assign a new collection.
 :::
 
-## BehaviorSubject vs Other Observables
+## ReactiveProperty vs Subject
 
-`[Reactive]` properties use `BehaviorSubject<T>` which:
+Use `ReactiveProperty<T>` for **state** (has a current value, subscribers need the latest):
 
-- **Holds current value** - Subscribers immediately receive the latest value
-- **Hot observable** - Emits to all subscribers
-- **Replays last value** - New subscribers get the current value immediately
+```csharp
+// State — use ReactiveProperty<T>
+public ReactiveProperty<string> Status { get; } = new("Ready");
+```
 
-This is ideal for UI state because:
-1. The page gets the current value when it subscribes
-2. All reactive bindings stay in sync
-3. You can read the current value synchronously
+Use `Subject<T>` for **events** (fire-and-forget notifications, no "current value"):
 
-## Source Generator Details
+```csharp
+// Events — use Subject<T>
+private readonly Subject<Unit> _shutdown = new();
+public Observable<Unit> ShutdownRequested => _shutdown;
+```
 
-See [Source Generators](/concepts/source-generators) for implementation details.
+## Disposal
+
+All `ReactiveProperty<T>` instances must be disposed to prevent leaks:
+
+```csharp
+public class MyViewModel : ReactiveViewModel
+{
+    public ReactiveProperty<int> Count { get; } = new(0);
+    public ReactiveProperty<string> Status { get; } = new("Ready");
+
+    public override void Dispose()
+    {
+        Count.Dispose();
+        Status.Dispose();
+        base.Dispose();
+    }
+}
+```

--- a/docs/concepts/source-generators.md
+++ b/docs/concepts/source-generators.md
@@ -1,6 +1,6 @@
 # Source Generators
 
-Termina uses C# source generators to eliminate boilerplate code while maintaining AOT compatibility. This page explains what gets generated and how it works.
+Termina uses C# source generators to eliminate boilerplate code while maintaining AOT compatibility.
 
 ## Why Source Generators?
 
@@ -11,45 +11,7 @@ Source generators provide:
 3. **IDE Support** - Generated code appears in IntelliSense
 4. **Debuggable** - You can step into generated code
 
-## The [Reactive] Generator
-
-### What You Write
-
-```csharp
-public partial class CounterViewModel : ReactiveViewModel
-{
-    [Reactive] private int _count;
-    [Reactive] private string _status = "Ready";
-}
-```
-
-### What Gets Generated
-
-```csharp
-// CounterViewModel.g.cs (generated)
-partial class CounterViewModel
-{
-    private readonly BehaviorSubject<int> _countSubject = new(default);
-
-    public int Count
-    {
-        get => _countSubject.Value;
-        set => _countSubject.OnNext(value);
-    }
-
-    public IObservable<int> CountChanged => _countSubject.AsObservable();
-
-    private readonly BehaviorSubject<string> _statusSubject = new("Ready");
-
-    public string Status
-    {
-        get => _statusSubject.Value;
-        set => _statusSubject.OnNext(value);
-    }
-
-    public IObservable<string> StatusChanged => _statusSubject.AsObservable();
-}
-```
+Termina uses source generators for route parameter injection via the `[FromRoute]` attribute.
 
 ## The [FromRoute] Generator
 
@@ -80,6 +42,10 @@ partial class DetailViewModel
 }
 ```
 
+::: warning
+Your ViewModel class **must** be `partial` when using `[FromRoute]` for the source generator to work.
+:::
+
 ## Viewing Generated Code
 
 To see the generated code in your IDE, add to your project file:
@@ -93,69 +59,54 @@ To see the generated code in your IDE, add to your project file:
 
 Generated files appear in `obj/Generated/`.
 
-## Generator Implementation
-
-The generators are in the `Termina.Generators` project:
-
-::: details View ReactivePropertyGenerator
-<<< @/../src/Termina.Generators/ReactivePropertyGenerator.cs{csharp}
-:::
-
 ## Key Requirements
 
-### Partial Classes
+### Partial Classes (for [FromRoute])
 
-Your ViewModel class **must** be `partial`:
+Your ViewModel class **must** be `partial` when using `[FromRoute]`:
 
 ```csharp
 // ✓ Correct
-public partial class MyViewModel : ReactiveViewModel { }
+public partial class MyViewModel : ReactiveViewModel
+{
+    [FromRoute] private int _id;
+}
 
 // ✗ Won't work - missing partial
-public class MyViewModel : ReactiveViewModel { }
+public class MyViewModel : ReactiveViewModel
+{
+    [FromRoute] private int _id;
+}
 ```
+
+::: tip
+If your ViewModel doesn't use `[FromRoute]`, it does **not** need to be `partial`. Reactive state is managed with `ReactiveProperty<T>` which doesn't require source generation.
+:::
 
 ### Field Naming
 
-Fields must start with `_` and use camelCase:
+`[FromRoute]` fields must start with `_` and use camelCase:
 
 ```csharp
 // ✓ Correct
-[Reactive] private int _count;        // → Count, CountChanged
-[Reactive] private string _userName;  // → UserName, UserNameChanged
+[FromRoute] private int _id;          // → Id
+[FromRoute] private string _userName; // → UserName
 
 // ✗ Won't work correctly
-[Reactive] private int count;         // No underscore
-[Reactive] private int Count;         // PascalCase
+[FromRoute] private int id;           // No underscore
+[FromRoute] private int Id;           // PascalCase
 ```
-
-### Default Values
-
-Default values are preserved:
-
-```csharp
-[Reactive] private int _count = 10;              // BehaviorSubject initialized with 10
-[Reactive] private List<string> _items = new();  // Initialized with empty list
-```
-
-## Compile-Time Errors
-
-The generator produces compile errors for common mistakes:
-
-- Non-partial class with `[Reactive]` attributes
-- Invalid field naming conventions
-- Missing required dependencies
 
 ## Benefits for AOT
 
-Traditional reactive libraries use reflection to:
+Traditional frameworks use reflection to:
 - Find properties at runtime
 - Create bindings dynamically
 - Invoke property changed notifications
 
-Termina's source generator approach:
-- Generates all code at compile time
-- No runtime reflection
+Termina's approach:
+- `[FromRoute]` generates route parameter binding at compile time
+- `ReactiveProperty<T>` provides observable state without reflection
 - Full support for `PublishAot=true`
 
 ```bash

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -22,7 +22,7 @@ dotnet add package Termina
 
 Termina uses an MVVM pattern with three key pieces:
 
-1. **ViewModel** - Manages state with `[Reactive]` properties, handles keyboard input, and provides navigation/shutdown actions
+1. **ViewModel** - Manages state with `ReactiveProperty<T>`, handles keyboard input, and provides navigation/shutdown actions
 2. **Page** - Builds the UI layout from state, manages focus for modals and interactive controls
 3. **Host** - Wires everything together with routing and dependency injection
 
@@ -32,17 +32,17 @@ Here's a complete working example from the Termina demos.
 
 ### The ViewModel
 
-The ViewModel manages state with `[Reactive]` properties that automatically generate observable change notifications:
+The ViewModel manages state with `ReactiveProperty<T>` — a value holder that is also an `Observable<T>`, enabling automatic UI updates:
 
 <<< @/../demos/Termina.Demo.RegionBased/CounterViewModel.cs{csharp}
 
-::: tip The [Reactive] Attribute
-The `[Reactive]` attribute uses source generation to create:
-- A public property (e.g., `Count` from `_count`)
-- An `IObservable<T>` property (e.g., `CountChanged`)
-- Automatic change notifications
+::: tip ReactiveProperty\<T\>
+`ReactiveProperty<T>` provides:
+- A `.Value` property for reading and writing state
+- Built-in `Observable<T>` — subscribe directly in your Page for reactive bindings
+- Built-in `DistinctUntilChanged` — only emits when the value actually changes
 
-Your class must be `partial` for the source generator to work.
+All `ReactiveProperty<T>` instances must be disposed in your ViewModel's `Dispose()` method.
 :::
 
 ### The Page
@@ -71,7 +71,7 @@ You should see a terminal UI with a counter. Press ↑ to increment, ↓ to decr
 2. **AddTermina** - Registered Termina with the starting route `/counter`
 3. **RegisterRoute** - Associated the route with our Page and ViewModel
 4. **BuildLayout** - Defined our UI as a tree of layout nodes
-5. **Reactive Binding** - `CountChanged.Select(...).AsLayout()` automatically updates the UI when `Count` changes
+5. **Reactive Binding** - `Count.Select(...).AsLayout()` automatically updates the UI when `Count.Value` changes
 
 ## Next Steps
 

--- a/docs/guide/migration-0.7.md
+++ b/docs/guide/migration-0.7.md
@@ -1,0 +1,355 @@
+# Migrating to Termina 0.7.0
+
+Termina 0.7.0 introduces breaking changes as part of the migration from System.Reactive to [R3](https://github.com/Cysharp/R3) and the removal of the `[Reactive]` source generator in favor of explicit `ReactiveProperty<T>`. This guide covers everything you need to update.
+
+## Overview of Changes
+
+| Area | Before (0.6.x) | After (0.7.0) |
+|------|----------------|----------------|
+| Reactive framework | System.Reactive (Rx.NET) | R3 |
+| ViewModel state | `[Reactive] private int _count;` | `ReactiveProperty<int> Count { get; } = new(0);` |
+| Observable type | `IObservable<T>` | `Observable<T>` |
+| Property access | `Count++` | `Count.Value++` |
+| Page binding | `CountChanged.Select(...)` | `Count.Select(...)` |
+| Backing store | `BehaviorSubject<T>` | `ReactiveProperty<T>` |
+| Class declaration | `public partial class MyVM` | `public class MyVM` (no `partial` needed) |
+
+## 1. Package Changes
+
+Remove System.Reactive and add R3:
+
+```xml
+<!-- Before -->
+<PackageReference Include="System.Reactive" Version="6.x" />
+
+<!-- After -->
+<PackageReference Include="R3" Version="1.3.0" />
+```
+
+::: tip
+Termina 0.7.0 brings R3 as a transitive dependency, so you may not need to add it explicitly unless you use R3 operators directly.
+:::
+
+## 2. Import Changes
+
+Replace System.Reactive imports with R3:
+
+```csharp
+// Before
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+// After
+using R3;
+```
+
+## 3. ViewModel Migration: [Reactive] → ReactiveProperty\<T\>
+
+The `[Reactive]` source generator has been removed. Use `ReactiveProperty<T>` directly.
+
+### Before
+
+```csharp
+public partial class CounterViewModel : ReactiveViewModel
+{
+    [Reactive] private int _count;
+    [Reactive] private string _status = "Ready";
+
+    private void Increment()
+    {
+        Count++;
+        Status = $"Count: {Count}";
+    }
+}
+```
+
+### After
+
+```csharp
+public class CounterViewModel : ReactiveViewModel
+{
+    public ReactiveProperty<int> Count { get; } = new(0);
+    public ReactiveProperty<string> Status { get; } = new("Ready");
+
+    private void Increment()
+    {
+        Count.Value++;
+        Status.Value = $"Count: {Count.Value}";
+    }
+
+    public override void Dispose()
+    {
+        Count.Dispose();
+        Status.Dispose();
+        base.Dispose();
+    }
+}
+```
+
+### Key differences
+
+| Aspect | `[Reactive]` (old) | `ReactiveProperty<T>` (new) |
+|--------|-------------------|----------------------------|
+| Declaration | `[Reactive] private int _count;` | `public ReactiveProperty<int> Count { get; } = new(0);` |
+| Read value | `Count` | `Count.Value` |
+| Write value | `Count = 5` | `Count.Value = 5` |
+| Subscribe | `CountChanged.Select(...)` | `Count.Select(...)` |
+| Class modifier | `partial` required | Not required |
+| Dispose | Auto-generated | Manual `Dispose()` override required |
+| DistinctUntilChanged | Not built-in | Built-in (won't emit duplicate values) |
+
+::: warning Important
+You **must** dispose all `ReactiveProperty<T>` instances. Add a `Dispose()` override to your ViewModel that disposes each property before calling `base.Dispose()`.
+:::
+
+## 4. Property Access Changes
+
+Every direct property read/write must go through `.Value`:
+
+```csharp
+// Before
+Count++;
+Status = "Done";
+if (Count > 10) { ... }
+
+// After
+Count.Value++;
+Status.Value = "Done";
+if (Count.Value > 10) { ... }
+```
+
+## 5. Page Subscription Changes
+
+`ReactiveProperty<T>` is itself an `Observable<T>`, so you subscribe directly to the property instead of a separate `*Changed` observable:
+
+```csharp
+// Before
+ViewModel.CountChanged
+    .Select(count => new TextNode($"Count: {count}"))
+    .AsLayout()
+
+// After
+ViewModel.Count
+    .Select<int, ILayoutNode>(count => new TextNode($"Count: {count}"))
+    .AsLayout()
+```
+
+::: tip
+Note the explicit type parameters on `Select<int, ILayoutNode>`. R3 sometimes needs explicit type parameters where System.Reactive could infer them.
+:::
+
+## 6. Observable Operator Changes
+
+### OfType
+
+R3's `OfType` requires both source and target type parameters:
+
+```csharp
+// Before
+Input.OfType<KeyPressed>()
+
+// After
+Input.OfType<IInputEvent, KeyPressed>()
+```
+
+### Select
+
+R3's `Select` may need explicit type parameters when inference fails:
+
+```csharp
+// Before
+observable.Select(x => new TextNode($"{x}")).AsLayout()
+
+// After
+observable.Select<int, ILayoutNode>(x => new TextNode($"{x}")).AsLayout()
+```
+
+### CombineLatest
+
+```csharp
+// Before
+Observable.CombineLatest(
+    ViewModel.UserNameChanged,
+    ViewModel.IsLoggedInChanged,
+    (name, loggedIn) => ...)
+
+// After
+Observable.CombineLatest(
+    ViewModel.UserName,
+    ViewModel.IsLoggedIn,
+    (name, loggedIn) => ...)
+```
+
+## 7. StartWith → Removal or Prepend
+
+`StartWith` does not exist in R3. The replacement depends on the source type:
+
+### ReactiveProperty\<T\>: Remove StartWith entirely
+
+`ReactiveProperty<T>` already emits its current value to new subscribers, so `StartWith` is unnecessary:
+
+```csharp
+// Before
+ViewModel.StateChanged
+    .StartWith(ViewModel.State)
+    .Select(state => BuildLayout(state))
+    .AsLayout()
+
+// After — ReactiveProperty replays current value automatically
+ViewModel.State
+    .Select(state => BuildLayout(state))
+    .AsLayout()
+```
+
+### Subject\<T\>: Use Prepend
+
+For `Subject<T>` (which does not replay), use `Prepend` to emit an initial value:
+
+```csharp
+// Before
+_selectionChanged.StartWith((ILayoutNode?)null)
+
+// After
+_selectionChanged.Prepend((ILayoutNode?)null)
+```
+
+## 8. BehaviorSubject → ReactiveProperty
+
+If you used `BehaviorSubject<T>` directly (outside of `[Reactive]`), migrate to `ReactiveProperty<T>`:
+
+```csharp
+// Before
+private readonly BehaviorSubject<string> _status = new("Ready");
+public IObservable<string> Status => _status.AsObservable();
+public string CurrentStatus => _status.Value;
+
+// Update:
+_status.OnNext("Processing");
+
+// After
+public ReactiveProperty<string> Status { get; } = new("Ready");
+
+// Update:
+Status.Value = "Processing";
+
+// ReactiveProperty IS Observable<T>, no wrapper needed
+```
+
+`ReactiveProperty<T>` replaces `BehaviorSubject<T>` for all state that needs both read access and subscriptions.
+
+## 9. Subject\<T\> Migration
+
+`Subject<T>` exists in both System.Reactive and R3. Just change the import:
+
+```csharp
+// Before
+using System.Reactive.Subjects;
+private readonly Subject<Unit> _shutdown = new();
+public IObservable<Unit> ShutdownRequested => _shutdown.AsObservable();
+
+// After
+using R3;
+private readonly Subject<Unit> _shutdown = new();
+public Observable<Unit> ShutdownRequested => _shutdown;
+```
+
+Note: In R3, `Subject<T>` is already `Observable<T>`, so `.AsObservable()` is not needed (though it still works).
+
+## 10. Subscribe Callback Changes
+
+R3 changes the signature of `Subscribe` callbacks:
+
+```csharp
+// Before (System.Reactive)
+observable.Subscribe(
+    onNext: value => { ... },
+    onError: error => { ... },
+    onCompleted: () => { ... });
+
+// After (R3)
+observable.Subscribe(
+    onNext: value => { ... },
+    onErrorResume: error => { ... },  // renamed
+    onCompleted: result => { ... });  // takes Result parameter
+```
+
+For simple subscriptions with just `onNext`, the API is the same:
+
+```csharp
+// Works in both
+observable.Subscribe(value => HandleValue(value));
+```
+
+::: danger Two-Argument Subscribe Trap
+The two-argument `Subscribe(onNext, second)` changed semantics silently. In System.Reactive the second argument was `onError`. In R3 the second argument is `onCompleted` (taking `Result`, not `Exception`):
+
+```csharp
+// System.Reactive — second arg is onError
+observable.Subscribe(_ => { }, ex => Log(ex));
+
+// R3 — second arg is onCompleted (takes Result, not Exception)
+// To capture errors, use the three-argument form:
+observable.Subscribe(_ => { }, ex => Log(ex), _ => { });
+```
+
+This won't just fail to compile — it will give a confusing `cannot convert from 'R3.Result' to 'System.Exception'` error. Always use the three-argument form when you need error handling.
+:::
+
+## 11. Timer Changes
+
+Replace `System.Timers.Timer` and `System.Threading.Timer` with `Observable.Interval` and `TimeProvider`:
+
+```csharp
+// Before
+private readonly Timer _timer = new(80);
+_timer.Elapsed += OnTick;
+_timer.Start();
+
+// After
+Observable.Interval(TimeSpan.FromMilliseconds(80), timeProvider ?? TimeProvider.System)
+    .Subscribe(_ => OnTick())
+    .DisposeWith(Subscriptions);
+```
+
+Components that use timers now accept an optional `TimeProvider` parameter for testable timing. Use `FakeTimeProvider` in tests for deterministic behavior.
+
+## 12. Custom Node Render Methods
+
+If you have custom `LayoutNode` subclasses, update `Render` methods to use `CreateSubContext`:
+
+```csharp
+// Before (may render at wrong coordinates)
+public override void Render(IRenderContext context, Rect bounds)
+{
+    context.DrawText(0, 0, "Hello");
+}
+
+// After (correct coordinate translation)
+public override void Render(IRenderContext context, Rect bounds)
+{
+    var sub = context.CreateSubContext(bounds);
+    sub.DrawText(0, 0, "Hello");
+}
+```
+
+This ensures content renders at the correct position within the layout tree.
+
+## Migration Checklist
+
+- [ ] Replace `System.Reactive` package with `R3`
+- [ ] Update all `using` statements: `System.Reactive.*` → `R3`
+- [ ] Convert `[Reactive]` fields to `ReactiveProperty<T>` properties
+- [ ] Remove `partial` modifier from ViewModel classes (if only needed for `[Reactive]`)
+- [ ] Update all property access: `Prop` → `Prop.Value`
+- [ ] Update page bindings: `PropChanged` → `Prop`
+- [ ] Remove `.StartWith()` on `ReactiveProperty<T>` (replays automatically); use `.Prepend()` on `Subject<T>`
+- [ ] Add explicit type params to `OfType<TSrc, TDest>()` and `Select<TIn, TOut>()`
+- [ ] Convert `BehaviorSubject<T>` to `ReactiveProperty<T>`
+- [ ] Update `Subject<T>` imports and exposed types (`IObservable<T>` → `Observable<T>`)
+- [ ] Update `Subscribe` callbacks: `onError` → `onErrorResume`, `onCompleted` takes `Result`
+- [ ] Add `Dispose()` overrides disposing all `ReactiveProperty<T>` instances
+- [ ] Replace timers with `Observable.Interval` + `TimeProvider`
+- [ ] Update custom `LayoutNode.Render()` methods to use `CreateSubContext`
+- [ ] Verify build compiles cleanly
+- [ ] Run all tests

--- a/docs/tutorials/counter-app.md
+++ b/docs/tutorials/counter-app.md
@@ -34,35 +34,27 @@ The ViewModel holds your application state and handles input.
 **Reactive Properties**
 
 ```csharp
-[Reactive] private int _count;
-[Reactive] private string _statusMessage = "Initial status";
+public ReactiveProperty<int> Count { get; } = new(0);
+public ReactiveProperty<string> StatusMessage { get; } = new("Press Up/Down...");
 ```
 
-The `[Reactive]` attribute generates:
-- A `Count` property with getter/setter
-- A `CountChanged` observable for UI binding
-- A `BehaviorSubject<int>` backing field
+`ReactiveProperty<T>` provides:
+- A `.Value` property for reading and writing state
+- Built-in `Observable<T>` for UI binding — subscribe directly to the property
+- Built-in `DistinctUntilChanged` — only emits when the value actually changes
 
 **Input Handling**
 
 ```csharp
 public override void OnActivated()
 {
-    Input.OfType<KeyPressed>()
+    Input.OfType<IInputEvent, KeyPressed>()
         .Subscribe(HandleKeyPress)
         .DisposeWith(Subscriptions);
 }
 ```
 
-Subscribe to the `Input` observable in `OnActivated()`. Use `DisposeWith(Subscriptions)` for automatic cleanup.
-
-**Partial Class**
-
-The class must be `partial` for the source generator to work:
-
-```csharp
-public partial class CounterViewModel : ReactiveViewModel
-```
+Subscribe to the `Input` observable in `OnActivated()`. Use `DisposeWith(Subscriptions)` for automatic cleanup. Note: R3's `OfType` requires both source and target type parameters.
 
 ## Step 2: Create the Page
 
@@ -77,12 +69,12 @@ The Page builds the layout from ViewModel state.
 **Reactive Bindings**
 
 ```csharp
-ViewModel.CountChanged
-    .Select(count => new TextNode($"Count: {count}"))
+ViewModel.Count
+    .Select<int, ILayoutNode>(count => new TextNode($"Count: {count}"))
     .AsLayout()
 ```
 
-The `AsLayout()` extension creates a `ReactiveLayoutNode` that automatically updates when the observable emits.
+`ReactiveProperty<T>` is an `Observable<T>`, so you subscribe directly to it. The `AsLayout()` extension creates a `ReactiveLayoutNode` that automatically updates when the value changes.
 
 **Layout Composition**
 


### PR DESCRIPTION
## Summary

- Create comprehensive migration guide (`docs/guide/migration-0.7.md`) covering all breaking changes from 0.6.x → 0.7.0: System.Reactive → R3, `[Reactive]` → `ReactiveProperty<T>`, `StartWith` → `Prepend`, Subscribe callback changes, timer migration, custom node rendering
- Rewrite `reactive-properties.md` and `observables.md` for new R3/ReactiveProperty patterns
- Update `source-generators.md` to remove `[Reactive]` section, keep `[FromRoute]`
- Update `getting-started.md`, `counter-app.md`, and `README.md` with new code examples
- Add migration guide to VitePress sidebar navigation
- Add 0.7.0 release notes to `RELEASE_NOTES.md`
- Bump `VersionPrefix` to 0.7.0

## Validated against
- VitePress docs build: clean (no broken links)
- Memorizer-mcp-agent successfully migrated using this guide as reference — 400/400 tests passing

## Test plan
- [ ] `npx vitepress build` succeeds with no errors
- [ ] Migration guide code examples are accurate (validated via real migration)
- [ ] All sidebar links resolve correctly