### PR TITLE
Prepare Termina 0.7.0 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,27 +11,63 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <VersionPrefix>0.7.0</VersionPrefix>
-    <PackageReleaseNotes>**New Features**:
-- **Built-in input history for TextInputNode** ([#144](https://github.com/Aaronontheweb/Termina/pull/144))
-  - New `WithHistory(maxEntries)` fluent API for enabling input history
-  - New `AddHistory(text)` method for programmatically adding history entries
-  - Up/Down arrow keys navigate through previous input submissions
-  - Enter key automatically records non-empty text for future recall
-  - Off by default for full backward compatibility
-  - Move history logic from `StreamingChatViewModel` into `TextInputNode` for better reusability
-  - Simplified `StreamingChatPage` by removing manual history wiring
-  - Includes 17 new comprehensive tests covering navigation, eviction, and restoration
-  - Updated text-input-node.md documentation
+    <PackageReleaseNotes>**Breaking Changes**:
+- **Migrate from System.Reactive to R3** ([#140](https://github.com/Aaronontheweb/Termina/pull/140))
+  - Replaced System.Reactive (Rx.NET) with [R3](https://github.com/Cysharp/R3) throughout the framework
+  - `IObservable&lt;T&gt;` → `Observable&lt;T&gt;` in all public APIs
+  - `OfType&lt;T&gt;()` → `OfType&lt;TSrc, TDest&gt;()` (R3 requires both type parameters)
+  - `Select(...)` may require explicit type parameters: `Select&lt;TIn, TOut&gt;(...)`
+  - `Subscribe` callbacks: `onError` → `onErrorResume`, `onCompleted` takes `Result` parameter
+  - `BehaviorSubject&lt;T&gt;` removed — use `ReactiveProperty&lt;T&gt;` instead
+  - `Subject&lt;T&gt;` now from R3 namespace
+  - See [Migration Guide](https://aaronstannard.com/termina/guide/migration-0.7.html) for details
 
-- **Auto-route PasteEvent to focused IPasteReceiver via layout tree walk** ([#143](https://github.com/Aaronontheweb/Termina/pull/143))
-  - Automatic paste event routing when no focused `IPasteReceiver` exists
-  - New `GetChildNodes()` virtual method on `LayoutNode` for tree traversal
-  - Implemented in `ContainerNode`, `PanelNode`, `ModalNode`, `ScrollableContainerNode`, `ReactiveLayoutNode`, and `ConditionalNode`
-  - Eliminates manual paste subscription boilerplate from pages
-  - Paste routing order: focused receiver &gt; tree walk &gt; ViewModel.Input
-  - Multi-line paste content in history recall shows as summary (e.g., `[Pasted 3 lines, 20 chars]`)
-  - `TextInputNode.Text` setter automatically condenses multi-line content into paste-display mode
-  - Includes comprehensive routing tests covering all scenarios
+- **Replace `[Reactive]` source generator with `ReactiveProperty&lt;T&gt;`** ([#149](https://github.com/Aaronontheweb/Termina/pull/149))
+  - Removed `[Reactive]` attribute and its source generator
+  - Use `ReactiveProperty&lt;T&gt;` for all ViewModel state: `public ReactiveProperty&lt;int&gt; Count { get; } = new(0);`
+  - Property access via `.Value`: `Count.Value++` instead of `Count++`
+  - Page bindings subscribe directly to property: `ViewModel.Count.Select(...)` instead of `ViewModel.CountChanged.Select(...)`
+  - ViewModels no longer need `partial` keyword (unless using `[FromRoute]`)
+  - Manual `Dispose()` override required to dispose all `ReactiveProperty&lt;T&gt;` instances
+  - Built-in `DistinctUntilChanged` — only emits when value actually changes
+
+- **Replace timers with `Observable.Interval` + `TimeProvider`** ([#140](https://github.com/Aaronontheweb/Termina/pull/140))
+  - All timer-based components now accept optional `TimeProvider` parameter
+  - Enables deterministic testing with `FakeTimeProvider`
+  - `System.Timers.Timer` and `System.Threading.Timer` no longer used
+
+**New Features**:
+- **DynamicLayoutNode** ([#147](https://github.com/Aaronontheweb/Termina/issues/147))
+  - New `Layouts.Dynamic(Func&lt;ILayoutNode&gt; factory)` for imperative, page-local state
+  - Re-evaluates factory on each Render/Measure cycle with reference equality to avoid lifecycle churn
+  - `Invalidate()` method for programmatic trigger; `AsDynamicLayout(Observable&lt;Unit&gt;)` extension
+  - Implements `IInvalidatingNode` for proper invalidation propagation
+
+- **FocusManager auto-focus and Tab cycling** ([#146](https://github.com/Aaronontheweb/Termina/issues/146))
+  - `FocusPolicy` enum: `Manual`, `FirstFocusable`, `ByPriority` — set on `ReactivePage` for automatic focus on navigation
+  - `CollectFocusables(ILayoutNode root)` — depth-first tree walk collecting focusable nodes
+  - `CycleFocus(focusables, reverse)` — next/previous with wrap-around
+  - `CycleFocusForward()` / `CycleFocusBackward()` helpers on `ReactivePage`
+  - `FocusManager` migrated from `BehaviorSubject&lt;IFocusable?&gt;` to `ReactiveProperty&lt;IFocusable?&gt;`
+
+- **WizardNode** ([#148](https://github.com/Aaronontheweb/Termina/issues/148))
+  - Multi-step wizard component: `Layouts.Wizard&lt;TStep&gt;()` where `TStep : struct, Enum`
+  - Fluent builder: `.WithStep()`, `.WithProgressStyle()`, `.WithTitle()`, `.WithBorder()`
+  - Navigation: `TryAdvance()`, `TryGoBack()`, `GoToStep()`, `AdvanceSubStep()`
+  - Cancellable `BeforeAdvance` observable for step validation
+  - `StepChanged` and `Completed` observables
+  - Progress styles: `BlockBar`, `Arrow`, `Dots`, `None`
+  - Sub-step support within each step
+  - Implements `IFocusable` and `IInvalidatingNode`
+  - Uses `DynamicLayoutNode` internally for step content switching
+
+**Bug Fixes**:
+- **Fix invalidation subscription lost after navigation round-trip** ([#150](https://github.com/Aaronontheweb/Termina/pull/150))
+  - Fixed rendering bug where leaf nodes lost their invalidation subscriptions after navigating away and back
+  - Custom `LayoutNode` subclasses should use `CreateSubContext(bounds)` in Render methods
+
+**Cleanup**:
+- Removed dead `HasReactiveAttribute` helper from `LayoutNodeInViewModelAnalyzer` (references removed `[Reactive]` attribute)
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ dotnet add package Termina
 dotnet add package Microsoft.Extensions.Hosting
 ```
 
+> **Upgrading to 0.7.0?** This release migrates from System.Reactive to R3 with breaking API changes. See the [Migration Guide](https://aaronstannard.com/termina/guide/migration-0.7.html) for details.
+
 ## Quick Start
 
 ### 1. Define a ViewModel

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,7 +9,7 @@
   - `Subscribe` callbacks: `onError` → `onErrorResume`, `onCompleted` takes `Result` parameter
   - `BehaviorSubject<T>` removed — use `ReactiveProperty<T>` instead
   - `Subject<T>` now from R3 namespace
-  - See [Migration Guide](https://aaronontheweb.github.io/termina/guide/migration-0.7) for details
+  - See [Migration Guide](https://aaronstannard.com/termina/guide/migration-0.7.html) for details
 
 - **Replace `[Reactive]` source generator with `ReactiveProperty<T>`** ([#149](https://github.com/Aaronontheweb/Termina/pull/149))
   - Removed `[Reactive]` attribute and its source generator


### PR DESCRIPTION
## Summary
- Updated migration guide link in RELEASE_NOTES.md to canonical `aaronstannard.com` URL
- Added upgrade advisory callout to README for users upgrading to 0.7.0
- Synced `Directory.Build.props` PackageReleaseNotes with 0.7.0 content

## Changes
- **README.md**: Short callout box after Installation section linking to [Migration Guide](https://aaronstannard.com/termina/guide/migration-0.7.html)
- **RELEASE_NOTES.md**: Migration guide link updated from `aaronontheweb.github.io` to `aaronstannard.com`
- **Directory.Build.props**: PackageReleaseNotes updated from 0.6.1 to 0.7.0 content

## Test plan
- [x] Build succeeds (0 warnings, 0 errors)
- [ ] Verify NuGet package metadata renders correctly after merge