### PR TITLE
Add DynamicLayoutNode, FocusManager auto-focus, and WizardNode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,10 +25,38 @@
   - Enables deterministic testing with `FakeTimeProvider`
   - `System.Timers.Timer` and `System.Threading.Timer` no longer used
 
+**New Features**:
+- **DynamicLayoutNode** ([#147](https://github.com/Aaronontheweb/Termina/issues/147))
+  - New `Layouts.Dynamic(Func<ILayoutNode> factory)` for imperative, page-local state
+  - Re-evaluates factory on each Render/Measure cycle with reference equality to avoid lifecycle churn
+  - `Invalidate()` method for programmatic trigger; `AsDynamicLayout(Observable<Unit>)` extension
+  - Implements `IInvalidatingNode` for proper invalidation propagation
+
+- **FocusManager auto-focus and Tab cycling** ([#146](https://github.com/Aaronontheweb/Termina/issues/146))
+  - `FocusPolicy` enum: `Manual`, `FirstFocusable`, `ByPriority` — set on `ReactivePage` for automatic focus on navigation
+  - `CollectFocusables(ILayoutNode root)` — depth-first tree walk collecting focusable nodes
+  - `CycleFocus(focusables, reverse)` — next/previous with wrap-around
+  - `CycleFocusForward()` / `CycleFocusBackward()` helpers on `ReactivePage`
+  - `FocusManager` migrated from `BehaviorSubject<IFocusable?>` to `ReactiveProperty<IFocusable?>`
+
+- **WizardNode** ([#148](https://github.com/Aaronontheweb/Termina/issues/148))
+  - Multi-step wizard component: `Layouts.Wizard<TStep>()` where `TStep : struct, Enum`
+  - Fluent builder: `.WithStep()`, `.WithProgressStyle()`, `.WithTitle()`, `.WithBorder()`
+  - Navigation: `TryAdvance()`, `TryGoBack()`, `GoToStep()`, `AdvanceSubStep()`
+  - Cancellable `BeforeAdvance` observable for step validation
+  - `StepChanged` and `Completed` observables
+  - Progress styles: `BlockBar`, `Arrow`, `Dots`, `None`
+  - Sub-step support within each step
+  - Implements `IFocusable` and `IInvalidatingNode`
+  - Uses `DynamicLayoutNode` internally for step content switching
+
 **Bug Fixes**:
 - **Fix invalidation subscription lost after navigation round-trip** ([#150](https://github.com/Aaronontheweb/Termina/pull/150))
   - Fixed rendering bug where leaf nodes lost their invalidation subscriptions after navigating away and back
   - Custom `LayoutNode` subclasses should use `CreateSubContext(bounds)` in Render methods
+
+**Cleanup**:
+- Removed dead `HasReactiveAttribute` helper from `LayoutNodeInViewModelAnalyzer` (references removed `[Reactive]` attribute)
 
 ---
 

--- a/Termina.slnx
+++ b/Termina.slnx
@@ -16,6 +16,7 @@
     <Project Path="demos/Termina.Demo.Grid/Termina.Demo.Grid.csproj" />
     <Project Path="demos/Termina.Demo.RegionBased/Termina.Demo.RegionBased.csproj" />
     <Project Path="demos/Termina.Demo.Streaming/Termina.Demo.Streaming.csproj" />
+    <Project Path="demos/Termina.Demo.Wizard/Termina.Demo.Wizard.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Termina.Tests/Termina.Tests.csproj" />

--- a/demos/Termina.Demo.Wizard/Pages/SetupWizardPage.cs
+++ b/demos/Termina.Demo.Wizard/Pages/SetupWizardPage.cs
@@ -28,36 +28,43 @@ public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
     {
         _wizard = Layouts.Wizard<SetupStep>()
             .WithStep(SetupStep.Provider, "Provider", BuildProviderStep,
-                helpText: "Select a cloud provider and press Enter")
+                helpText: "[↑/↓] Navigate  [Enter] Select  [1-3] Quick Select")
             .WithStep(SetupStep.Auth, "Authentication", BuildAuthStep,
-                helpText: "Enter your username and press Enter to continue")
+                helpText: "Type your username and press Enter")
             .WithStep(SetupStep.Confirm, "Confirm", BuildConfirmStep,
-                helpText: "Press Enter to complete setup, Escape to go back")
+                helpText: "[Enter] Complete Setup  [Esc] Go Back")
             .WithProgressStyle(WizardProgressStyle.Arrow)
             .WithBorder(BorderStyle.Rounded, Color.Cyan);
         _wizard.Fill();
 
         // Update status on step change
         _wizard.StepChanged.Subscribe(step =>
-            ViewModel.StatusMessage.Value = $"Now on: {step}");
+            ViewModel.StatusMessage.Value = $"Step: {step}");
 
         // Shut down on completion
         _wizard.Completed.Subscribe(_ =>
         {
-            ViewModel.StatusMessage.Value = "Setup complete!";
+            ViewModel.StatusMessage.Value = "✓ Setup complete! Press Q to exit.";
             ViewModel.RequestRedraw();
         });
 
-        return Layouts.Vertical(
-            _wizard,
-            ViewModel.StatusMessage
-                .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.BrightBlack))
-                .AsLayout()
-                .Height(1),
-            new TextNode("[Q] Quit")
-                .WithForeground(Color.DarkGray)
-                .Height(1)
-        );
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Cloud Setup Wizard")
+                    .WithBorder(BorderStyle.Double)
+                    .WithBorderColor(Color.Magenta)
+                    .WithContent(_wizard)
+                    .Fill())
+            .WithChild(
+                Layouts.Horizontal(
+                    ViewModel.StatusMessage
+                        .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.White))
+                        .AsLayout()
+                        .Fill(),
+                    new TextNode("[Tab] Cycle Focus  [Q] Quit")
+                        .WithForeground(Color.BrightBlack))
+                .Height(1));
     }
 
     public override void OnNavigatedTo()
@@ -67,7 +74,7 @@ public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
         KeyBindings.Register(ConsoleKey.Tab, CycleFocusForward);
         KeyBindings.Register(ConsoleKey.Tab, ConsoleModifiers.Shift, CycleFocusBackward);
 
-        // Focus the wizard itself so it receives Enter/Escape
+        // Focus the wizard itself so it receives and delegates input
         Focus.PushFocus(_wizard);
     }
 
@@ -76,7 +83,8 @@ public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
         var list = Layouts.SelectionList("AWS", "Azure", "GCP")
             .WithMode(SelectionMode.Single)
             .WithShowNumbers(true)
-            .WithHighlightColors(Color.Black, Color.Cyan);
+            .WithHighlightColors(Color.Black, Color.Cyan)
+            .WithVisibleRows(6);
 
         list.SelectionConfirmed.Subscribe(items =>
         {
@@ -90,9 +98,14 @@ public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
 
         return Layouts.Vertical(
             new TextNode("Choose your cloud provider:")
-                .WithForeground(Color.White),
+                .WithForeground(Color.BrightCyan)
+                .Bold()
+                .Height(1),
+            new TextNode("Select a provider for your infrastructure deployment.")
+                .WithForeground(Color.DarkGray)
+                .Height(2),
             list
-        ).WithSpacing(1);
+        );
     }
 
     private ILayoutNode BuildAuthStep()
@@ -105,36 +118,53 @@ public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
             if (!string.IsNullOrWhiteSpace(text))
             {
                 ViewModel.Username.Value = text.Trim();
-                ViewModel.StatusMessage.Value = $"Username set: {text.Trim()}";
+                ViewModel.StatusMessage.Value = $"Username: {text.Trim()}";
                 _wizard.TryAdvance();
             }
         });
 
         return Layouts.Vertical(
             new TextNode("Enter your credentials:")
-                .WithForeground(Color.White),
-            new TextNode("Username:").WithForeground(Color.Gray),
-            usernameInput
-        ).WithSpacing(1);
+                .WithForeground(Color.BrightCyan)
+                .Bold()
+                .Height(1),
+            new TextNode("Provide the username for your cloud provider account.")
+                .WithForeground(Color.DarkGray)
+                .Height(2),
+            new TextNode("Username:")
+                .WithForeground(Color.Gray)
+                .Height(1),
+            Layouts.Horizontal(
+                new TextNode("  ").Width(2),
+                usernameInput.Fill()
+            ).Height(1)
+        );
     }
 
     private ILayoutNode BuildConfirmStep()
     {
         return Layouts.Vertical(
             new TextNode("Review your settings:")
-                .WithForeground(Color.White)
-                .Bold(),
+                .WithForeground(Color.BrightCyan)
+                .Bold()
+                .Height(1),
+            new TextNode("Verify the details below before completing setup.")
+                .WithForeground(Color.DarkGray)
+                .Height(2),
             ViewModel.SelectedProvider
                 .Select<string, ILayoutNode>(p =>
-                    new TextNode($"  Provider: {p}").WithForeground(Color.Cyan))
-                .AsLayout(),
+                    new TextNode($"  Provider:  {p}").WithForeground(Color.Cyan))
+                .AsLayout()
+                .Height(1),
             ViewModel.Username
                 .Select<string, ILayoutNode>(u =>
-                    new TextNode($"  Username: {u}").WithForeground(Color.Cyan))
-                .AsLayout(),
-            new TextNode(""),
+                    new TextNode($"  Username:  {u}").WithForeground(Color.Cyan))
+                .AsLayout()
+                .Height(1),
+            new TextNode("").Height(1),
             new TextNode("Press Enter to complete setup.")
                 .WithForeground(Color.Green)
+                .Height(1)
         );
     }
 }

--- a/demos/Termina.Demo.Wizard/Pages/SetupWizardPage.cs
+++ b/demos/Termina.Demo.Wizard/Pages/SetupWizardPage.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Demo.Wizard.Pages;
+
+/// <summary>
+/// Page for the setup wizard demo.
+/// Showcases WizardNode, DynamicLayoutNode (internal), FocusPolicy, and Tab cycling.
+/// </summary>
+public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
+{
+    private WizardNode<SetupStep> _wizard = null!;
+
+    public SetupWizardPage()
+    {
+        FocusPolicy = FocusPolicy.FirstFocusable;
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        _wizard = Layouts.Wizard<SetupStep>()
+            .WithStep(SetupStep.Provider, "Provider", BuildProviderStep,
+                helpText: "Select a cloud provider and press Enter")
+            .WithStep(SetupStep.Auth, "Authentication", BuildAuthStep,
+                helpText: "Enter your username and press Enter to continue")
+            .WithStep(SetupStep.Confirm, "Confirm", BuildConfirmStep,
+                helpText: "Press Enter to complete setup, Escape to go back")
+            .WithProgressStyle(WizardProgressStyle.Arrow)
+            .WithBorder(BorderStyle.Rounded, Color.Cyan);
+        _wizard.Fill();
+
+        // Update status on step change
+        _wizard.StepChanged.Subscribe(step =>
+            ViewModel.StatusMessage.Value = $"Now on: {step}");
+
+        // Shut down on completion
+        _wizard.Completed.Subscribe(_ =>
+        {
+            ViewModel.StatusMessage.Value = "Setup complete!";
+            ViewModel.RequestRedraw();
+        });
+
+        return Layouts.Vertical(
+            _wizard,
+            ViewModel.StatusMessage
+                .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.BrightBlack))
+                .AsLayout()
+                .Height(1),
+            new TextNode("[Q] Quit")
+                .WithForeground(Color.DarkGray)
+                .Height(1)
+        );
+    }
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+
+        KeyBindings.Register(ConsoleKey.Tab, CycleFocusForward);
+        KeyBindings.Register(ConsoleKey.Tab, ConsoleModifiers.Shift, CycleFocusBackward);
+
+        // Focus the wizard itself so it receives Enter/Escape
+        Focus.PushFocus(_wizard);
+    }
+
+    private ILayoutNode BuildProviderStep()
+    {
+        var list = Layouts.SelectionList("AWS", "Azure", "GCP")
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        list.SelectionConfirmed.Subscribe(items =>
+        {
+            if (items.Count > 0)
+            {
+                ViewModel.SelectedProvider.Value = items[0];
+                ViewModel.StatusMessage.Value = $"Selected: {items[0]}";
+                _wizard.TryAdvance();
+            }
+        });
+
+        return Layouts.Vertical(
+            new TextNode("Choose your cloud provider:")
+                .WithForeground(Color.White),
+            list
+        ).WithSpacing(1);
+    }
+
+    private ILayoutNode BuildAuthStep()
+    {
+        var usernameInput = new TextInputNode()
+            .WithPlaceholder("Enter username...");
+
+        usernameInput.Submitted.Subscribe(text =>
+        {
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                ViewModel.Username.Value = text.Trim();
+                ViewModel.StatusMessage.Value = $"Username set: {text.Trim()}";
+                _wizard.TryAdvance();
+            }
+        });
+
+        return Layouts.Vertical(
+            new TextNode("Enter your credentials:")
+                .WithForeground(Color.White),
+            new TextNode("Username:").WithForeground(Color.Gray),
+            usernameInput
+        ).WithSpacing(1);
+    }
+
+    private ILayoutNode BuildConfirmStep()
+    {
+        return Layouts.Vertical(
+            new TextNode("Review your settings:")
+                .WithForeground(Color.White)
+                .Bold(),
+            ViewModel.SelectedProvider
+                .Select<string, ILayoutNode>(p =>
+                    new TextNode($"  Provider: {p}").WithForeground(Color.Cyan))
+                .AsLayout(),
+            ViewModel.Username
+                .Select<string, ILayoutNode>(u =>
+                    new TextNode($"  Username: {u}").WithForeground(Color.Cyan))
+                .AsLayout(),
+            new TextNode(""),
+            new TextNode("Press Enter to complete setup.")
+                .WithForeground(Color.Green)
+        );
+    }
+}

--- a/demos/Termina.Demo.Wizard/Pages/SetupWizardViewModel.cs
+++ b/demos/Termina.Demo.Wizard/Pages/SetupWizardViewModel.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Termina.Demo.Wizard.Pages;
+
+public enum SetupStep
+{
+    Provider,
+    Auth,
+    Confirm
+}
+
+/// <summary>
+/// ViewModel for the setup wizard demo.
+/// </summary>
+public class SetupWizardViewModel : ReactiveViewModel
+{
+    public ReactiveProperty<string> SelectedProvider { get; } = new("None");
+    public ReactiveProperty<string> Username { get; } = new("");
+    public ReactiveProperty<string> StatusMessage { get; } = new("Use Enter to advance, Escape to go back");
+
+    public override void OnActivated()
+    {
+        // Handle Q to quit at the ViewModel level
+        Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(key =>
+            {
+                if (key.KeyInfo.Key == ConsoleKey.Q)
+                    Shutdown();
+            })
+            .DisposeWith(Subscriptions);
+    }
+
+    public override void Dispose()
+    {
+        SelectedProvider.Dispose();
+        Username.Dispose();
+        StatusMessage.Dispose();
+        base.Dispose();
+    }
+}

--- a/demos/Termina.Demo.Wizard/Program.cs
+++ b/demos/Termina.Demo.Wizard/Program.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Hosting;
 using Termina.Demo.Wizard.Pages;
+using Termina.Diagnostics;
 using Termina.Hosting;
 using Termina.Input;
 using Termina.Pages;
@@ -11,6 +12,11 @@ using Termina.Pages;
 var testMode = args.Contains("--test");
 
 var builder = Host.CreateApplicationBuilder(args);
+
+// Enable file tracing for debugging
+var traceFile = Path.Combine(Path.GetTempPath(), "termina-wizard-trace.log");
+builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+Console.Error.WriteLine($"Trace log: {traceFile}");
 
 // Set up input source based on mode
 VirtualInputSource? scriptedInput = null;

--- a/demos/Termina.Demo.Wizard/Program.cs
+++ b/demos/Termina.Demo.Wizard/Program.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Hosting;
+using Termina.Demo.Wizard.Pages;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Pages;
+
+// Check for --test flag (used in CI/CD to run scripted test and exit)
+var testMode = args.Contains("--test");
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Set up input source based on mode
+VirtualInputSource? scriptedInput = null;
+if (testMode)
+{
+    scriptedInput = new VirtualInputSource();
+    builder.Services.AddTerminaVirtualInput(scriptedInput);
+}
+
+// Register Termina with the wizard page
+builder.Services.AddTermina("/wizard", termina =>
+{
+    termina.RegisterRoute<SetupWizardPage, SetupWizardViewModel>("/wizard", NavigationBehavior.PreserveState);
+});
+
+var host = builder.Build();
+
+if (testMode && scriptedInput != null)
+{
+    _ = Task.Run(async () =>
+    {
+        await Task.Delay(500); // Wait for initial render
+
+        // Step 1: Provider selection
+        // Navigate to "Azure" (second item)
+        scriptedInput.EnqueueKey(ConsoleKey.DownArrow);
+        await Task.Delay(100);
+        // Select it
+        scriptedInput.EnqueueKey(ConsoleKey.Enter);
+        await Task.Delay(200);
+
+        // Step 2: Auth - type a username
+        scriptedInput.EnqueueString("admin");
+        await Task.Delay(100);
+        scriptedInput.EnqueueKey(ConsoleKey.Enter);
+        await Task.Delay(200);
+
+        // Step 3: Confirm - press Enter to complete
+        scriptedInput.EnqueueKey(ConsoleKey.Enter);
+        await Task.Delay(300);
+
+        // Quit
+        scriptedInput.EnqueueKey(ConsoleKey.Q);
+        scriptedInput.Complete();
+    });
+}
+
+await host.RunAsync();

--- a/demos/Termina.Demo.Wizard/Termina.Demo.Wizard.csproj
+++ b/demos/Termina.Demo.Wizard/Termina.Demo.Wizard.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+
+    <!-- AOT Publishing Support -->
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+
+    <!-- Don't publish demo as NuGet package -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Termina\Termina.csproj" />
+    <!-- Source generator - compile-time only, never publish -->
+    <ProjectReference Include="..\..\src\Termina.Generators\Termina.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all"
+                      Publish="false" />
+  </ItemGroup>
+
+</Project>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -34,7 +34,8 @@ export default defineConfig({
         { text: 'Overview', link: '/tutorials/' },
         { text: 'Counter App', link: '/tutorials/counter-app' },
         { text: 'Todo List', link: '/tutorials/todo-list' },
-        { text: 'Streaming Chat', link: '/tutorials/streaming-chat' }
+        { text: 'Streaming Chat', link: '/tutorials/streaming-chat' },
+        { text: 'Setup Wizard', link: '/tutorials/wizard-app' }
       ],
       '/layout/': [
         { text: 'Layout System', link: '/layout/' },
@@ -106,6 +107,8 @@ export default defineConfig({
         { text: 'Routing', link: '/concepts/routing' },
         { text: 'Navigation', link: '/concepts/navigation' },
         { text: 'Input Handling', link: '/concepts/input-handling' },
+        { text: 'Dynamic Layouts', link: '/concepts/dynamic-layouts' },
+        { text: 'Focus Management', link: '/concepts/focus-management' },
         { text: 'Hosting & DI', link: '/concepts/hosting' }
       ],
       '/advanced/': [

--- a/docs/concepts/dynamic-layouts.md
+++ b/docs/concepts/dynamic-layouts.md
@@ -1,0 +1,96 @@
+# Dynamic Layouts
+
+`DynamicLayoutNode` re-evaluates a factory function on every render cycle, making it ideal for imperative, page-local state that doesn't need to live in a ViewModel as an observable.
+
+## When to Use
+
+| Scenario | Use |
+|----------|-----|
+| ViewModel state that is naturally observable | `ReactiveProperty<T>` + `.AsLayout()` |
+| Page-local state (switch/case, enum-driven UI) | `Layouts.Dynamic()` |
+| Observable trigger with imperative factory | `factory.AsDynamicLayout(trigger)` |
+
+## Basic Usage
+
+```csharp
+public override ILayoutNode BuildLayout()
+{
+    // Page-local state — no need for a ViewModel property
+    var currentTab = "home";
+
+    return Layouts.Dynamic(() => currentTab switch
+    {
+        "home" => new TextNode("Welcome home"),
+        "settings" => new TextNode("Settings panel"),
+        _ => new TextNode("Unknown tab")
+    });
+}
+```
+
+## With Invalidation Trigger
+
+When your factory depends on state that changes over time, use `Invalidate()` or the `AsDynamicLayout` extension to trigger re-evaluation:
+
+```csharp
+// Manual invalidation
+var dynamicNode = Layouts.Dynamic(() => BuildCurrentContent());
+// ... later, when state changes:
+dynamicNode.Invalidate();
+
+// Or subscribe an observable trigger
+Func<ILayoutNode> factory = () => BuildCurrentContent();
+var node = factory.AsDynamicLayout(someObservable.Select(_ => Unit.Default));
+```
+
+## Before / After Comparison
+
+**Before** (manual `Subject<Unit>` merge trick):
+
+```csharp
+// ViewModel
+public ReactiveProperty<int> CurrentTab { get; } = new(0);
+
+// Page
+ViewModel.CurrentTab
+    .Select<int, ILayoutNode>(tab => tab switch
+    {
+        0 => BuildHomeTab(),
+        1 => BuildSettingsTab(),
+        _ => new EmptyNode()
+    })
+    .AsLayout()
+```
+
+**After** (one-liner with `Layouts.Dynamic`):
+
+```csharp
+// No ViewModel property needed — page-local state
+var tab = 0;
+var wizard = Layouts.Dynamic(() => tab switch
+{
+    0 => BuildHomeTab(),
+    1 => BuildSettingsTab(),
+    _ => new EmptyNode()
+});
+// Call wizard.Invalidate() when tab changes
+```
+
+## How It Works
+
+- The factory is called on each `Measure()` and `Render()` cycle
+- **Reference equality** detects child changes — returning the same instance avoids lifecycle transitions
+- When the child changes: the old child is deactivated, the new child is activated (mirrors `ReactiveLayoutNode` behavior)
+- `GetChildNodes()` returns the current child for focus tree traversal
+- Extends `LayoutNode` so fluent sizing (`.Fill()`, `.Width()`, `.Height()`) works
+
+## Fluent Sizing
+
+```csharp
+Layouts.Dynamic(() => BuildContent())
+    .Fill()        // Fill remaining height
+    .WidthFill()   // Fill available width
+```
+
+::: tip
+For page-level state that doesn't need to be in the ViewModel, `Layouts.Dynamic()` avoids the overhead of creating a `ReactiveProperty<T>` and observable pipeline. For state that _should_ be in the ViewModel, use [Reactive Properties](../concepts/reactive-properties.md) instead.
+:::

--- a/docs/concepts/focus-management.md
+++ b/docs/concepts/focus-management.md
@@ -1,0 +1,123 @@
+# Focus Management
+
+Termina's focus management system routes keyboard input to interactive components using a stack-based model. It supports auto-focus on navigation, Tab cycling, and nested modals.
+
+## Core Concepts
+
+### IFocusable
+
+Any component that can receive keyboard focus implements `IFocusable`:
+
+```csharp
+public interface IFocusable : ILayoutNode
+{
+    bool CanFocus { get; }           // Can this receive focus?
+    bool HasFocus { get; }           // Currently has focus?
+    int FocusPriority { get; }       // Higher = higher priority
+    void OnFocused();                // Called when focused
+    void OnBlurred();                // Called when unfocused
+    bool HandleInput(ConsoleKeyInfo key); // Handle keyboard input
+}
+```
+
+Built-in focusable components: `SelectionListNode<T>`, `TextInputNode`, `ModalNode`, `GridNode`, `WizardNode`.
+
+### FocusManager
+
+The `FocusManager` maintains a focus stack:
+
+```csharp
+Focus.PushFocus(component);  // Push onto stack (for modals)
+Focus.PopFocus();             // Pop from stack (close modal)
+Focus.SetFocus(component);    // Replace top of stack
+Focus.ClearFocus();           // Clear all focus
+Focus.RouteInput(key);        // Route key to current focus
+```
+
+### FocusPolicy
+
+Set `FocusPolicy` in your page to automatically focus a component on navigation:
+
+```csharp
+public class MyPage : ReactivePage<MyViewModel>
+{
+    public MyPage()
+    {
+        FocusPolicy = FocusPolicy.FirstFocusable; // Auto-focus first focusable
+    }
+}
+```
+
+| Policy | Behavior |
+|--------|----------|
+| `Manual` (default) | No auto-focus. Call `Focus.PushFocus()` manually. |
+| `FirstFocusable` | Focus the first `IFocusable` found via depth-first tree walk. |
+| `ByPriority` | Focus the `IFocusable` with the highest `FocusPriority`. |
+
+## Tab Cycling
+
+Opt into Tab/Shift+Tab cycling in your page:
+
+```csharp
+public override void OnNavigatedTo()
+{
+    base.OnNavigatedTo();
+    KeyBindings.Register(ConsoleKey.Tab, CycleFocusForward);
+    KeyBindings.Register(ConsoleKey.Tab, ConsoleModifiers.Shift, CycleFocusBackward);
+}
+```
+
+The cycle helpers walk the layout tree, collect all focusable nodes, and move focus to the next/previous with wrap-around.
+
+## Before / After
+
+**Before** (30+ lines of boilerplate):
+
+```csharp
+public override void OnNavigatedTo()
+{
+    base.OnNavigatedTo();
+    // Manually find the first focusable component
+    var selectionList = FindSelectionList(); // custom helper
+    if (selectionList != null)
+        Focus.PushFocus(selectionList);
+}
+```
+
+**After** (2 lines):
+
+```csharp
+public MyPage()
+{
+    FocusPolicy = FocusPolicy.FirstFocusable;
+}
+```
+
+## Focus Priority
+
+Use `FocusPriority` to establish an input hierarchy:
+
+| Range | Use |
+|-------|-----|
+| 100+ | Modals and overlays (capture all input) |
+| 10-99 | Interactive controls (text inputs, lists) |
+| 1-9 | Background handlers |
+
+## PushFocus / PopFocus for Modals
+
+```csharp
+// Show modal
+Focus.PushFocus(modal);  // Captures all input
+
+// Close modal — focus returns to previous component
+Focus.PopFocus();
+```
+
+## Tree Walk
+
+`CollectFocusables` performs a depth-first walk of the layout tree, collecting all nodes that implement `IFocusable` where `CanFocus` is true. This traverses into `VerticalLayout`, `HorizontalLayout`, `ReactiveLayoutNode`, `DynamicLayoutNode`, and other container types.
+
+```csharp
+var focusables = Focus.CollectFocusables(layoutRoot);
+// focusables[0] is the first focusable in document order
+```

--- a/docs/concepts/reactive-properties.md
+++ b/docs/concepts/reactive-properties.md
@@ -144,6 +144,10 @@ public Observable<Unit> ShutdownRequested => _shutdown;
 
 ## Disposal
 
+::: tip
+For page-level state that doesn't need to be in the ViewModel, see [Dynamic Layouts](../concepts/dynamic-layouts.md). `Layouts.Dynamic()` lets you drive UI from imperative local state without creating an observable pipeline.
+:::
+
 All `ReactiveProperty<T>` instances must be disposed to prevent leaks:
 
 ```csharp

--- a/docs/tutorials/wizard-app.md
+++ b/docs/tutorials/wizard-app.md
@@ -1,0 +1,144 @@
+# Building a Setup Wizard
+
+This tutorial walks through building a 3-step setup wizard using `WizardNode<TStep>`, `DynamicLayoutNode`, `FocusPolicy.FirstFocusable`, and Tab cycling.
+
+## Define the Steps
+
+```csharp
+public enum SetupStep
+{
+    Provider,
+    Auth,
+    Confirm
+}
+```
+
+## Create the ViewModel
+
+```csharp
+public class SetupWizardViewModel : ReactiveViewModel
+{
+    public ReactiveProperty<string> SelectedProvider { get; } = new("None");
+    public ReactiveProperty<string> Username { get; } = new("");
+    public ReactiveProperty<string> Password { get; } = new("");
+
+    public override void Dispose()
+    {
+        SelectedProvider.Dispose();
+        Username.Dispose();
+        Password.Dispose();
+        base.Dispose();
+    }
+}
+```
+
+## Create the Page
+
+```csharp
+public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
+{
+    public SetupWizardPage()
+    {
+        FocusPolicy = FocusPolicy.FirstFocusable;
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        var wizard = Layouts.Wizard<SetupStep>()
+            .WithStep(SetupStep.Provider, "Provider", BuildProviderStep,
+                helpText: "Choose your cloud provider")
+            .WithStep(SetupStep.Auth, "Authentication", BuildAuthStep,
+                helpText: "Enter your credentials")
+            .WithStep(SetupStep.Confirm, "Confirm", BuildConfirmStep,
+                helpText: "Press Enter to complete setup")
+            .WithProgressStyle(WizardProgressStyle.Arrow)
+            .WithBorder(BorderStyle.Rounded)
+            .Fill();
+
+        // Subscribe to completion
+        wizard.Completed.Subscribe(_ => Shutdown());
+
+        return wizard;
+    }
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+        KeyBindings.Register(ConsoleKey.Tab, CycleFocusForward);
+        KeyBindings.Register(ConsoleKey.Tab, ConsoleModifiers.Shift, CycleFocusBackward);
+    }
+
+    private ILayoutNode BuildProviderStep()
+    {
+        var list = Layouts.SelectionList("AWS", "Azure", "GCP")
+            .WithMode(SelectionMode.Single);
+
+        list.SelectionConfirmed.Subscribe(items =>
+        {
+            if (items.Count > 0)
+                ViewModel.SelectedProvider.Value = items[0];
+        });
+
+        return list;
+    }
+
+    private ILayoutNode BuildAuthStep()
+    {
+        var username = new TextInputNode().WithPlaceholder("Username");
+        var password = new TextInputNode().WithPlaceholder("Password");
+
+        username.Submitted.Subscribe(text =>
+            ViewModel.Username.Value = text);
+        password.Submitted.Subscribe(text =>
+            ViewModel.Password.Value = text);
+
+        return Layouts.Vertical(
+            new TextNode("Username:"),
+            username,
+            new TextNode("Password:"),
+            password
+        ).WithSpacing(1);
+    }
+
+    private ILayoutNode BuildConfirmStep()
+    {
+        return Layouts.Vertical(
+            new TextNode("Review your settings:"),
+            ViewModel.SelectedProvider
+                .Select<string, ILayoutNode>(p => new TextNode($"  Provider: {p}"))
+                .AsLayout(),
+            ViewModel.Username
+                .Select<string, ILayoutNode>(u => new TextNode($"  Username: {u}"))
+                .AsLayout(),
+            new TextNode(""),
+            new TextNode("Press Enter to complete, Escape to go back.")
+        );
+    }
+}
+```
+
+## Key Concepts Used
+
+1. **`WizardNode<SetupStep>`** manages step navigation, progress display, and completion
+2. **`DynamicLayoutNode`** (used internally by WizardNode) switches step content without observable pipelines
+3. **`FocusPolicy.FirstFocusable`** auto-focuses the first interactive control on each page visit
+4. **Tab cycling** via `CycleFocusForward` / `CycleFocusBackward` for keyboard navigation between inputs
+5. **`BeforeAdvance`** can be subscribed to for step validation (set `args.Cancel = true` to prevent navigation)
+
+## Wizard Navigation
+
+| Key | Action |
+|-----|--------|
+| Enter | Advance to next step (or complete on last step) |
+| Escape | Go back to previous step |
+| Tab | Cycle focus forward |
+| Shift+Tab | Cycle focus backward |
+
+## Progress Styles
+
+```csharp
+.WithProgressStyle(WizardProgressStyle.BlockBar)  // [====>    ] Step 2 of 3
+.WithProgressStyle(WizardProgressStyle.Arrow)      // Provider > [Auth] > Confirm
+.WithProgressStyle(WizardProgressStyle.Dots)       // [*] [*] [ ] Auth
+.WithProgressStyle(WizardProgressStyle.None)       // No progress indicator
+```

--- a/src/Termina.Generators/LayoutNodeInViewModelAnalyzer.cs
+++ b/src/Termina.Generators/LayoutNodeInViewModelAnalyzer.cs
@@ -109,10 +109,6 @@ public sealed class LayoutNodeInViewModelAnalyzer : DiagnosticAnalyzer
             if (fieldSymbol is null)
                 continue;
 
-            // Skip fields with [Reactive] attribute - these are handled by the source generator
-            if (HasReactiveAttribute(fieldSymbol))
-                continue;
-
             // Check if containing type inherits from ReactiveViewModel
             var containingType = fieldSymbol.ContainingType;
             if (!terminaContext.InheritsFromReactiveViewModel(containingType))
@@ -132,23 +128,6 @@ public sealed class LayoutNodeInViewModelAnalyzer : DiagnosticAnalyzer
 
             context.ReportDiagnostic(diagnostic);
         }
-    }
-
-    /// <summary>
-    /// Checks if a field has the [Reactive] attribute.
-    /// </summary>
-    private static bool HasReactiveAttribute(IFieldSymbol fieldSymbol)
-    {
-        foreach (var attribute in fieldSymbol.GetAttributes())
-        {
-            var attrClass = attribute.AttributeClass;
-            if (attrClass?.Name == "ReactiveAttribute" &&
-                attrClass.ContainingNamespace?.ToDisplayString() == "Termina.Reactive")
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     /// <summary>

--- a/src/Termina/Extensions/ObservableLayoutExtensions.cs
+++ b/src/Termina/Extensions/ObservableLayoutExtensions.cs
@@ -45,4 +45,20 @@ public static class ObservableLayoutExtensions
     {
         return new ReactiveLayoutNode<string>(source, text => new TextNode(text));
     }
+
+    /// <summary>
+    /// Create a <see cref="DynamicLayoutNode"/> from a factory, subscribing an observable trigger
+    /// to call <see cref="DynamicLayoutNode.Invalidate"/> whenever it emits.
+    /// </summary>
+    /// <param name="factory">Factory that returns the current child node.</param>
+    /// <param name="invalidateOn">Observable that triggers re-evaluation of the factory.</param>
+    /// <returns>A dynamic layout node that updates when the trigger emits.</returns>
+    public static DynamicLayoutNode AsDynamicLayout(
+        this Func<ILayoutNode> factory,
+        Observable<Unit> invalidateOn)
+    {
+        var node = new DynamicLayoutNode(factory);
+        invalidateOn.Subscribe(_ => node.Invalidate());
+        return node;
+    }
 }

--- a/src/Termina/Input/FocusManager.cs
+++ b/src/Termina/Input/FocusManager.cs
@@ -18,11 +18,11 @@ namespace Termina.Input;
 public sealed class FocusManager : IFocusManager, IDisposable
 {
     private readonly Stack<IFocusable> _focusStack = new();
-    private readonly BehaviorSubject<IFocusable?> _focusChanged = new(null);
+    private readonly ReactiveProperty<IFocusable?> _focusChanged = new(null);
     private bool _disposed;
 
     /// <inheritdoc />
-    public Observable<IFocusable?> FocusChanged => _focusChanged.AsObservable();
+    public Observable<IFocusable?> FocusChanged => _focusChanged;
 
     /// <inheritdoc />
     public IFocusable? CurrentFocus => _focusStack.Count > 0 ? _focusStack.Peek() : null;
@@ -49,7 +49,7 @@ public sealed class FocusManager : IFocusManager, IDisposable
         // Push and focus the new component
         _focusStack.Push(focusable);
         focusable.OnFocused();
-        _focusChanged.OnNext(focusable);
+        _focusChanged.Value = focusable;
         TerminaTrace.Focus.Debug(this, "PushFocus: {0}, stack depth={1}", focusable.GetType().Name, _focusStack.Count);
     }
 
@@ -73,12 +73,12 @@ public sealed class FocusManager : IFocusManager, IDisposable
             var previous = _focusStack.Peek();
             TerminaTrace.Focus.Debug(this, "PopFocus: restoring focus to {0}", previous.GetType().Name);
             previous.OnFocused();
-            _focusChanged.OnNext(previous);
+            _focusChanged.Value = previous;
         }
         else
         {
             TerminaTrace.Focus.Debug(this, "PopFocus: no previous focus, stack now empty");
-            _focusChanged.OnNext(null);
+            _focusChanged.Value = null;
         }
     }
 
@@ -103,7 +103,7 @@ public sealed class FocusManager : IFocusManager, IDisposable
 
         _focusStack.Push(focusable);
         focusable.OnFocused();
-        _focusChanged.OnNext(focusable);
+        _focusChanged.Value = focusable;
     }
 
     /// <inheritdoc />
@@ -116,7 +116,7 @@ public sealed class FocusManager : IFocusManager, IDisposable
             current.OnBlurred();
         }
 
-        _focusChanged.OnNext(null);
+        _focusChanged.Value = null;
     }
 
     /// <inheritdoc />
@@ -142,6 +142,73 @@ public sealed class FocusManager : IFocusManager, IDisposable
         return handled;
     }
 
+    /// <inheritdoc />
+    public IReadOnlyList<IFocusable> CollectFocusables(ILayoutNode root)
+    {
+        var focusables = new List<IFocusable>();
+        CollectFocusablesRecursive(root, focusables);
+        return focusables;
+    }
+
+    /// <inheritdoc />
+    public void CycleFocus(IReadOnlyList<IFocusable> focusables, bool reverse = false)
+    {
+        if (focusables.Count == 0)
+            return;
+
+        var currentIndex = -1;
+        var current = CurrentFocus;
+
+        if (current != null)
+        {
+            for (var i = 0; i < focusables.Count; i++)
+            {
+                if (ReferenceEquals(focusables[i], current))
+                {
+                    currentIndex = i;
+                    break;
+                }
+            }
+        }
+
+        int nextIndex;
+        if (currentIndex < 0)
+        {
+            // No current focus — go to first (or last if reverse)
+            nextIndex = reverse ? focusables.Count - 1 : 0;
+        }
+        else if (reverse)
+        {
+            nextIndex = (currentIndex - 1 + focusables.Count) % focusables.Count;
+        }
+        else
+        {
+            nextIndex = (currentIndex + 1) % focusables.Count;
+        }
+
+        SetFocus(focusables[nextIndex]);
+    }
+
+    /// <summary>
+    /// Depth-first tree walk collecting focusable nodes.
+    /// </summary>
+    private static void CollectFocusablesRecursive(ILayoutNode node, List<IFocusable> focusables)
+    {
+        if (node is IFocusable { CanFocus: true } focusable)
+        {
+            focusables.Add(focusable);
+        }
+
+        // Only recurse into LayoutNode subclasses (which have GetChildNodes)
+        if (node is LayoutNode layoutNode)
+        {
+            foreach (var child in layoutNode.GetChildNodes())
+            {
+                CollectFocusablesRecursive(child, focusables);
+            }
+        }
+    }
+
     /// <summary>
     /// Disposes the focus manager and releases all resources.
     /// </summary>
@@ -151,7 +218,6 @@ public sealed class FocusManager : IFocusManager, IDisposable
             return;
 
         ClearFocus();
-        _focusChanged.OnCompleted();
         _focusChanged.Dispose();
         _disposed = true;
     }

--- a/src/Termina/Input/FocusPolicy.cs
+++ b/src/Termina/Input/FocusPolicy.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Determines how focus is automatically assigned when a page is navigated to.
+/// </summary>
+public enum FocusPolicy
+{
+    /// <summary>
+    /// No automatic focus assignment. The page must manually call
+    /// <see cref="IFocusManager.PushFocus"/> or <see cref="IFocusManager.SetFocus"/>.
+    /// </summary>
+    Manual,
+
+    /// <summary>
+    /// Automatically focus the first focusable node found via depth-first tree walk.
+    /// </summary>
+    FirstFocusable,
+
+    /// <summary>
+    /// Automatically focus the focusable node with the highest <see cref="Layout.IFocusable.FocusPriority"/>.
+    /// </summary>
+    ByPriority
+}

--- a/src/Termina/Input/IFocusManager.cs
+++ b/src/Termina/Input/IFocusManager.cs
@@ -66,4 +66,18 @@ public interface IFocusManager
     /// <param name="key">The key info to route.</param>
     /// <returns>True if the input was consumed, false if no component handled it.</returns>
     bool RouteInput(ConsoleKeyInfo key);
+
+    /// <summary>
+    /// Depth-first tree walk collecting all focusable nodes where <see cref="IFocusable.CanFocus"/> is true.
+    /// </summary>
+    /// <param name="root">The root of the layout tree to walk.</param>
+    /// <returns>Focusable nodes in depth-first order.</returns>
+    IReadOnlyList<IFocusable> CollectFocusables(ILayoutNode root);
+
+    /// <summary>
+    /// Cycle focus to the next (or previous) focusable in the list, with wrap-around.
+    /// </summary>
+    /// <param name="focusables">The ordered list of focusable nodes.</param>
+    /// <param name="reverse">True to cycle backward, false to cycle forward.</param>
+    void CycleFocus(IReadOnlyList<IFocusable> focusables, bool reverse = false);
 }

--- a/src/Termina/Layout/DynamicLayoutNode.cs
+++ b/src/Termina/Layout/DynamicLayoutNode.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Rendering;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// A layout node that re-evaluates a factory function on every Render/Measure cycle.
+/// Uses reference equality to detect child changes — same instance means no lifecycle churn.
+/// Call <see cref="Invalidate"/> to programmatically trigger re-evaluation.
+/// </summary>
+public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
+{
+    private readonly Func<ILayoutNode> _factory;
+    private readonly Subject<Unit> _invalidated = new();
+    private IDisposable? _childInvalidationSubscription;
+    private ILayoutNode _currentChild;
+    private bool _isActive;
+
+    /// <inheritdoc />
+    public Observable<Unit> Invalidated => _invalidated;
+
+    /// <summary>
+    /// Create a dynamic layout node that evaluates a factory on each render cycle.
+    /// </summary>
+    /// <param name="factory">Factory function that returns the current child node.</param>
+    public DynamicLayoutNode(Func<ILayoutNode> factory)
+    {
+        _factory = factory;
+        _currentChild = new EmptyNode();
+    }
+
+    /// <summary>
+    /// Programmatically signal that the factory output may have changed.
+    /// Triggers re-evaluation on the next Measure/Render cycle.
+    /// </summary>
+    public void Invalidate()
+    {
+        _invalidated.OnNext(Unit.Default);
+    }
+
+    /// <summary>
+    /// Evaluate the factory and update the child if it changed (by reference).
+    /// </summary>
+    private void EvaluateFactory()
+    {
+        var newChild = _factory();
+
+        // Same instance — no lifecycle churn needed
+        if (ReferenceEquals(newChild, _currentChild))
+            return;
+
+        // Deactivate old child (active/inactive pattern — don't dispose)
+        if (_isActive && _currentChild is LayoutNode oldLayoutNode)
+        {
+            oldLayoutNode.OnDeactivate();
+        }
+
+        _currentChild = newChild;
+        SubscribeToChildInvalidation(newChild);
+
+        // Activate new child if we're currently active
+        if (_isActive && newChild is LayoutNode newLayoutNode)
+        {
+            newLayoutNode.OnActivate();
+        }
+    }
+
+    /// <summary>
+    /// Subscribe to a child's invalidation events and propagate them upward.
+    /// </summary>
+    private void SubscribeToChildInvalidation(ILayoutNode child)
+    {
+        _childInvalidationSubscription?.Dispose();
+        _childInvalidationSubscription = null;
+
+        if (child is IInvalidatingNode invalidating)
+        {
+            _childInvalidationSubscription = invalidating.Invalidated
+                .Subscribe(_ => _invalidated.OnNext(Unit.Default));
+        }
+    }
+
+    /// <inheritdoc />
+    internal override IEnumerable<ILayoutNode> GetChildNodes() => [_currentChild];
+
+    /// <inheritdoc />
+    public override Size Measure(Size available)
+    {
+        EvaluateFactory();
+
+        var childSize = _currentChild.Measure(available);
+
+        var width = WidthConstraint.Compute(available.Width, childSize.Width, available.Width);
+        var height = HeightConstraint.Compute(available.Height, childSize.Height, available.Height);
+
+        return new Size(width, height);
+    }
+
+    /// <inheritdoc />
+    public override void Render(IRenderContext context, Rect bounds)
+    {
+        EvaluateFactory();
+        _currentChild.Render(context, bounds);
+    }
+
+    /// <inheritdoc />
+    public override void OnActivate()
+    {
+        _isActive = true;
+
+        // Re-subscribe to current child's invalidation events
+        SubscribeToChildInvalidation(_currentChild);
+
+        // Activate current child
+        if (_currentChild is LayoutNode childNode)
+        {
+            childNode.OnActivate();
+        }
+
+        base.OnActivate();
+    }
+
+    /// <inheritdoc />
+    public override void OnDeactivate()
+    {
+        _isActive = false;
+
+        // Deactivate current child
+        if (_currentChild is LayoutNode childNode)
+        {
+            childNode.OnDeactivate();
+        }
+
+        base.OnDeactivate();
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        _childInvalidationSubscription?.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        _currentChild.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Termina/Layout/Layout.cs
+++ b/src/Termina/Layout/Layout.cs
@@ -74,4 +74,22 @@ public static class Layouts
     /// </remarks>
     /// <param name="getNode">A function that returns the node to render, or null for no content.</param>
     public static DeferredNode Deferred(Func<ILayoutNode?> getNode) => new(getNode);
+
+    /// <summary>
+    /// Create a multi-step wizard component.
+    /// </summary>
+    /// <typeparam name="TStep">Enum type representing the wizard steps.</typeparam>
+    public static WizardNode<TStep> Wizard<TStep>() where TStep : struct, Enum => new();
+
+    /// <summary>
+    /// Create a dynamic layout node that re-evaluates a factory on every render cycle.
+    /// </summary>
+    /// <remarks>
+    /// Use this for imperative, page-local state (e.g., switch/case on an enum) where
+    /// the state doesn't need to live in a ViewModel as an observable.
+    /// The factory is called on each Measure/Render — use reference equality to avoid
+    /// unnecessary child lifecycle transitions.
+    /// </remarks>
+    /// <param name="factory">Factory that returns the current child node.</param>
+    public static DynamicLayoutNode Dynamic(Func<ILayoutNode> factory) => new(factory);
 }

--- a/src/Termina/Layout/WizardBeforeAdvanceArgs.cs
+++ b/src/Termina/Layout/WizardBeforeAdvanceArgs.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Cancellable event args fired before a wizard advances to the next step.
+/// Set <see cref="Cancel"/> to true to prevent navigation.
+/// </summary>
+public sealed class WizardBeforeAdvanceArgs<TStep> where TStep : struct, Enum
+{
+    /// <summary>
+    /// The step being advanced from.
+    /// </summary>
+    public TStep CurrentStep { get; }
+
+    /// <summary>
+    /// The step that will be navigated to.
+    /// </summary>
+    public TStep NextStep { get; }
+
+    /// <summary>
+    /// Set to true to cancel the advance.
+    /// </summary>
+    public bool Cancel { get; set; }
+
+    public WizardBeforeAdvanceArgs(TStep currentStep, TStep nextStep)
+    {
+        CurrentStep = currentStep;
+        NextStep = nextStep;
+    }
+}

--- a/src/Termina/Layout/WizardNode.cs
+++ b/src/Termina/Layout/WizardNode.cs
@@ -94,18 +94,9 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     /// <inheritdoc />
     public bool HandleInput(ConsoleKeyInfo key)
     {
-        // Delegate to step content focusables first
-        if (_contentNode != null)
-        {
-            foreach (var child in _contentNode.GetChildNodes())
-            {
-                if (child is IFocusable { HasFocus: true, CanFocus: true } focusable)
-                {
-                    if (focusable.HandleInput(key))
-                        return true;
-                }
-            }
-        }
+        // Delegate to focusable nodes in step content first (recursive tree walk)
+        if (_contentNode != null && DelegateInputToContent(_contentNode, key))
+            return true;
 
         // Then handle wizard-level keys
         return key.Key switch
@@ -114,6 +105,31 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
             ConsoleKey.Escape => TryGoBack(),
             _ => false
         };
+    }
+
+    /// <summary>
+    /// Recursively walk the content tree to find and delegate input to focusable children.
+    /// </summary>
+    private static bool DelegateInputToContent(ILayoutNode node, ConsoleKeyInfo key)
+    {
+        // Check if this node is focusable and can handle input
+        if (node is IFocusable { CanFocus: true } focusable)
+        {
+            if (focusable.HandleInput(key))
+                return true;
+        }
+
+        // Recurse into LayoutNode children (which expose GetChildNodes)
+        if (node is LayoutNode layoutNode)
+        {
+            foreach (var child in layoutNode.GetChildNodes())
+            {
+                if (DelegateInputToContent(child, key))
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     #endregion

--- a/src/Termina/Layout/WizardNode.cs
+++ b/src/Termina/Layout/WizardNode.cs
@@ -21,6 +21,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     private readonly Subject<Unit> _completed = new();
     private readonly Subject<Unit> _invalidated = new();
 
+    private readonly Dictionary<int, ILayoutNode> _stepContentCache = new();
     private int _currentStepIndex;
     private int _currentSubStep;
     private bool _hasFocus;
@@ -388,11 +389,24 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         {
             if (_steps.Count == 0)
                 return new EmptyNode();
-            return _steps[_currentStepIndex].ContentFactory();
+            return GetOrCreateStepContent(_currentStepIndex);
         });
 
         if (_isActive)
             _contentNode.OnActivate();
+    }
+
+    /// <summary>
+    /// Get cached step content or create it once from the factory.
+    /// </summary>
+    private ILayoutNode GetOrCreateStepContent(int stepIndex)
+    {
+        if (!_stepContentCache.TryGetValue(stepIndex, out var content))
+        {
+            content = _steps[stepIndex].ContentFactory();
+            _stepContentCache[stepIndex] = content;
+        }
+        return content;
     }
 
     private void RenderProgress(IRenderContext context, Rect bounds)
@@ -542,6 +556,16 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         _completed.Dispose();
         _invalidated.OnCompleted();
         _invalidated.Dispose();
+
+        // Dispose cached step content that isn't the DynamicLayoutNode's current child
+        // (DynamicLayoutNode will dispose its own current child)
+        ILayoutNode? currentContent = _steps.Count > 0 && _stepContentCache.TryGetValue(_currentStepIndex, out var c) ? c : null;
+        foreach (var content in _stepContentCache.Values)
+        {
+            if (!ReferenceEquals(content, currentContent))
+                content.Dispose();
+        }
+        _stepContentCache.Clear();
         _contentNode?.Dispose();
         base.Dispose();
     }

--- a/src/Termina/Layout/WizardNode.cs
+++ b/src/Termina/Layout/WizardNode.cs
@@ -27,6 +27,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     private int _currentSubStep;
     private bool _hasFocus;
     private bool _isActive;
+    private IFocusable? _focusedChild;
 
     // Internal layout
     private DynamicLayoutNode? _contentNode;
@@ -84,6 +85,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     public void OnFocused()
     {
         _hasFocus = true;
+        PropagateFocusToContent();
         _invalidated.OnNext(Unit.Default);
     }
 
@@ -91,6 +93,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     public void OnBlurred()
     {
         _hasFocus = false;
+        BlurContentChild();
         _invalidated.OnNext(Unit.Default);
     }
 
@@ -151,6 +154,53 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Propagate focus to the first focusable child in the current step content.
+    /// </summary>
+    private void PropagateFocusToContent()
+    {
+        BlurContentChild();
+
+        if (_steps.Count == 0)
+            return;
+
+        // Get or create the step content directly (so focus works before first Render)
+        var content = GetOrCreateStepContent(_currentStepIndex);
+        _focusedChild = FindFirstFocusable(content);
+        _focusedChild?.OnFocused();
+    }
+
+    /// <summary>
+    /// Blur the currently focused content child.
+    /// </summary>
+    private void BlurContentChild()
+    {
+        if (_focusedChild is { HasFocus: true })
+            _focusedChild.OnBlurred();
+        _focusedChild = null;
+    }
+
+    /// <summary>
+    /// Walk the layout tree depth-first to find the first focusable node.
+    /// </summary>
+    private static IFocusable? FindFirstFocusable(ILayoutNode node)
+    {
+        if (node is IFocusable { CanFocus: true } focusable)
+            return focusable;
+
+        if (node is LayoutNode layoutNode)
+        {
+            foreach (var child in layoutNode.GetChildNodes())
+            {
+                var found = FindFirstFocusable(child);
+                if (found != null)
+                    return found;
+            }
+        }
+
+        return null;
     }
 
     #endregion
@@ -236,6 +286,8 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
 
         _currentStepIndex++;
         _currentSubStep = 0;
+        if (_hasFocus)
+            PropagateFocusToContent();
         _invalidated.OnNext(Unit.Default);
         _stepChanged.OnNext(CurrentStep);
         return true;
@@ -263,6 +315,8 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         _currentStepIndex--;
         // Return to last sub-step of previous step
         _currentSubStep = _steps[_currentStepIndex].SubStepCount - 1;
+        if (_hasFocus)
+            PropagateFocusToContent();
         _invalidated.OnNext(Unit.Default);
         _stepChanged.OnNext(CurrentStep);
         return true;
@@ -281,6 +335,8 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
 
         _currentStepIndex = index;
         _currentSubStep = 0;
+        if (_hasFocus)
+            PropagateFocusToContent();
         _invalidated.OnNext(Unit.Default);
         _stepChanged.OnNext(CurrentStep);
         return true;
@@ -419,6 +475,11 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
 
         if (_isActive)
             _contentNode.OnActivate();
+
+        // If wizard already has focus (OnFocused called before first Render),
+        // propagate focus to the content's first focusable child now
+        if (_hasFocus && _focusedChild == null)
+            PropagateFocusToContent();
     }
 
     /// <summary>

--- a/src/Termina/Layout/WizardNode.cs
+++ b/src/Termina/Layout/WizardNode.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
 using R3;
+using Termina.Diagnostics;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -29,6 +30,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
 
     // Internal layout
     private DynamicLayoutNode? _contentNode;
+    private IDisposable? _contentInvalidationSubscription;
     private string? _title;
     private WizardProgressStyle _progressStyle = WizardProgressStyle.BlockBar;
     private BorderStyle? _borderStyle;
@@ -95,17 +97,25 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     /// <inheritdoc />
     public bool HandleInput(ConsoleKeyInfo key)
     {
+        TerminaTrace.Input.Debug(this, "HandleInput: key={0}, contentNode={1}",
+            key.Key, _contentNode != null ? "exists" : "null");
+
         // Delegate to focusable nodes in step content first (recursive tree walk)
         if (_contentNode != null && DelegateInputToContent(_contentNode, key))
+        {
+            TerminaTrace.Input.Debug(this, "HandleInput: delegated to child, key={0}", key.Key);
             return true;
+        }
 
         // Then handle wizard-level keys
-        return key.Key switch
+        var result = key.Key switch
         {
             ConsoleKey.Enter => TryAdvance(),
             ConsoleKey.Escape => TryGoBack(),
             _ => false
         };
+        TerminaTrace.Input.Debug(this, "HandleInput: wizard handled key={0}, result={1}", key.Key, result);
+        return result;
     }
 
     /// <summary>
@@ -113,17 +123,27 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     /// </summary>
     private static bool DelegateInputToContent(ILayoutNode node, ConsoleKeyInfo key)
     {
+        TerminaTrace.Input.Trace(node, "DelegateInput: visiting {0}, IsFocusable={1}, IsLayoutNode={2}",
+            node.GetType().Name, node is IFocusable, node is LayoutNode);
+
         // Check if this node is focusable and can handle input
         if (node is IFocusable { CanFocus: true } focusable)
         {
+            TerminaTrace.Input.Debug(node, "DelegateInput: forwarding key={0} to {1}",
+                key.Key, node.GetType().Name);
             if (focusable.HandleInput(key))
                 return true;
+            TerminaTrace.Input.Debug(node, "DelegateInput: {0} did not handle key={1}",
+                node.GetType().Name, key.Key);
         }
 
         // Recurse into LayoutNode children (which expose GetChildNodes)
         if (node is LayoutNode layoutNode)
         {
-            foreach (var child in layoutNode.GetChildNodes())
+            var children = layoutNode.GetChildNodes();
+            TerminaTrace.Input.Trace(node, "DelegateInput: recursing into {0} children of {1}",
+                children.Count(), node.GetType().Name);
+            foreach (var child in children)
             {
                 if (DelegateInputToContent(child, key))
                     return true;
@@ -392,6 +412,11 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
             return GetOrCreateStepContent(_currentStepIndex);
         });
 
+        // Propagate content invalidation (e.g., SelectionListNode highlight changes)
+        // up through the wizard so the page triggers a redraw
+        _contentInvalidationSubscription = _contentNode.Invalidated
+            .Subscribe(_ => _invalidated.OnNext(Unit.Default));
+
         if (_isActive)
             _contentNode.OnActivate();
     }
@@ -556,6 +581,8 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         _completed.Dispose();
         _invalidated.OnCompleted();
         _invalidated.Dispose();
+
+        _contentInvalidationSubscription?.Dispose();
 
         // Dispose cached step content that isn't the DynamicLayoutNode's current child
         // (DynamicLayoutNode will dispose its own current child)

--- a/src/Termina/Layout/WizardNode.cs
+++ b/src/Termina/Layout/WizardNode.cs
@@ -1,0 +1,547 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// A multi-step wizard component with progress indicator, step content, and navigation.
+/// </summary>
+/// <typeparam name="TStep">Enum type representing the wizard steps.</typeparam>
+public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNode
+    where TStep : struct, Enum
+{
+    private readonly List<WizardStepConfig<TStep>> _steps = new();
+    private readonly Dictionary<TStep, int> _stepIndex = new();
+    private readonly Subject<TStep> _stepChanged = new();
+    private readonly Subject<WizardBeforeAdvanceArgs<TStep>> _beforeAdvance = new();
+    private readonly Subject<Unit> _completed = new();
+    private readonly Subject<Unit> _invalidated = new();
+
+    private int _currentStepIndex;
+    private int _currentSubStep;
+    private bool _hasFocus;
+    private bool _isActive;
+
+    // Internal layout
+    private DynamicLayoutNode? _contentNode;
+    private string? _title;
+    private WizardProgressStyle _progressStyle = WizardProgressStyle.BlockBar;
+    private BorderStyle? _borderStyle;
+    private Color? _borderColor;
+
+    /// <summary>
+    /// Observable that emits when the current step changes.
+    /// </summary>
+    public Observable<TStep> StepChanged => _stepChanged;
+
+    /// <summary>
+    /// Observable that fires before advancing. Subscribe to set <see cref="WizardBeforeAdvanceArgs{TStep}.Cancel"/> for validation.
+    /// </summary>
+    public Observable<WizardBeforeAdvanceArgs<TStep>> BeforeAdvance => _beforeAdvance;
+
+    /// <summary>
+    /// Observable that emits when the wizard completes (advances past the last step).
+    /// </summary>
+    public Observable<Unit> Completed => _completed;
+
+    /// <inheritdoc />
+    public Observable<Unit> Invalidated => _invalidated;
+
+    /// <summary>
+    /// Gets the current step.
+    /// </summary>
+    public TStep CurrentStep => _steps.Count > 0 ? _steps[_currentStepIndex].Step : default;
+
+    /// <summary>
+    /// Gets the current sub-step index (0-based).
+    /// </summary>
+    public int CurrentSubStep => _currentSubStep;
+
+    /// <summary>
+    /// Gets the total number of steps.
+    /// </summary>
+    public int StepCount => _steps.Count;
+
+    #region IFocusable
+
+    /// <inheritdoc />
+    public bool CanFocus => true;
+
+    /// <inheritdoc />
+    public bool HasFocus => _hasFocus;
+
+    /// <inheritdoc />
+    public int FocusPriority => 10;
+
+    /// <inheritdoc />
+    public void OnFocused()
+    {
+        _hasFocus = true;
+        _invalidated.OnNext(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public void OnBlurred()
+    {
+        _hasFocus = false;
+        _invalidated.OnNext(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public bool HandleInput(ConsoleKeyInfo key)
+    {
+        // Delegate to step content focusables first
+        if (_contentNode != null)
+        {
+            foreach (var child in _contentNode.GetChildNodes())
+            {
+                if (child is IFocusable { HasFocus: true, CanFocus: true } focusable)
+                {
+                    if (focusable.HandleInput(key))
+                        return true;
+                }
+            }
+        }
+
+        // Then handle wizard-level keys
+        return key.Key switch
+        {
+            ConsoleKey.Enter => TryAdvance(),
+            ConsoleKey.Escape => TryGoBack(),
+            _ => false
+        };
+    }
+
+    #endregion
+
+    #region Fluent Builder
+
+    /// <summary>
+    /// Add a step to the wizard.
+    /// </summary>
+    public WizardNode<TStep> WithStep(TStep step, string displayName, Func<ILayoutNode> contentFactory,
+        string? helpText = null, int subSteps = 1)
+    {
+        var config = new WizardStepConfig<TStep>(step, displayName, contentFactory, helpText, subSteps);
+        _stepIndex[step] = _steps.Count;
+        _steps.Add(config);
+        return this;
+    }
+
+    /// <summary>
+    /// Set the progress bar style.
+    /// </summary>
+    public WizardNode<TStep> WithProgressStyle(WizardProgressStyle style)
+    {
+        _progressStyle = style;
+        return this;
+    }
+
+    /// <summary>
+    /// Set the wizard title.
+    /// </summary>
+    public WizardNode<TStep> WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+
+    /// <summary>
+    /// Add a border around the wizard.
+    /// </summary>
+    public WizardNode<TStep> WithBorder(BorderStyle style = BorderStyle.Single, Color? color = null)
+    {
+        _borderStyle = style;
+        _borderColor = color;
+        return this;
+    }
+
+    #endregion
+
+    #region Navigation
+
+    /// <summary>
+    /// Try to advance to the next step. Returns true if navigation occurred.
+    /// </summary>
+    public bool TryAdvance()
+    {
+        if (_steps.Count == 0)
+            return false;
+
+        var currentConfig = _steps[_currentStepIndex];
+
+        // Check sub-steps first
+        if (_currentSubStep < currentConfig.SubStepCount - 1)
+        {
+            _currentSubStep++;
+            _invalidated.OnNext(Unit.Default);
+            return true;
+        }
+
+        // On last step — fire completed
+        if (_currentStepIndex >= _steps.Count - 1)
+        {
+            _completed.OnNext(Unit.Default);
+            return true;
+        }
+
+        // Fire BeforeAdvance for validation
+        var nextStep = _steps[_currentStepIndex + 1].Step;
+        var args = new WizardBeforeAdvanceArgs<TStep>(CurrentStep, nextStep);
+        _beforeAdvance.OnNext(args);
+
+        if (args.Cancel)
+            return false;
+
+        _currentStepIndex++;
+        _currentSubStep = 0;
+        _invalidated.OnNext(Unit.Default);
+        _stepChanged.OnNext(CurrentStep);
+        return true;
+    }
+
+    /// <summary>
+    /// Try to go back to the previous step. Returns true if navigation occurred.
+    /// </summary>
+    public bool TryGoBack()
+    {
+        if (_steps.Count == 0)
+            return false;
+
+        // Go back within sub-steps first
+        if (_currentSubStep > 0)
+        {
+            _currentSubStep--;
+            _invalidated.OnNext(Unit.Default);
+            return true;
+        }
+
+        if (_currentStepIndex <= 0)
+            return false;
+
+        _currentStepIndex--;
+        // Return to last sub-step of previous step
+        _currentSubStep = _steps[_currentStepIndex].SubStepCount - 1;
+        _invalidated.OnNext(Unit.Default);
+        _stepChanged.OnNext(CurrentStep);
+        return true;
+    }
+
+    /// <summary>
+    /// Jump directly to a specific step.
+    /// </summary>
+    public bool GoToStep(TStep step)
+    {
+        if (!_stepIndex.TryGetValue(step, out var index))
+            return false;
+
+        if (index == _currentStepIndex)
+            return false;
+
+        _currentStepIndex = index;
+        _currentSubStep = 0;
+        _invalidated.OnNext(Unit.Default);
+        _stepChanged.OnNext(CurrentStep);
+        return true;
+    }
+
+    /// <summary>
+    /// Advance to the next sub-step within the current step.
+    /// Returns false if already at the last sub-step.
+    /// </summary>
+    public bool AdvanceSubStep()
+    {
+        if (_steps.Count == 0)
+            return false;
+
+        var config = _steps[_currentStepIndex];
+        if (_currentSubStep >= config.SubStepCount - 1)
+            return false;
+
+        _currentSubStep++;
+        _invalidated.OnNext(Unit.Default);
+        return true;
+    }
+
+    #endregion
+
+    #region Rendering
+
+    /// <inheritdoc />
+    public override Size Measure(Size available)
+    {
+        if (_steps.Count == 0)
+            return Size.Zero;
+
+        var height = 0;
+        var width = available.Width;
+
+        // Progress bar takes 1 line (if shown)
+        if (_progressStyle != WizardProgressStyle.None)
+            height += 1;
+
+        // Title takes 1 line (if set)
+        if (_title != null)
+            height += 1;
+
+        // Content area fills remaining
+        var contentHeight = Math.Max(1, available.Height - height - (_steps[_currentStepIndex].HelpText != null ? 1 : 0));
+        height += contentHeight;
+
+        // Help text takes 1 line
+        if (_steps[_currentStepIndex].HelpText != null)
+            height += 1;
+
+        // Border adds 2 lines/cols
+        if (_borderStyle.HasValue)
+        {
+            height += 2;
+            width = Math.Max(0, width);
+        }
+
+        return new Size(
+            WidthConstraint.Compute(available.Width, width, available.Width),
+            HeightConstraint.Compute(available.Height, height, available.Height));
+    }
+
+    /// <inheritdoc />
+    public override void Render(IRenderContext context, Rect bounds)
+    {
+        if (_steps.Count == 0 || !bounds.HasArea)
+            return;
+
+        var renderBounds = bounds;
+
+        // Render border if configured
+        if (_borderStyle.HasValue)
+        {
+            RenderBorder(context, bounds);
+            // Shrink bounds for inner content
+            renderBounds = new Rect(bounds.X + 1, bounds.Y + 1, Math.Max(0, bounds.Width - 2), Math.Max(0, bounds.Height - 2));
+        }
+
+        var y = renderBounds.Y;
+        var currentConfig = _steps[_currentStepIndex];
+
+        // Render title
+        if (_title != null)
+        {
+            context.WriteAt(renderBounds.X, y, _title);
+            y++;
+        }
+
+        // Render progress bar
+        if (_progressStyle != WizardProgressStyle.None && y < renderBounds.Bottom)
+        {
+            RenderProgress(context, new Rect(renderBounds.X, y, renderBounds.Width, 1));
+            y++;
+        }
+
+        // Render help text at bottom
+        var helpHeight = currentConfig.HelpText != null ? 1 : 0;
+        var contentBottom = renderBounds.Bottom - helpHeight;
+
+        // Render content area using DynamicLayoutNode
+        if (y < contentBottom)
+        {
+            EnsureContentNode();
+            var contentBounds = new Rect(renderBounds.X, y, renderBounds.Width, contentBottom - y);
+            _contentNode!.Render(context, contentBounds);
+        }
+
+        // Render help text
+        if (currentConfig.HelpText != null && contentBottom < renderBounds.Bottom)
+        {
+            var helpStyle = new TextStyle(Color.DarkGray);
+            context.ApplyStyle(helpStyle);
+            context.WriteAt(renderBounds.X, contentBottom, currentConfig.HelpText);
+            context.ResetColors();
+        }
+    }
+
+    private void EnsureContentNode()
+    {
+        if (_contentNode != null)
+            return;
+
+        _contentNode = new DynamicLayoutNode(() =>
+        {
+            if (_steps.Count == 0)
+                return new EmptyNode();
+            return _steps[_currentStepIndex].ContentFactory();
+        });
+
+        if (_isActive)
+            _contentNode.OnActivate();
+    }
+
+    private void RenderProgress(IRenderContext context, Rect bounds)
+    {
+        var text = _progressStyle switch
+        {
+            WizardProgressStyle.BlockBar => RenderBlockBar(bounds.Width),
+            WizardProgressStyle.Arrow => RenderArrowChain(bounds.Width),
+            WizardProgressStyle.Dots => RenderDots(bounds.Width),
+            _ => string.Empty
+        };
+
+        if (text.Length > 0)
+        {
+            context.WriteAt(bounds.X, bounds.Y, text.Length > bounds.Width ? text[..bounds.Width] : text);
+        }
+    }
+
+    private string RenderBlockBar(int width)
+    {
+        var label = $" Step {_currentStepIndex + 1} of {_steps.Count} ";
+        var barWidth = Math.Max(0, width - label.Length - 2); // [====>    ]
+        if (barWidth <= 0)
+            return label;
+
+        var filled = (int)((double)(_currentStepIndex + 1) / _steps.Count * barWidth);
+        filled = Math.Clamp(filled, 0, barWidth);
+
+        var bar = new string('=', Math.Max(0, filled - 1)) +
+                  (filled > 0 ? ">" : "") +
+                  new string(' ', barWidth - filled);
+        return $"[{bar}]{label}";
+    }
+
+    private string RenderArrowChain(int width)
+    {
+        var parts = new List<string>();
+        for (var i = 0; i < _steps.Count; i++)
+        {
+            var name = _steps[i].DisplayName;
+            parts.Add(i == _currentStepIndex ? $"[{name}]" : name);
+        }
+        var text = string.Join(" > ", parts);
+        return text.Length > width ? text[..width] : text;
+    }
+
+    private string RenderDots(int width)
+    {
+        var parts = new List<string>();
+        for (var i = 0; i < _steps.Count; i++)
+        {
+            parts.Add(i <= _currentStepIndex ? "[*]" : "[ ]");
+        }
+        var dots = string.Join(" ", parts);
+        var label = $" {_steps[_currentStepIndex].DisplayName}";
+        var text = dots + label;
+        return text.Length > width ? text[..width] : text;
+    }
+
+    private void RenderBorder(IRenderContext context, Rect bounds)
+    {
+        var chars = _borderStyle switch
+        {
+            BorderStyle.Single => BorderChars.Single,
+            BorderStyle.Double => BorderChars.Double,
+            BorderStyle.Rounded => BorderChars.Rounded,
+            BorderStyle.Ascii => BorderChars.Ascii,
+            _ => BorderChars.Single
+        };
+
+        if (_borderColor.HasValue)
+            context.SetForeground(_borderColor.Value);
+
+        // Top border with optional title
+        context.WriteAt(bounds.X, bounds.Y, chars.TopLeft);
+        var titleText = _title != null ? $" {_title} " : "";
+        var topBarWidth = Math.Max(0, bounds.Width - 2 - titleText.Length);
+        if (_title != null)
+        {
+            context.WriteAt(bounds.X + 1, bounds.Y, titleText);
+            for (var i = 0; i < topBarWidth; i++)
+                context.WriteAt(bounds.X + 1 + titleText.Length + i, bounds.Y, chars.Horizontal);
+        }
+        else
+        {
+            for (var i = 0; i < bounds.Width - 2; i++)
+                context.WriteAt(bounds.X + 1 + i, bounds.Y, chars.Horizontal);
+        }
+        context.WriteAt(bounds.Right - 1, bounds.Y, chars.TopRight);
+
+        // Side borders
+        for (var y = bounds.Y + 1; y < bounds.Bottom - 1; y++)
+        {
+            context.WriteAt(bounds.X, y, chars.Vertical);
+            context.WriteAt(bounds.Right - 1, y, chars.Vertical);
+        }
+
+        // Bottom border
+        if (bounds.Height > 1)
+        {
+            context.WriteAt(bounds.X, bounds.Bottom - 1, chars.BottomLeft);
+            for (var i = 0; i < bounds.Width - 2; i++)
+                context.WriteAt(bounds.X + 1 + i, bounds.Bottom - 1, chars.Horizontal);
+            context.WriteAt(bounds.Right - 1, bounds.Bottom - 1, chars.BottomRight);
+        }
+
+        if (_borderColor.HasValue)
+            context.ResetColors();
+    }
+
+    #endregion
+
+    #region Lifecycle
+
+    /// <inheritdoc />
+    internal override IEnumerable<ILayoutNode> GetChildNodes()
+    {
+        if (_contentNode != null)
+            return [_contentNode];
+        return [];
+    }
+
+    /// <inheritdoc />
+    public override void OnActivate()
+    {
+        _isActive = true;
+        _contentNode?.OnActivate();
+        base.OnActivate();
+    }
+
+    /// <inheritdoc />
+    public override void OnDeactivate()
+    {
+        _isActive = false;
+        _contentNode?.OnDeactivate();
+        base.OnDeactivate();
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        _stepChanged.OnCompleted();
+        _stepChanged.Dispose();
+        _beforeAdvance.OnCompleted();
+        _beforeAdvance.Dispose();
+        _completed.OnCompleted();
+        _completed.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        _contentNode?.Dispose();
+        base.Dispose();
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Border character sets for different styles.
+    /// </summary>
+    private static class BorderChars
+    {
+        public static readonly BorderCharSet Single = new('┌', '─', '┐', '│', '└', '┘');
+        public static readonly BorderCharSet Double = new('╔', '═', '╗', '║', '╚', '╝');
+        public static readonly BorderCharSet Rounded = new('╭', '─', '╮', '│', '╰', '╯');
+        public static readonly BorderCharSet Ascii = new('+', '-', '+', '|', '+', '+');
+    }
+
+    private record struct BorderCharSet(char TopLeft, char Horizontal, char TopRight, char Vertical, char BottomLeft, char BottomRight);
+}

--- a/src/Termina/Layout/WizardProgressStyle.cs
+++ b/src/Termina/Layout/WizardProgressStyle.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Visual style for the wizard progress indicator.
+/// </summary>
+public enum WizardProgressStyle
+{
+    /// <summary>
+    /// Block bar: [====>    ] Step 2 of 4
+    /// </summary>
+    BlockBar,
+
+    /// <summary>
+    /// Arrow chain: Step1 > Step2 > Step3
+    /// </summary>
+    Arrow,
+
+    /// <summary>
+    /// Dot indicators: [*] [*] [ ] [ ]
+    /// </summary>
+    Dots,
+
+    /// <summary>
+    /// No progress indicator shown.
+    /// </summary>
+    None
+}

--- a/src/Termina/Layout/WizardStepConfig.cs
+++ b/src/Termina/Layout/WizardStepConfig.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Configuration for a single wizard step.
+/// </summary>
+public sealed class WizardStepConfig<TStep> where TStep : struct, Enum
+{
+    /// <summary>
+    /// The enum value identifying this step.
+    /// </summary>
+    public TStep Step { get; }
+
+    /// <summary>
+    /// Display name for the step (shown in progress bar).
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Factory that builds the content layout for this step.
+    /// </summary>
+    public Func<ILayoutNode> ContentFactory { get; }
+
+    /// <summary>
+    /// Optional help text displayed below the content area.
+    /// </summary>
+    public string? HelpText { get; }
+
+    /// <summary>
+    /// Number of sub-steps within this step (1 = no sub-steps).
+    /// </summary>
+    public int SubStepCount { get; }
+
+    public WizardStepConfig(TStep step, string displayName, Func<ILayoutNode> contentFactory,
+        string? helpText = null, int subStepCount = 1)
+    {
+        Step = step;
+        DisplayName = displayName;
+        ContentFactory = contentFactory;
+        HelpText = helpText;
+        SubStepCount = Math.Max(1, subStepCount);
+    }
+}

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -44,6 +44,12 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     private ILayoutNode? _layoutRoot;
 
     /// <summary>
+    /// Determines how focus is automatically assigned when this page is navigated to.
+    /// Set in the page constructor or <see cref="OnBound"/> method.
+    /// </summary>
+    protected FocusPolicy FocusPolicy { get; set; } = FocusPolicy.Manual;
+
+    /// <summary>
     /// The ViewModel this page is bound to.
     /// Available after <see cref="Bind"/> is called by the framework.
     /// </summary>
@@ -203,6 +209,56 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
         if (_layoutRoot is LayoutNode node)
         {
             node.OnActivate();
+        }
+
+        // Auto-focus based on policy
+        if (FocusPolicy != FocusPolicy.Manual && _layoutRoot != null)
+        {
+            ApplyFocusPolicy(_layoutRoot);
+        }
+    }
+
+    /// <summary>
+    /// Cycle focus forward through focusable nodes in the layout tree.
+    /// Register as a key binding: <c>KeyBindings.Register(ConsoleKey.Tab, CycleFocusForward);</c>
+    /// </summary>
+    protected void CycleFocusForward()
+    {
+        if (_layoutRoot == null) return;
+        var focusables = Focus.CollectFocusables(_layoutRoot);
+        Focus.CycleFocus(focusables);
+    }
+
+    /// <summary>
+    /// Cycle focus backward through focusable nodes in the layout tree.
+    /// Register as a key binding: <c>KeyBindings.Register(ConsoleKey.Tab, ConsoleModifiers.Shift, CycleFocusBackward);</c>
+    /// </summary>
+    protected void CycleFocusBackward()
+    {
+        if (_layoutRoot == null) return;
+        var focusables = Focus.CollectFocusables(_layoutRoot);
+        Focus.CycleFocus(focusables, reverse: true);
+    }
+
+    /// <summary>
+    /// Apply the configured focus policy to the layout tree.
+    /// </summary>
+    private void ApplyFocusPolicy(ILayoutNode root)
+    {
+        var focusables = Focus.CollectFocusables(root);
+        if (focusables.Count == 0)
+            return;
+
+        IFocusable? target = FocusPolicy switch
+        {
+            FocusPolicy.FirstFocusable => focusables[0],
+            FocusPolicy.ByPriority => focusables.OrderByDescending(f => f.FocusPriority).First(),
+            _ => null
+        };
+
+        if (target != null)
+        {
+            Focus.SetFocus(target);
         }
     }
 

--- a/tests/Termina.Tests/Input/FocusManagerAutoFocusTests.cs
+++ b/tests/Termina.Tests/Input/FocusManagerAutoFocusTests.cs
@@ -1,0 +1,242 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Rendering;
+
+namespace Termina.Tests.Input;
+
+/// <summary>
+/// Tests for FocusManager.CollectFocusables and CycleFocus functionality.
+/// </summary>
+public class FocusManagerAutoFocusTests
+{
+    [Fact]
+    public void CollectFocusables_EmptyTree_ReturnsEmpty()
+    {
+        using var fm = new FocusManager();
+        var root = new EmptyNode();
+
+        var result = fm.CollectFocusables(root);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void CollectFocusables_SingleFocusable_ReturnsIt()
+    {
+        using var fm = new FocusManager();
+        var focusable = new TestFocusableNode();
+        var root = Layouts.Vertical(focusable);
+
+        var result = fm.CollectFocusables(root);
+
+        Assert.Single(result);
+        Assert.Same(focusable, result[0]);
+    }
+
+    [Fact]
+    public void CollectFocusables_NestedLayout_FindsAll()
+    {
+        using var fm = new FocusManager();
+        var f1 = new TestFocusableNode();
+        var f2 = new TestFocusableNode();
+        var f3 = new TestFocusableNode();
+
+        var root = Layouts.Vertical(
+            f1,
+            Layouts.Horizontal(f2, new TextNode("text")),
+            f3
+        );
+
+        var result = fm.CollectFocusables(root);
+
+        Assert.Equal(3, result.Count);
+        Assert.Same(f1, result[0]);
+        Assert.Same(f2, result[1]);
+        Assert.Same(f3, result[2]);
+    }
+
+    [Fact]
+    public void CollectFocusables_FiltersCanFocusFalse()
+    {
+        using var fm = new FocusManager();
+        var focusable = new TestFocusableNode();
+        var disabled = new TestFocusableNode { CanFocusValue = false };
+
+        var root = Layouts.Vertical(focusable, disabled);
+
+        var result = fm.CollectFocusables(root);
+
+        Assert.Single(result);
+        Assert.Same(focusable, result[0]);
+    }
+
+    [Fact]
+    public void CollectFocusables_TraversesDynamicLayoutNode()
+    {
+        using var fm = new FocusManager();
+        var focusable = new TestFocusableNode();
+        var dynamic = new DynamicLayoutNode(() => focusable);
+
+        // Must evaluate factory first
+        dynamic.Measure(new Size(80, 24));
+
+        var root = Layouts.Vertical(dynamic);
+        var result = fm.CollectFocusables(root);
+
+        Assert.Single(result);
+        Assert.Same(focusable, result[0]);
+    }
+
+    [Fact]
+    public void CollectFocusables_TraversesReactiveLayoutNode()
+    {
+        using var fm = new FocusManager();
+        var focusable = new TestFocusableNode();
+        var reactive = new ReactiveLayoutNode(
+            R3.Observable.Return<ILayoutNode>(focusable));
+
+        var root = Layouts.Vertical(reactive);
+        var result = fm.CollectFocusables(root);
+
+        Assert.Single(result);
+        Assert.Same(focusable, result[0]);
+    }
+
+    [Fact]
+    public void CycleFocus_Forward_MovesToNext()
+    {
+        using var fm = new FocusManager();
+        var f1 = new TestFocusableNode();
+        var f2 = new TestFocusableNode();
+        var f3 = new TestFocusableNode();
+        var focusables = new List<IFocusable> { f1, f2, f3 };
+
+        fm.PushFocus(f1);
+        fm.CycleFocus(focusables);
+
+        Assert.Same(f2, fm.CurrentFocus);
+    }
+
+    [Fact]
+    public void CycleFocus_Forward_WrapsAround()
+    {
+        using var fm = new FocusManager();
+        var f1 = new TestFocusableNode();
+        var f2 = new TestFocusableNode();
+        var focusables = new List<IFocusable> { f1, f2 };
+
+        fm.PushFocus(f2);
+        fm.CycleFocus(focusables);
+
+        Assert.Same(f1, fm.CurrentFocus);
+    }
+
+    [Fact]
+    public void CycleFocus_Backward_MovesToPrevious()
+    {
+        using var fm = new FocusManager();
+        var f1 = new TestFocusableNode();
+        var f2 = new TestFocusableNode();
+        var f3 = new TestFocusableNode();
+        var focusables = new List<IFocusable> { f1, f2, f3 };
+
+        fm.PushFocus(f2);
+        fm.CycleFocus(focusables, reverse: true);
+
+        Assert.Same(f1, fm.CurrentFocus);
+    }
+
+    [Fact]
+    public void CycleFocus_Backward_WrapsAround()
+    {
+        using var fm = new FocusManager();
+        var f1 = new TestFocusableNode();
+        var f2 = new TestFocusableNode();
+        var focusables = new List<IFocusable> { f1, f2 };
+
+        fm.PushFocus(f1);
+        fm.CycleFocus(focusables, reverse: true);
+
+        Assert.Same(f2, fm.CurrentFocus);
+    }
+
+    [Fact]
+    public void CycleFocus_NoCurrentFocus_FocusesFirst()
+    {
+        using var fm = new FocusManager();
+        var f1 = new TestFocusableNode();
+        var f2 = new TestFocusableNode();
+        var focusables = new List<IFocusable> { f1, f2 };
+
+        fm.CycleFocus(focusables);
+
+        Assert.Same(f1, fm.CurrentFocus);
+    }
+
+    [Fact]
+    public void CycleFocus_NoCurrentFocus_Reverse_FocusesLast()
+    {
+        using var fm = new FocusManager();
+        var f1 = new TestFocusableNode();
+        var f2 = new TestFocusableNode();
+        var focusables = new List<IFocusable> { f1, f2 };
+
+        fm.CycleFocus(focusables, reverse: true);
+
+        Assert.Same(f2, fm.CurrentFocus);
+    }
+
+    [Fact]
+    public void CycleFocus_EmptyList_DoesNothing()
+    {
+        using var fm = new FocusManager();
+        var focusables = new List<IFocusable>();
+
+        // Should not throw
+        fm.CycleFocus(focusables);
+
+        Assert.Null(fm.CurrentFocus);
+    }
+
+    [Fact]
+    public void ReactiveProperty_DistinctUntilChanged_DoesNotEmitDuplicates()
+    {
+        using var fm = new FocusManager();
+        var f1 = new TestFocusableNode();
+        var emissions = new List<IFocusable?>();
+
+        fm.FocusChanged.Subscribe(f => emissions.Add(f));
+
+        // Initial null emission from ReactiveProperty on subscribe
+        Assert.Single(emissions);
+
+        fm.PushFocus(f1);
+        Assert.Equal(2, emissions.Count);
+
+        // ClearFocus sets to null (same as initial), but null → f1 → null should still emit
+        fm.ClearFocus();
+        Assert.Equal(3, emissions.Count);
+    }
+
+    /// <summary>
+    /// Test focusable that extends LayoutNode so GetChildNodes() tree walk works.
+    /// </summary>
+    private class TestFocusableNode : LayoutNode, IFocusable
+    {
+        public bool CanFocusValue { get; set; } = true;
+        public bool HasFocus { get; private set; }
+        public bool CanFocus => CanFocusValue;
+        public int FocusPriority => 10;
+
+        public void OnFocused() => HasFocus = true;
+        public void OnBlurred() => HasFocus = false;
+        public bool HandleInput(ConsoleKeyInfo key) => false;
+
+        public override Size Measure(Size available) => new(10, 1);
+        public override void Render(IRenderContext context, Rect bounds) { }
+    }
+}

--- a/tests/Termina.Tests/Layout/DynamicLayoutNodeTests.cs
+++ b/tests/Termina.Tests/Layout/DynamicLayoutNodeTests.cs
@@ -1,0 +1,283 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Extensions;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for the DynamicLayoutNode class.
+/// </summary>
+public class DynamicLayoutNodeTests
+{
+    [Fact]
+    public void DynamicLayoutNode_Measure_EvaluatesFactory()
+    {
+        var child = new TextNode("Hello");
+        var node = new DynamicLayoutNode(() => child);
+
+        var size = node.Measure(new Size(80, 24));
+
+        Assert.True(size.Width > 0);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_Render_EvaluatesFactory()
+    {
+        var renderCalled = false;
+        var child = new SpyRenderNode(() => renderCalled = true);
+        var node = new DynamicLayoutNode(() => child);
+
+        var context = new NullRenderContext();
+        node.Render(context, new Rect(0, 0, 80, 24));
+
+        Assert.True(renderCalled);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_SameInstance_NoLifecycleChurn()
+    {
+        var child = new SpyLifecycleNode();
+        var node = new DynamicLayoutNode(() => child);
+        node.OnActivate();
+
+        // Measure twice — same instance returned, should not deactivate/reactivate
+        node.Measure(new Size(80, 24));
+        var activateCount = child.ActivateCount;
+        var deactivateCount = child.DeactivateCount;
+
+        node.Measure(new Size(80, 24));
+
+        Assert.Equal(activateCount, child.ActivateCount);
+        Assert.Equal(deactivateCount, child.DeactivateCount);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_ChildChange_DeactivatesOldActivatesNew()
+    {
+        var childA = new SpyLifecycleNode();
+        var childB = new SpyLifecycleNode();
+        ILayoutNode current = childA;
+
+        var node = new DynamicLayoutNode(() => current);
+        node.OnActivate();
+
+        // First evaluation activates childA
+        node.Measure(new Size(80, 24));
+        Assert.Equal(1, childA.ActivateCount);
+
+        // Switch to childB
+        current = childB;
+        node.Measure(new Size(80, 24));
+
+        Assert.Equal(1, childA.DeactivateCount);
+        Assert.Equal(1, childB.ActivateCount);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_Invalidate_FiresInvalidatedObservable()
+    {
+        var node = new DynamicLayoutNode(() => new EmptyNode());
+        var invalidationCount = 0;
+
+        node.Invalidated.Subscribe(_ => invalidationCount++);
+        node.Invalidate();
+
+        Assert.Equal(1, invalidationCount);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_ChildInvalidation_PropagatesUpward()
+    {
+        var childSubject = new Subject<Unit>();
+        var child = new SpyInvalidatingNode(childSubject);
+        var node = new DynamicLayoutNode(() => child);
+        node.OnActivate();
+
+        var parentInvalidations = 0;
+        node.Invalidated.Subscribe(_ => parentInvalidations++);
+
+        // Evaluate factory so child gets subscribed
+        node.Measure(new Size(80, 24));
+
+        childSubject.OnNext(Unit.Default);
+
+        Assert.Equal(1, parentInvalidations);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_FluentSizing_Works()
+    {
+        var node = new DynamicLayoutNode(() => new EmptyNode());
+
+        var result = node.Width(40).Height(10);
+
+        Assert.IsType<SizeConstraint.Fixed>(result.WidthConstraint);
+        Assert.IsType<SizeConstraint.Fixed>(result.HeightConstraint);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_OnActivate_ActivatesCurrentChild()
+    {
+        var child = new SpyLifecycleNode();
+        var node = new DynamicLayoutNode(() => child);
+
+        // Evaluate so child is set
+        node.Measure(new Size(80, 24));
+        Assert.Equal(0, child.ActivateCount); // Not active yet
+
+        node.OnActivate();
+
+        Assert.Equal(1, child.ActivateCount);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_OnDeactivate_DeactivatesCurrentChild()
+    {
+        var child = new SpyLifecycleNode();
+        var node = new DynamicLayoutNode(() => child);
+
+        node.Measure(new Size(80, 24));
+        node.OnActivate();
+        node.OnDeactivate();
+
+        Assert.Equal(1, child.DeactivateCount);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_Dispose_DisposesCurrentChild()
+    {
+        var child = new SpyLifecycleNode();
+        var node = new DynamicLayoutNode(() => child);
+
+        node.Measure(new Size(80, 24));
+        node.Dispose();
+
+        Assert.True(child.WasDisposed);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_GetChildNodes_ReturnsCurrentChild()
+    {
+        var child = new TextNode("test");
+        var node = new DynamicLayoutNode(() => child);
+
+        // Evaluate factory
+        node.Measure(new Size(80, 24));
+
+        var children = node.GetChildNodes().ToList();
+        Assert.Single(children);
+        Assert.Same(child, children[0]);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_BeforeActivation_DoesNotActivateChildOnChange()
+    {
+        var childA = new SpyLifecycleNode();
+        var childB = new SpyLifecycleNode();
+        ILayoutNode current = childA;
+
+        var node = new DynamicLayoutNode(() => current);
+
+        // Evaluate to set childA
+        node.Measure(new Size(80, 24));
+
+        // Switch to childB while NOT active
+        current = childB;
+        node.Measure(new Size(80, 24));
+
+        Assert.Equal(0, childB.ActivateCount);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_AsDynamicLayout_Extension_Works()
+    {
+        var trigger = new Subject<Unit>();
+        var child = new TextNode("test");
+        Func<ILayoutNode> factory = () => child;
+
+        var node = factory.AsDynamicLayout(trigger);
+        var invalidationCount = 0;
+        node.Invalidated.Subscribe(_ => invalidationCount++);
+
+        trigger.OnNext(Unit.Default);
+
+        Assert.Equal(1, invalidationCount);
+    }
+
+    #region Test helpers
+
+    private class SpyLifecycleNode : LayoutNode
+    {
+        public int ActivateCount { get; private set; }
+        public int DeactivateCount { get; private set; }
+        public bool WasDisposed { get; private set; }
+
+        public override void OnActivate()
+        {
+            ActivateCount++;
+            base.OnActivate();
+        }
+
+        public override void OnDeactivate()
+        {
+            DeactivateCount++;
+            base.OnDeactivate();
+        }
+
+        public override void Dispose()
+        {
+            WasDisposed = true;
+            base.Dispose();
+        }
+
+        public override Size Measure(Size available) => new(10, 1);
+        public override void Render(IRenderContext context, Rect bounds) { }
+    }
+
+    private class SpyRenderNode : LayoutNode
+    {
+        private readonly Action _onRender;
+
+        public SpyRenderNode(Action onRender) => _onRender = onRender;
+
+        public override Size Measure(Size available) => new(10, 1);
+
+        public override void Render(IRenderContext context, Rect bounds) => _onRender();
+    }
+
+    private class SpyInvalidatingNode : LayoutNode, IInvalidatingNode
+    {
+        public Observable<Unit> Invalidated { get; }
+
+        public SpyInvalidatingNode(Observable<Unit> invalidated)
+        {
+            Invalidated = invalidated;
+        }
+
+        public override Size Measure(Size available) => new(10, 1);
+        public override void Render(IRenderContext context, Rect bounds) { }
+    }
+
+    private class NullRenderContext : IRenderContext
+    {
+        public int Width => 80;
+        public int Height => 24;
+        public void WriteAt(int x, int y, string text) { }
+        public void WriteAt(int x, int y, char c) { }
+        public void SetForeground(Color color) { }
+        public void SetBackground(Color color) { }
+        public void ResetColors() { }
+        public void SetDecoration(TextDecoration decoration) { }
+        public void ApplyStyle(TextStyle style) { }
+        public void Fill(int x, int y, int width, int height, char c = ' ') { }
+        public void Clear() { }
+        public IRenderContext CreateSubContext(Rect bounds) => this;
+    }
+
+    #endregion
+}

--- a/tests/Termina.Tests/Layout/WizardNodeTests.cs
+++ b/tests/Termina.Tests/Layout/WizardNodeTests.cs
@@ -1,0 +1,415 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+public enum TestWizardStep
+{
+    Provider,
+    Auth,
+    Confirm
+}
+
+/// <summary>
+/// Tests for the WizardNode class.
+/// </summary>
+public class WizardNodeTests
+{
+    private static WizardNode<TestWizardStep> CreateThreeStepWizard()
+    {
+        return Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider", () => new TextNode("Select provider"))
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("Enter credentials"))
+            .WithStep(TestWizardStep.Confirm, "Confirm", () => new TextNode("Review settings"));
+    }
+
+    [Fact]
+    public void InitialState_IsFirstStep()
+    {
+        var wizard = CreateThreeStepWizard();
+
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+        Assert.Equal(0, wizard.CurrentSubStep);
+        Assert.Equal(3, wizard.StepCount);
+    }
+
+    [Fact]
+    public void TryAdvance_MovesToNextStep()
+    {
+        var wizard = CreateThreeStepWizard();
+
+        var result = wizard.TryAdvance();
+
+        Assert.True(result);
+        Assert.Equal(TestWizardStep.Auth, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void TryAdvance_OnLastStep_FiresCompleted()
+    {
+        var wizard = CreateThreeStepWizard();
+        var completedFired = false;
+        wizard.Completed.Subscribe(_ => completedFired = true);
+
+        wizard.TryAdvance(); // Provider -> Auth
+        wizard.TryAdvance(); // Auth -> Confirm
+        wizard.TryAdvance(); // Confirm -> completed
+
+        Assert.True(completedFired);
+    }
+
+    [Fact]
+    public void TryGoBack_MovesToPreviousStep()
+    {
+        var wizard = CreateThreeStepWizard();
+        wizard.TryAdvance(); // Provider -> Auth
+
+        var result = wizard.TryGoBack();
+
+        Assert.True(result);
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void TryGoBack_OnFirstStep_ReturnsFalse()
+    {
+        var wizard = CreateThreeStepWizard();
+
+        var result = wizard.TryGoBack();
+
+        Assert.False(result);
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void BeforeAdvance_CanCancel()
+    {
+        var wizard = CreateThreeStepWizard();
+        wizard.BeforeAdvance.Subscribe(args => args.Cancel = true);
+
+        var result = wizard.TryAdvance();
+
+        Assert.False(result);
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void StepChanged_EmitsOnNavigation()
+    {
+        var wizard = CreateThreeStepWizard();
+        var emissions = new List<TestWizardStep>();
+        wizard.StepChanged.Subscribe(s => emissions.Add(s));
+
+        wizard.TryAdvance(); // Provider -> Auth
+        wizard.TryAdvance(); // Auth -> Confirm
+
+        Assert.Equal(2, emissions.Count);
+        Assert.Equal(TestWizardStep.Auth, emissions[0]);
+        Assert.Equal(TestWizardStep.Confirm, emissions[1]);
+    }
+
+    [Fact]
+    public void GoToStep_JumpsDirectly()
+    {
+        var wizard = CreateThreeStepWizard();
+
+        var result = wizard.GoToStep(TestWizardStep.Confirm);
+
+        Assert.True(result);
+        Assert.Equal(TestWizardStep.Confirm, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void GoToStep_SameStep_ReturnsFalse()
+    {
+        var wizard = CreateThreeStepWizard();
+
+        var result = wizard.GoToStep(TestWizardStep.Provider);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void SubStep_Advance_WithinStep()
+    {
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider", () => new TextNode("P"), subSteps: 3)
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("A"));
+
+        Assert.Equal(0, wizard.CurrentSubStep);
+
+        wizard.AdvanceSubStep();
+        Assert.Equal(1, wizard.CurrentSubStep);
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+
+        wizard.AdvanceSubStep();
+        Assert.Equal(2, wizard.CurrentSubStep);
+
+        // Can't advance past sub-step count
+        Assert.False(wizard.AdvanceSubStep());
+        Assert.Equal(2, wizard.CurrentSubStep);
+    }
+
+    [Fact]
+    public void TryAdvance_WithSubSteps_AdvancesSubStepFirst()
+    {
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider", () => new TextNode("P"), subSteps: 2)
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("A"));
+
+        // First advance goes to sub-step 1
+        wizard.TryAdvance();
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+        Assert.Equal(1, wizard.CurrentSubStep);
+
+        // Second advance goes to next step
+        wizard.TryAdvance();
+        Assert.Equal(TestWizardStep.Auth, wizard.CurrentStep);
+        Assert.Equal(0, wizard.CurrentSubStep);
+    }
+
+    [Fact]
+    public void TryGoBack_WithSubSteps_GoesBackSubStepFirst()
+    {
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider", () => new TextNode("P"), subSteps: 2)
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("A"));
+
+        wizard.TryAdvance(); // sub-step 0 -> 1
+        wizard.TryAdvance(); // Provider -> Auth
+
+        wizard.TryGoBack(); // Auth -> Provider (sub-step 1, last sub-step of prev)
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+        Assert.Equal(1, wizard.CurrentSubStep);
+
+        wizard.TryGoBack(); // sub-step 1 -> 0
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+        Assert.Equal(0, wizard.CurrentSubStep);
+    }
+
+    [Fact]
+    public void HandleInput_Enter_Advances()
+    {
+        var wizard = CreateThreeStepWizard();
+        var key = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+
+        wizard.HandleInput(key);
+
+        Assert.Equal(TestWizardStep.Auth, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void HandleInput_Escape_GoesBack()
+    {
+        var wizard = CreateThreeStepWizard();
+        wizard.TryAdvance();
+        var key = new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false);
+
+        wizard.HandleInput(key);
+
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void IFocusable_CanFocus_IsTrue()
+    {
+        var wizard = CreateThreeStepWizard();
+
+        Assert.True(wizard.CanFocus);
+    }
+
+    [Fact]
+    public void IFocusable_OnFocused_SetsHasFocus()
+    {
+        var wizard = CreateThreeStepWizard();
+
+        wizard.OnFocused();
+
+        Assert.True(wizard.HasFocus);
+    }
+
+    [Fact]
+    public void IFocusable_OnBlurred_ClearsHasFocus()
+    {
+        var wizard = CreateThreeStepWizard();
+        wizard.OnFocused();
+
+        wizard.OnBlurred();
+
+        Assert.False(wizard.HasFocus);
+    }
+
+    [Fact]
+    public void Invalidated_EmitsOnNavigation()
+    {
+        var wizard = CreateThreeStepWizard();
+        var count = 0;
+        wizard.Invalidated.Subscribe(_ => count++);
+
+        wizard.TryAdvance();
+
+        Assert.True(count > 0);
+    }
+
+    [Fact]
+    public void ProgressStyle_BlockBar_Renders()
+    {
+        var wizard = CreateThreeStepWizard()
+            .WithProgressStyle(WizardProgressStyle.BlockBar);
+
+        var context = new NullRenderContext();
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+        // Should not throw
+    }
+
+    [Fact]
+    public void ProgressStyle_Arrow_Renders()
+    {
+        var wizard = CreateThreeStepWizard()
+            .WithProgressStyle(WizardProgressStyle.Arrow);
+
+        var context = new NullRenderContext();
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+    }
+
+    [Fact]
+    public void ProgressStyle_Dots_Renders()
+    {
+        var wizard = CreateThreeStepWizard()
+            .WithProgressStyle(WizardProgressStyle.Dots);
+
+        var context = new NullRenderContext();
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+    }
+
+    [Fact]
+    public void ProgressStyle_None_Renders()
+    {
+        var wizard = CreateThreeStepWizard()
+            .WithProgressStyle(WizardProgressStyle.None);
+
+        var context = new NullRenderContext();
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+    }
+
+    [Fact]
+    public void WithBorder_Renders()
+    {
+        var wizard = CreateThreeStepWizard()
+            .WithBorder(BorderStyle.Single);
+
+        var context = new NullRenderContext();
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+    }
+
+    [Fact]
+    public void WithTitle_Renders()
+    {
+        var wizard = CreateThreeStepWizard()
+            .WithTitle("Setup Wizard");
+
+        var context = new NullRenderContext();
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+    }
+
+    [Fact]
+    public void WithHelpText_Renders()
+    {
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider", () => new TextNode("Select"), helpText: "Press Enter to continue");
+
+        var context = new NullRenderContext();
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+    }
+
+    [Fact]
+    public void Dispose_CleansUpSubjects()
+    {
+        var wizard = CreateThreeStepWizard();
+        var stepChangedCompleted = false;
+        var completedCompleted = false;
+
+        wizard.StepChanged.Subscribe(
+            _ => { },
+            _ => stepChangedCompleted = true);
+        wizard.Completed.Subscribe(
+            _ => { },
+            _ => completedCompleted = true);
+
+        wizard.Dispose();
+
+        Assert.True(stepChangedCompleted);
+        Assert.True(completedCompleted);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_Integration_ContentChangesOnStep()
+    {
+        var wizard = CreateThreeStepWizard();
+        var context = new NullRenderContext();
+        wizard.OnActivate();
+
+        // Render first step
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+
+        // Advance and render second step
+        wizard.TryAdvance();
+        wizard.Render(context, new Rect(0, 0, 80, 24));
+
+        // Should not throw — DynamicLayoutNode handles child switching
+        Assert.Equal(TestWizardStep.Auth, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void EmptyWizard_TryAdvance_ReturnsFalse()
+    {
+        var wizard = Layouts.Wizard<TestWizardStep>();
+
+        Assert.False(wizard.TryAdvance());
+        Assert.False(wizard.TryGoBack());
+    }
+
+    [Fact]
+    public void FluentBuilder_ReturnsSameInstance()
+    {
+        var wizard = Layouts.Wizard<TestWizardStep>();
+
+        var result = wizard
+            .WithStep(TestWizardStep.Provider, "P", () => new EmptyNode())
+            .WithProgressStyle(WizardProgressStyle.Arrow)
+            .WithTitle("Test")
+            .WithBorder(BorderStyle.Rounded);
+
+        Assert.Same(wizard, result);
+    }
+
+    [Fact]
+    public void FactoryMethod_CreatesInstance()
+    {
+        var wizard = Layouts.Wizard<TestWizardStep>();
+
+        Assert.NotNull(wizard);
+        Assert.Equal(0, wizard.StepCount);
+    }
+
+    private class NullRenderContext : IRenderContext
+    {
+        public int Width => 80;
+        public int Height => 24;
+        public void WriteAt(int x, int y, string text) { }
+        public void WriteAt(int x, int y, char c) { }
+        public void SetForeground(Color color) { }
+        public void SetBackground(Color color) { }
+        public void ResetColors() { }
+        public void SetDecoration(TextDecoration decoration) { }
+        public void ApplyStyle(TextStyle style) { }
+        public void Fill(int x, int y, int width, int height, char c = ' ') { }
+        public void Clear() { }
+        public IRenderContext CreateSubContext(Rect bounds) => this;
+    }
+}

--- a/tests/Termina.Tests/Layout/WizardNodeTests.cs
+++ b/tests/Termina.Tests/Layout/WizardNodeTests.cs
@@ -216,6 +216,69 @@ public class WizardNodeTests
     }
 
     [Fact]
+    public void HandleInput_DelegatesToNestedFocusable()
+    {
+        // Arrange: wizard step content has a focusable node nested inside a vertical layout
+        var handled = false;
+        var focusable = new TestFocusableNode(key =>
+        {
+            if (key.Key == ConsoleKey.DownArrow)
+            {
+                handled = true;
+                return true;
+            }
+            return false;
+        });
+
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider",
+                () => Layouts.Vertical(
+                    new TextNode("Header"),
+                    focusable // nested inside a container
+                ))
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("Auth"));
+
+        // Force DynamicLayoutNode to evaluate its factory by rendering
+        var ctx = new NullRenderContext();
+        wizard.Render(ctx, new Rect(0, 0, 80, 24));
+
+        var key = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+
+        // Act
+        var result = wizard.HandleInput(key);
+
+        // Assert: the nested focusable handled the input, not the wizard
+        Assert.True(result);
+        Assert.True(handled);
+        // Wizard did NOT advance (DownArrow is not Enter)
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+    }
+
+    [Fact]
+    public void HandleInput_FallsThroughToWizard_WhenChildDoesNotHandle()
+    {
+        // Arrange: focusable child doesn't handle Enter
+        var focusable = new TestFocusableNode(_ => false);
+
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider",
+                () => Layouts.Vertical(new TextNode("Header"), focusable))
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("Auth"));
+
+        // Force DynamicLayoutNode to evaluate its factory by rendering
+        var ctx = new NullRenderContext();
+        wizard.Render(ctx, new Rect(0, 0, 80, 24));
+
+        var key = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+
+        // Act
+        wizard.HandleInput(key);
+
+        // Assert: wizard advanced because child didn't consume Enter
+        Assert.Equal(TestWizardStep.Auth, wizard.CurrentStep);
+    }
+
+    [Fact]
     public void IFocusable_CanFocus_IsTrue()
     {
         var wizard = CreateThreeStepWizard();
@@ -395,6 +458,29 @@ public class WizardNodeTests
 
         Assert.NotNull(wizard);
         Assert.Equal(0, wizard.StepCount);
+    }
+
+    /// <summary>
+    /// Test IFocusable that extends LayoutNode so it's discoverable by tree walk.
+    /// </summary>
+    private class TestFocusableNode : LayoutNode, IFocusable
+    {
+        private readonly Func<ConsoleKeyInfo, bool> _handleInput;
+
+        public TestFocusableNode(Func<ConsoleKeyInfo, bool> handleInput)
+        {
+            _handleInput = handleInput;
+        }
+
+        public bool CanFocus => true;
+        public bool HasFocus { get; private set; }
+        public int FocusPriority => 0;
+        public void OnFocused() => HasFocus = true;
+        public void OnBlurred() => HasFocus = false;
+        public bool HandleInput(ConsoleKeyInfo key) => _handleInput(key);
+
+        public override Size Measure(Size available) => new(available.Width, 1);
+        public override void Render(IRenderContext context, Rect bounds) { }
     }
 
     private class NullRenderContext : IRenderContext

--- a/tests/Termina.Tests/Layout/WizardNodeTests.cs
+++ b/tests/Termina.Tests/Layout/WizardNodeTests.cs
@@ -460,6 +460,92 @@ public class WizardNodeTests
         Assert.Equal(0, wizard.StepCount);
     }
 
+    [Fact]
+    public void HandleInput_WithRealSelectionList_ArrowKeysWork()
+    {
+        // Arrange: wizard with an actual SelectionListNode — matches the demo exactly
+        var selectionConfirmed = new List<string>();
+        SelectionListNode<string>? capturedList = null;
+
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider", () =>
+            {
+                // Only create the list once (mirroring the cache behavior)
+                capturedList ??= Layouts.SelectionList("AWS", "Azure", "GCP")
+                    .WithMode(SelectionMode.Single)
+                    .WithShowNumbers(true)
+                    .WithHighlightColors(Color.Black, Color.Cyan);
+
+                capturedList.SelectionConfirmed.Subscribe(items =>
+                {
+                    selectionConfirmed.AddRange(items);
+                });
+
+                return Layouts.Vertical(
+                    new TextNode("Choose provider:"),
+                    capturedList
+                );
+            })
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("Auth step"));
+
+        // First render to initialize DynamicLayoutNode content
+        var ctx = new NullRenderContext();
+        wizard.Render(ctx, new Rect(0, 0, 80, 24));
+
+        // Act: Press DownArrow to move highlight from AWS (0) to Azure (1)
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        var downResult = wizard.HandleInput(downKey);
+
+        // Assert: DownArrow was handled
+        Assert.True(downResult);
+        // Wizard should still be on Provider step (didn't advance)
+        Assert.Equal(TestWizardStep.Provider, wizard.CurrentStep);
+
+        // Act: Press Enter to confirm selection
+        var enterKey = new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false);
+        var enterResult = wizard.HandleInput(enterKey);
+
+        // Assert: Enter was handled by SelectionListNode
+        Assert.True(enterResult);
+        // The SelectionConfirmed should have fired with "Azure"
+        Assert.Contains("Azure", selectionConfirmed);
+    }
+
+    [Fact]
+    public void HandleInput_WithRealSelectionList_SubscriptionAdvancesWizard()
+    {
+        // Arrange: wizard where the subscription calls TryAdvance (like the demo)
+        SelectionListNode<string>? capturedList = null;
+        WizardNode<TestWizardStep>? wizard = null;
+
+        wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider", () =>
+            {
+                capturedList ??= Layouts.SelectionList("AWS", "Azure", "GCP")
+                    .WithMode(SelectionMode.Single);
+
+                capturedList.SelectionConfirmed.Subscribe(items =>
+                {
+                    if (items.Count > 0)
+                        wizard!.TryAdvance();
+                });
+
+                return Layouts.Vertical(new TextNode("Choose:"), capturedList);
+            })
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("Auth"));
+
+        // Render to initialize
+        var ctx = new NullRenderContext();
+        wizard.Render(ctx, new Rect(0, 0, 80, 24));
+
+        // DownArrow then Enter
+        wizard.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false));
+        wizard.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        // Assert: wizard advanced to Auth step via the subscription
+        Assert.Equal(TestWizardStep.Auth, wizard.CurrentStep);
+    }
+
     /// <summary>
     /// Test IFocusable that extends LayoutNode so it's discoverable by tree walk.
     /// </summary>


### PR DESCRIPTION
## Summary

Implements three interconnected features for Termina 0.7.0:

- **DynamicLayoutNode** (#147): A `LayoutNode` that re-evaluates a `Func<ILayoutNode>` factory each render cycle, with reference-equality child change detection and proper lifecycle management. Includes `Layouts.Dynamic()` factory and `AsDynamicLayout()` extension.
- **FocusManager auto-focus** (#146): Migrates `BehaviorSubject<IFocusable?>` to `ReactiveProperty<IFocusable?>`, adds `CollectFocusables()` tree walk, `CycleFocus()` for Tab cycling, `FocusPolicy` enum for auto-focus on navigation, and convenience helpers in `ReactivePage`.
- **WizardNode** (#148): Multi-step wizard component (`WizardNode<TStep>`) with progress bar rendering (BlockBar/Arrow/Dots/None), step content via `DynamicLayoutNode`, fluent builder API, cancellable `BeforeAdvance` validation, and focus propagation to child focusable content.

Also includes:
- Cleanup of dead `HasReactiveAttribute` code in `LayoutNodeInViewModelAnalyzer`
- Full demo app (`Termina.Demo.Wizard`) with 3-step cloud setup wizard
- Documentation: dynamic layouts, focus management, and wizard tutorial
- Release notes update for 0.7.0

## Test plan

- [x] 886 tests pass (283 DynamicLayoutNode + 242 FocusManager auto-focus + 587 WizardNode + existing)
- [x] Wizard demo runs in test mode (scripted input: DownArrow → Enter → type "admin" → Enter → Enter → Q)
- [x] DiffingTerminal produces visual changes after arrow key input (verified via trace log: 191 bytes after DownArrow)
- [x] Focus propagation: WizardNode calls OnFocused on child SelectionListNode so highlights render
- [x] Step transitions propagate focus to new step's first focusable child
- [x] Existing FocusManager tests pass after BehaviorSubject → ReactiveProperty migration