### PR TITLE
Fix invalidation-driven DynamicLayoutNode + WizardNode sub-step focus (#155, #156)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,26 @@
+#### 0.7.1 February 26th 2026 ####
+
+**Bug Fixes**:
+- **DynamicLayoutNode is now invalidation-driven** ([#155](https://github.com/Aaronontheweb/Termina/issues/155))
+  - Factory no longer runs on every Measure/Render cycle — runs once, then only on `Invalidate()`
+  - Fixes silent state destruction (highlights, typed text, focus) when factory creates new instances
+  - `Invalidate()` now eagerly evaluates the factory for immediate child swap
+  - `OnActivate()` marks the node dirty so factory re-evaluates after navigation round-trip
+
+- **WizardNode sub-step focus propagation** ([#156](https://github.com/Aaronontheweb/Termina/issues/156))
+  - `PropagateFocusToContent()` now called on sub-step changes, not just step changes
+  - Fixes stale focus when navigating between sub-steps with different focusable content
+
+**New Features**:
+- **KeyedDynamicLayoutNode&lt;TKey&gt;** — pit-of-success API for key-based content switching
+  - `Layouts.KeyedDynamic<TKey>(keySelector, contentFactory)` factory method
+  - Caches content by key — navigating back reuses cached instances, preserving child state
+  - WizardNode now uses this internally (replaces manual step content cache)
+
+**Upgrade Advisory**:
+- `DynamicLayoutNode` no longer evaluates its factory per-frame. If you relied on per-frame evaluation, add `Invalidate()` calls when state changes. The `AsDynamicLayout(trigger)` extension already calls `Invalidate()` on each trigger emission and works unchanged.
+- For content that switches based on a key (enum, step index, tab), prefer `Layouts.KeyedDynamic<TKey>()` over `Layouts.Dynamic()` for automatic caching and state preservation.
+
 #### 0.7.0 February 26th 2026 ####
 
 **Breaking Changes**:
@@ -28,7 +51,7 @@
 **New Features**:
 - **DynamicLayoutNode** ([#147](https://github.com/Aaronontheweb/Termina/issues/147))
   - New `Layouts.Dynamic(Func<ILayoutNode> factory)` for imperative, page-local state
-  - Re-evaluates factory on each Render/Measure cycle with reference equality to avoid lifecycle churn
+  - Evaluates factory once, then only on `Invalidate()` with reference equality to avoid lifecycle churn
   - `Invalidate()` method for programmatic trigger; `AsDynamicLayout(Observable<Unit>)` extension
   - Implements `IInvalidatingNode` for proper invalidation propagation
 
@@ -48,7 +71,7 @@
   - Progress styles: `BlockBar`, `Arrow`, `Dots`, `None`
   - Sub-step support within each step
   - Implements `IFocusable` and `IInvalidatingNode`
-  - Uses `DynamicLayoutNode` internally for step content switching
+  - Uses `KeyedDynamicLayoutNode<int>` internally for step content switching with automatic caching
 
 **Bug Fixes**:
 - **Fix invalidation subscription lost after navigation round-trip** ([#150](https://github.com/Aaronontheweb/Termina/pull/150))

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -32,6 +32,14 @@ Termina provides a set of built-in layout nodes (components) for building termin
 |-----------|-------------|
 | [ReactiveLayoutNode](/components/reactive-layout) | Updates content from observables |
 | [ConditionalNode](/components/conditional-node) | Show/hide based on condition |
+| [DynamicLayoutNode](/components/dynamic-layout) | Re-evaluates factory on invalidation |
+| [KeyedDynamicLayoutNode](/components/keyed-dynamic-layout) | Key-based content switching with caching |
+
+## Composite Components
+
+| Component | Description |
+|-----------|-------------|
+| [WizardNode](/components/wizard-node) | Multi-step wizard with progress, navigation, and focus |
 
 ## Utility Components
 

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -32,14 +32,14 @@ Termina provides a set of built-in layout nodes (components) for building termin
 |-----------|-------------|
 | [ReactiveLayoutNode](/components/reactive-layout) | Updates content from observables |
 | [ConditionalNode](/components/conditional-node) | Show/hide based on condition |
-| [DynamicLayoutNode](/components/dynamic-layout) | Re-evaluates factory on invalidation |
-| [KeyedDynamicLayoutNode](/components/keyed-dynamic-layout) | Key-based content switching with caching |
+| `DynamicLayoutNode` | Re-evaluates factory on invalidation |
+| `KeyedDynamicLayoutNode` | Key-based content switching with caching |
 
 ## Composite Components
 
 | Component | Description |
 |-----------|-------------|
-| [WizardNode](/components/wizard-node) | Multi-step wizard with progress, navigation, and focus |
+| `WizardNode` | Multi-step wizard with progress, navigation, and focus |
 
 ## Utility Components
 

--- a/docs/concepts/dynamic-layouts.md
+++ b/docs/concepts/dynamic-layouts.md
@@ -1,31 +1,60 @@
 # Dynamic Layouts
 
-`DynamicLayoutNode` re-evaluates a factory function on every render cycle, making it ideal for imperative, page-local state that doesn't need to live in a ViewModel as an observable.
+`DynamicLayoutNode` evaluates a factory function once on first render, then re-evaluates only when `Invalidate()` is called. For content that switches based on a key (enum, step index, tab), use `KeyedDynamicLayoutNode<TKey>` which caches content by key and preserves child state across key changes.
 
 ## When to Use
 
 | Scenario | Use |
 |----------|-----|
-| ViewModel state that is naturally observable | `ReactiveProperty<T>` + `.AsLayout()` |
-| Page-local state (switch/case, enum-driven UI) | `Layouts.Dynamic()` |
-| Observable trigger with imperative factory | `factory.AsDynamicLayout(trigger)` |
+| Content switches based on a key (enum, int, string) | `Layouts.KeyedDynamic<TKey>()` — caches by key, preserves state |
+| Observable-driven content updates | `ReactiveProperty<T>` + `.AsLayout()` or `factory.AsDynamicLayout(trigger)` |
+| Advanced: custom factory with manual caching | `Layouts.Dynamic()` — low-level, you manage caching |
 
 ## Basic Usage
+
+### KeyedDynamic (Recommended)
+
+The natural way to write content that switches based on a key. No manual caching needed — child state (highlights, typed text, focus) is preserved across key changes:
 
 ```csharp
 public override ILayoutNode BuildLayout()
 {
-    // Page-local state — no need for a ViewModel property
-    var currentTab = "home";
+    var currentTab = 0;
 
-    return Layouts.Dynamic(() => currentTab switch
-    {
-        "home" => new TextNode("Welcome home"),
-        "settings" => new TextNode("Settings panel"),
-        _ => new TextNode("Unknown tab")
-    });
+    var layout = Layouts.KeyedDynamic(
+        () => currentTab,
+        tab => tab switch
+        {
+            0 => new TextNode("Welcome home"),
+            1 => new TextNode("Settings panel"),
+            _ => new TextNode("Unknown tab")
+        });
+
+    // Change tab and invalidate:
+    currentTab = 1;
+    layout.Invalidate();
+
+    return layout;
 }
 ```
+
+### Dynamic (Low-Level)
+
+For cases where you need full control over the factory:
+
+```csharp
+var dynamicNode = Layouts.Dynamic(() => BuildCurrentContent());
+// ... later, when state changes:
+dynamicNode.Invalidate();
+```
+
+## Choosing the Right Dynamic Node
+
+| Need | Use |
+|------|-----|
+| Content switches based on a key (enum, int, string) | `Layouts.KeyedDynamic<TKey>()` — caches by key, preserves state |
+| Observable-driven content updates | `observable.AsLayout()` or `factory.AsDynamicLayout(trigger)` |
+| Advanced: custom factory with manual caching | `Layouts.Dynamic()` — low-level, you manage caching |
 
 ## With Invalidation Trigger
 
@@ -61,36 +90,40 @@ ViewModel.CurrentTab
     .AsLayout()
 ```
 
-**After** (one-liner with `Layouts.Dynamic`):
+**After** (one-liner with `Layouts.KeyedDynamic`):
 
 ```csharp
 // No ViewModel property needed — page-local state
 var tab = 0;
-var wizard = Layouts.Dynamic(() => tab switch
-{
-    0 => BuildHomeTab(),
-    1 => BuildSettingsTab(),
-    _ => new EmptyNode()
-});
-// Call wizard.Invalidate() when tab changes
+var layout = Layouts.KeyedDynamic(
+    () => tab,
+    t => t switch
+    {
+        0 => BuildHomeTab(),
+        1 => BuildSettingsTab(),
+        _ => new EmptyNode()
+    });
+// Call layout.Invalidate() when tab changes
 ```
 
 ## How It Works
 
-- The factory is called on each `Measure()` and `Render()` cycle
+- The factory is called once on first `Measure()`/`Render()`, then only when `Invalidate()` is called
+- `Invalidate()` eagerly evaluates the factory so the new child is immediately available for tree traversal (e.g., focus propagation)
 - **Reference equality** detects child changes — returning the same instance avoids lifecycle transitions
 - When the child changes: the old child is deactivated, the new child is activated (mirrors `ReactiveLayoutNode` behavior)
+- `KeyedDynamicLayoutNode<TKey>` additionally caches content by key — navigating back to a previous key reuses the cached instance
 - `GetChildNodes()` returns the current child for focus tree traversal
 - Extends `LayoutNode` so fluent sizing (`.Fill()`, `.Width()`, `.Height()`) works
 
 ## Fluent Sizing
 
 ```csharp
-Layouts.Dynamic(() => BuildContent())
+Layouts.KeyedDynamic(() => currentTab, tab => BuildTab(tab))
     .Fill()        // Fill remaining height
     .WidthFill()   // Fill available width
 ```
 
 ::: tip
-For page-level state that doesn't need to be in the ViewModel, `Layouts.Dynamic()` avoids the overhead of creating a `ReactiveProperty<T>` and observable pipeline. For state that _should_ be in the ViewModel, use [Reactive Properties](../concepts/reactive-properties.md) instead.
+For page-level state that doesn't need to be in the ViewModel, `Layouts.KeyedDynamic()` avoids the overhead of creating a `ReactiveProperty<T>` and observable pipeline. For state that _should_ be in the ViewModel, use [Reactive Properties](../concepts/reactive-properties.md) instead.
 :::

--- a/docs/concepts/focus-management.md
+++ b/docs/concepts/focus-management.md
@@ -115,7 +115,7 @@ Focus.PopFocus();
 
 ## Tree Walk
 
-`CollectFocusables` performs a depth-first walk of the layout tree, collecting all nodes that implement `IFocusable` where `CanFocus` is true. This traverses into `VerticalLayout`, `HorizontalLayout`, `ReactiveLayoutNode`, `DynamicLayoutNode`, and other container types.
+`CollectFocusables` performs a depth-first walk of the layout tree, collecting all nodes that implement `IFocusable` where `CanFocus` is true. This traverses into `VerticalLayout`, `HorizontalLayout`, `ReactiveLayoutNode`, `DynamicLayoutNode`, `KeyedDynamicLayoutNode`, and other container types.
 
 ```csharp
 var focusables = Focus.CollectFocusables(layoutRoot);

--- a/docs/tutorials/wizard-app.md
+++ b/docs/tutorials/wizard-app.md
@@ -1,6 +1,6 @@
 # Building a Setup Wizard
 
-This tutorial walks through building a 3-step setup wizard using `WizardNode<TStep>`, `DynamicLayoutNode`, `FocusPolicy.FirstFocusable`, and Tab cycling.
+This tutorial walks through building a 3-step setup wizard using `WizardNode<TStep>`, `FocusPolicy.FirstFocusable`, and Tab cycling. WizardNode uses `KeyedDynamicLayoutNode<int>` internally for automatic step content caching — each step's content factory is called once and the result is cached for reuse when navigating back.
 
 ## Define the Steps
 
@@ -120,7 +120,7 @@ public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
 ## Key Concepts Used
 
 1. **`WizardNode<SetupStep>`** manages step navigation, progress display, and completion
-2. **`DynamicLayoutNode`** (used internally by WizardNode) switches step content without observable pipelines
+2. **`KeyedDynamicLayoutNode<int>`** (used internally by WizardNode) caches step content by index — navigating back reuses cached instances, preserving child state
 3. **`FocusPolicy.FirstFocusable`** auto-focuses the first interactive control on each page visit
 4. **`BeforeAdvance`** can be subscribed to for step validation (set `args.Cancel = true` to prevent navigation)
 

--- a/src/Termina/Layout/KeyedDynamicLayoutNode.cs
+++ b/src/Termina/Layout/KeyedDynamicLayoutNode.cs
@@ -7,20 +7,25 @@ using Termina.Rendering;
 namespace Termina.Layout;
 
 /// <summary>
-/// A layout node that evaluates a factory function once, then re-evaluates only when
-/// <see cref="Invalidate"/> is called. Uses reference equality to detect child changes —
-/// same instance means no lifecycle churn.
+/// A dynamic layout node that caches content by key. When the key changes, looks up the cache
+/// first — only creates new content on cache miss. Navigating back to a previous key reuses the
+/// cached instance, preserving all child state (highlights, typed text, focus).
 /// </summary>
+/// <typeparam name="TKey">The type of key used to identify content variants.</typeparam>
 /// <remarks>
-/// For content that switches based on a key (enum, step index, tab), prefer
-/// <see cref="KeyedDynamicLayoutNode{TKey}"/> which provides automatic caching and state preservation.
+/// This is the preferred API for content that switches based on a key (enum, step index, tab).
+/// Use <see cref="Layouts.KeyedDynamic{TKey}"/> to create instances.
 /// </remarks>
-public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
+public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
+    where TKey : notnull
 {
-    private readonly Func<ILayoutNode> _factory;
+    private readonly Func<TKey> _keySelector;
+    private readonly Func<TKey, ILayoutNode> _contentFactory;
+    private readonly Dictionary<TKey, ILayoutNode> _cache = new();
     private readonly Subject<Unit> _invalidated = new();
     private IDisposable? _childInvalidationSubscription;
     private ILayoutNode _currentChild;
+    private TKey? _currentKey;
     private bool _isActive;
     private bool _needsEvaluation = true;
 
@@ -28,18 +33,20 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
     public Observable<Unit> Invalidated => _invalidated;
 
     /// <summary>
-    /// Create a dynamic layout node that evaluates a factory once, then only on <see cref="Invalidate"/>.
+    /// Create a keyed dynamic layout node.
     /// </summary>
-    /// <param name="factory">Factory function that returns the current child node.</param>
-    public DynamicLayoutNode(Func<ILayoutNode> factory)
+    /// <param name="keySelector">Function that returns the current key.</param>
+    /// <param name="contentFactory">Function that creates content for a given key (called once per key).</param>
+    public KeyedDynamicLayoutNode(Func<TKey> keySelector, Func<TKey, ILayoutNode> contentFactory)
     {
-        _factory = factory;
+        _keySelector = keySelector;
+        _contentFactory = contentFactory;
         _currentChild = new EmptyNode();
     }
 
     /// <summary>
-    /// Signal that the factory output may have changed.
-    /// Eagerly re-evaluates the factory so the new child is immediately available
+    /// Signal that the key may have changed.
+    /// Eagerly re-evaluates so the new child is immediately available
     /// for tree traversal (e.g., focus propagation).
     /// </summary>
     public void Invalidate()
@@ -50,7 +57,7 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
     }
 
     /// <summary>
-    /// Evaluate the factory and update the child if it changed (by reference).
+    /// Evaluate the key selector, look up or create content, and swap child if changed.
     /// No-op when clean (not invalidated).
     /// </summary>
     private void EvaluateFactory()
@@ -59,13 +66,22 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
             return;
 
         _needsEvaluation = false;
-        var newChild = _factory();
+        var key = _keySelector();
+
+        // Look up cache, create on miss
+        if (!_cache.TryGetValue(key, out var newChild))
+        {
+            newChild = _contentFactory(key);
+            _cache[key] = newChild;
+        }
+
+        _currentKey = key;
 
         // Same instance — no lifecycle churn needed
         if (ReferenceEquals(newChild, _currentChild))
             return;
 
-        // Deactivate old child (active/inactive pattern — don't dispose)
+        // Deactivate old child
         if (_isActive && _currentChild is LayoutNode oldLayoutNode)
         {
             oldLayoutNode.OnDeactivate();
@@ -157,7 +173,23 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
         _childInvalidationSubscription?.Dispose();
         _invalidated.OnCompleted();
         _invalidated.Dispose();
-        _currentChild.Dispose();
+
+        // Check if _currentChild is in the cache (it won't be if factory was never evaluated)
+        var currentChildInCache = _cache.Values.Any(c => ReferenceEquals(c, _currentChild));
+
+        // Dispose ALL cached children
+        foreach (var child in _cache.Values)
+        {
+            child.Dispose();
+        }
+        _cache.Clear();
+
+        // Dispose the initial EmptyNode if it was never replaced by a cached entry
+        if (!currentChildInCache)
+        {
+            _currentChild.Dispose();
+        }
+
         base.Dispose();
     }
 }

--- a/src/Termina/Layout/Layout.cs
+++ b/src/Termina/Layout/Layout.cs
@@ -82,14 +82,24 @@ public static class Layouts
     public static WizardNode<TStep> Wizard<TStep>() where TStep : struct, Enum => new();
 
     /// <summary>
-    /// Create a dynamic layout node that re-evaluates a factory on every render cycle.
+    /// Create a dynamic layout node that evaluates a factory once, then only on <see cref="DynamicLayoutNode.Invalidate"/>.
     /// </summary>
     /// <remarks>
-    /// Use this for imperative, page-local state (e.g., switch/case on an enum) where
-    /// the state doesn't need to live in a ViewModel as an observable.
-    /// The factory is called on each Measure/Render — use reference equality to avoid
-    /// unnecessary child lifecycle transitions.
+    /// For content that switches based on a key (enum, step index, tab), prefer
+    /// <see cref="KeyedDynamic{TKey}"/> which provides automatic caching and state preservation.
     /// </remarks>
     /// <param name="factory">Factory that returns the current child node.</param>
     public static DynamicLayoutNode Dynamic(Func<ILayoutNode> factory) => new(factory);
+
+    /// <summary>
+    /// Create a keyed dynamic layout node that caches content by key.
+    /// Navigating back to a previous key reuses the cached instance, preserving all child state.
+    /// </summary>
+    /// <typeparam name="TKey">The type of key used to identify content variants.</typeparam>
+    /// <param name="keySelector">Function that returns the current key.</param>
+    /// <param name="contentFactory">Function that creates content for a given key (called once per key).</param>
+    public static KeyedDynamicLayoutNode<TKey> KeyedDynamic<TKey>(
+        Func<TKey> keySelector,
+        Func<TKey, ILayoutNode> contentFactory)
+        where TKey : notnull => new(keySelector, contentFactory);
 }

--- a/src/Termina/Layout/WizardNode.cs
+++ b/src/Termina/Layout/WizardNode.cs
@@ -22,7 +22,6 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     private readonly Subject<Unit> _completed = new();
     private readonly Subject<Unit> _invalidated = new();
 
-    private readonly Dictionary<int, ILayoutNode> _stepContentCache = new();
     private int _currentStepIndex;
     private int _currentSubStep;
     private bool _hasFocus;
@@ -30,7 +29,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     private IFocusable? _focusedChild;
 
     // Internal layout
-    private DynamicLayoutNode? _contentNode;
+    private KeyedDynamicLayoutNode<int>? _contentNode;
     private IDisposable? _contentInvalidationSubscription;
     private string? _title;
     private WizardProgressStyle _progressStyle = WizardProgressStyle.BlockBar;
@@ -165,12 +164,10 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     {
         BlurContentChild();
 
-        if (_steps.Count == 0)
+        if (_steps.Count == 0 || _contentNode == null)
             return;
 
-        // Get or create the step content directly (so focus works before first Render)
-        var content = GetOrCreateStepContent(_currentStepIndex);
-        _focusedChild = FindFirstFocusable(content);
+        _focusedChild = FindFirstFocusable(_contentNode);
         _focusedChild?.OnFocused();
     }
 
@@ -267,6 +264,9 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         if (_currentSubStep < currentConfig.SubStepCount - 1)
         {
             _currentSubStep++;
+            _contentNode?.Invalidate();
+            if (_hasFocus)
+                PropagateFocusToContent();
             _invalidated.OnNext(Unit.Default);
             return true;
         }
@@ -288,6 +288,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
 
         _currentStepIndex++;
         _currentSubStep = 0;
+        _contentNode?.Invalidate();
         if (_hasFocus)
             PropagateFocusToContent();
         _invalidated.OnNext(Unit.Default);
@@ -307,6 +308,9 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         if (_currentSubStep > 0)
         {
             _currentSubStep--;
+            _contentNode?.Invalidate();
+            if (_hasFocus)
+                PropagateFocusToContent();
             _invalidated.OnNext(Unit.Default);
             return true;
         }
@@ -317,6 +321,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         _currentStepIndex--;
         // Return to last sub-step of previous step
         _currentSubStep = _steps[_currentStepIndex].SubStepCount - 1;
+        _contentNode?.Invalidate();
         if (_hasFocus)
             PropagateFocusToContent();
         _invalidated.OnNext(Unit.Default);
@@ -337,6 +342,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
 
         _currentStepIndex = index;
         _currentSubStep = 0;
+        _contentNode?.Invalidate();
         if (_hasFocus)
             PropagateFocusToContent();
         _invalidated.OnNext(Unit.Default);
@@ -358,6 +364,9 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
             return false;
 
         _currentSubStep++;
+        _contentNode?.Invalidate();
+        if (_hasFocus)
+            PropagateFocusToContent();
         _invalidated.OnNext(Unit.Default);
         return true;
     }
@@ -463,12 +472,14 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         if (_contentNode != null)
             return;
 
-        _contentNode = new DynamicLayoutNode(() =>
-        {
-            if (_steps.Count == 0)
-                return new EmptyNode();
-            return GetOrCreateStepContent(_currentStepIndex);
-        });
+        _contentNode = new KeyedDynamicLayoutNode<int>(
+            () => _currentStepIndex,
+            stepIndex =>
+            {
+                if (_steps.Count == 0)
+                    return new EmptyNode();
+                return _steps[stepIndex].ContentFactory();
+            });
 
         // Propagate content invalidation (e.g., SelectionListNode highlight changes)
         // up through the wizard so the page triggers a redraw
@@ -478,23 +489,13 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         if (_isActive)
             _contentNode.OnActivate();
 
+        // Eagerly evaluate so real content is available for focus finding and input delegation
+        _contentNode.Invalidate();
+
         // If wizard already has focus (OnFocused called before first Render),
         // propagate focus to the content's first focusable child now
         if (_hasFocus && _focusedChild == null)
             PropagateFocusToContent();
-    }
-
-    /// <summary>
-    /// Get cached step content or create it once from the factory.
-    /// </summary>
-    private ILayoutNode GetOrCreateStepContent(int stepIndex)
-    {
-        if (!_stepContentCache.TryGetValue(stepIndex, out var content))
-        {
-            content = _steps[stepIndex].ContentFactory();
-            _stepContentCache[stepIndex] = content;
-        }
-        return content;
     }
 
     private void RenderProgress(IRenderContext context, Rect bounds)
@@ -646,16 +647,6 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
         _invalidated.Dispose();
 
         _contentInvalidationSubscription?.Dispose();
-
-        // Dispose cached step content that isn't the DynamicLayoutNode's current child
-        // (DynamicLayoutNode will dispose its own current child)
-        ILayoutNode? currentContent = _steps.Count > 0 && _stepContentCache.TryGetValue(_currentStepIndex, out var c) ? c : null;
-        foreach (var content in _stepContentCache.Values)
-        {
-            if (!ReferenceEquals(content, currentContent))
-                content.Dispose();
-        }
-        _stepContentCache.Clear();
         _contentNode?.Dispose();
         base.Dispose();
     }

--- a/tests/Termina.Tests/Layout/DynamicLayoutNodeTests.cs
+++ b/tests/Termina.Tests/Layout/DynamicLayoutNodeTests.cs
@@ -70,9 +70,9 @@ public class DynamicLayoutNodeTests
         node.Measure(new Size(80, 24));
         Assert.Equal(1, childA.ActivateCount);
 
-        // Switch to childB
+        // Switch to childB and invalidate
         current = childB;
-        node.Measure(new Size(80, 24));
+        node.Invalidate();
 
         Assert.Equal(1, childA.DeactivateCount);
         Assert.Equal(1, childB.ActivateCount);
@@ -186,11 +186,80 @@ public class DynamicLayoutNodeTests
         // Evaluate to set childA
         node.Measure(new Size(80, 24));
 
-        // Switch to childB while NOT active
+        // Switch to childB while NOT active and invalidate
         current = childB;
-        node.Measure(new Size(80, 24));
+        node.Invalidate();
 
         Assert.Equal(0, childB.ActivateCount);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_FactoryNotCalledPerFrame()
+    {
+        var callCount = 0;
+        var child = new TextNode("Hello");
+        var node = new DynamicLayoutNode(() =>
+        {
+            callCount++;
+            return child;
+        });
+
+        // First Measure evaluates (needsEvaluation starts true)
+        node.Measure(new Size(80, 24));
+        Assert.Equal(1, callCount);
+
+        // Subsequent Measure/Render without Invalidate should NOT call factory
+        node.Measure(new Size(80, 24));
+        node.Render(new NullRenderContext(), new Rect(0, 0, 80, 24));
+        Assert.Equal(1, callCount);
+
+        // After Invalidate, factory runs again
+        node.Invalidate();
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_Invalidate_EagerlyEvaluatesFactory()
+    {
+        var childA = new TextNode("A");
+        var childB = new TextNode("B");
+        ILayoutNode current = childA;
+
+        var node = new DynamicLayoutNode(() => current);
+
+        // First Measure sets childA
+        node.Measure(new Size(80, 24));
+        Assert.Same(childA, node.GetChildNodes().First());
+
+        // Switch and Invalidate — child swaps immediately (before Measure/Render)
+        current = childB;
+        node.Invalidate();
+        Assert.Same(childB, node.GetChildNodes().First());
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_OnActivate_SetsNeedsEvaluation()
+    {
+        var callCount = 0;
+        var child = new TextNode("Hello");
+        var node = new DynamicLayoutNode(() =>
+        {
+            callCount++;
+            return child;
+        });
+
+        // First Measure evaluates
+        node.Measure(new Size(80, 24));
+        Assert.Equal(1, callCount);
+
+        // Deactivate, then re-activate
+        node.OnActivate();
+        node.OnDeactivate();
+        node.OnActivate();
+
+        // Next Measure should re-evaluate because OnActivate sets _needsEvaluation
+        node.Measure(new Size(80, 24));
+        Assert.Equal(2, callCount);
     }
 
     [Fact]

--- a/tests/Termina.Tests/Layout/KeyedDynamicLayoutNodeTests.cs
+++ b/tests/Termina.Tests/Layout/KeyedDynamicLayoutNodeTests.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Layout;
+using Termina.Rendering;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for the KeyedDynamicLayoutNode class.
+/// </summary>
+public class KeyedDynamicLayoutNodeTests
+{
+    [Fact]
+    public void KeyedDynamic_FirstMeasure_EvaluatesFactory()
+    {
+        var currentKey = 0;
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key => new TextNode($"Content {key}"));
+
+        var size = node.Measure(new Size(80, 24));
+
+        Assert.True(size.Width > 0);
+        var children = node.GetChildNodes().ToList();
+        Assert.Single(children);
+        Assert.IsType<TextNode>(children[0]);
+    }
+
+    [Fact]
+    public void KeyedDynamic_SameKey_ReusesInstance()
+    {
+        var currentKey = 0;
+        var factoryCallCount = 0;
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key =>
+            {
+                factoryCallCount++;
+                return new TextNode($"Content {key}");
+            });
+
+        // First evaluation
+        node.Measure(new Size(80, 24));
+        Assert.Equal(1, factoryCallCount);
+        var firstChild = node.GetChildNodes().First();
+
+        // Invalidate with same key — should reuse cached instance
+        node.Invalidate();
+        Assert.Equal(1, factoryCallCount); // factory NOT called again
+        var secondChild = node.GetChildNodes().First();
+        Assert.Same(firstChild, secondChild);
+    }
+
+    [Fact]
+    public void KeyedDynamic_DifferentKey_CreatesAndCachesNew()
+    {
+        var currentKey = 0;
+        var factoryCallCount = 0;
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key =>
+            {
+                factoryCallCount++;
+                return new TextNode($"Content {key}");
+            });
+
+        node.Measure(new Size(80, 24));
+        Assert.Equal(1, factoryCallCount);
+
+        // Switch to different key
+        currentKey = 1;
+        node.Invalidate();
+        Assert.Equal(2, factoryCallCount);
+    }
+
+    [Fact]
+    public void KeyedDynamic_ReturnToPreviousKey_ReusesCached()
+    {
+        var currentKey = 0;
+        var factoryCallCount = 0;
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key =>
+            {
+                factoryCallCount++;
+                return new SpyLifecycleNode();
+            });
+        node.OnActivate();
+
+        // Create content for key 0
+        node.Measure(new Size(80, 24));
+        var child0 = node.GetChildNodes().First();
+        Assert.Equal(1, factoryCallCount);
+
+        // Switch to key 1
+        currentKey = 1;
+        node.Invalidate();
+        Assert.Equal(2, factoryCallCount);
+
+        // Return to key 0 — should reuse cached instance
+        currentKey = 0;
+        node.Invalidate();
+        Assert.Equal(2, factoryCallCount); // factory NOT called again
+        Assert.Same(child0, node.GetChildNodes().First());
+    }
+
+    [Fact]
+    public void KeyedDynamic_ChildChange_LifecycleManaged()
+    {
+        var currentKey = 0;
+        SpyLifecycleNode? child0 = null;
+        SpyLifecycleNode? child1 = null;
+
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key =>
+            {
+                var child = new SpyLifecycleNode();
+                if (key == 0) child0 = child;
+                else child1 = child;
+                return child;
+            });
+        node.OnActivate();
+
+        // First evaluation activates child0
+        node.Measure(new Size(80, 24));
+        Assert.NotNull(child0);
+        Assert.Equal(1, child0!.ActivateCount);
+
+        // Switch to key 1 — child0 deactivated, child1 activated
+        currentKey = 1;
+        node.Invalidate();
+
+        Assert.Equal(1, child0.DeactivateCount);
+        Assert.NotNull(child1);
+        Assert.Equal(1, child1!.ActivateCount);
+    }
+
+    [Fact]
+    public void KeyedDynamic_ChildInvalidation_PropagatesUpward()
+    {
+        var childSubject = new Subject<Unit>();
+        var child = new SpyInvalidatingNode(childSubject);
+        var currentKey = 0;
+
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            _ => child);
+        node.OnActivate();
+
+        var parentInvalidations = 0;
+        node.Invalidated.Subscribe(_ => parentInvalidations++);
+
+        // Evaluate factory so child gets subscribed
+        node.Measure(new Size(80, 24));
+
+        childSubject.OnNext(Unit.Default);
+
+        Assert.Equal(1, parentInvalidations);
+    }
+
+    [Fact]
+    public void KeyedDynamic_Dispose_DisposesAllCachedChildren()
+    {
+        var currentKey = 0;
+        var children = new List<SpyLifecycleNode>();
+
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key =>
+            {
+                var child = new SpyLifecycleNode();
+                children.Add(child);
+                return child;
+            });
+
+        // Create content for key 0 and 1
+        node.Measure(new Size(80, 24));
+        currentKey = 1;
+        node.Invalidate();
+
+        Assert.Equal(2, children.Count);
+
+        node.Dispose();
+
+        Assert.All(children, c => Assert.True(c.WasDisposed));
+    }
+
+    [Fact]
+    public void KeyedDynamic_Invalidate_EagerlyEvaluates()
+    {
+        var currentKey = 0;
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key => new TextNode($"Content {key}"));
+
+        // First Measure
+        node.Measure(new Size(80, 24));
+        var firstChild = node.GetChildNodes().First();
+
+        // Switch key and Invalidate — child swaps immediately (before Measure/Render)
+        currentKey = 1;
+        node.Invalidate();
+        var secondChild = node.GetChildNodes().First();
+
+        Assert.NotSame(firstChild, secondChild);
+    }
+
+    [Fact]
+    public void KeyedDynamic_FluentSizing_Works()
+    {
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => 0,
+            _ => new EmptyNode());
+
+        var result = node.Width(40).Height(10);
+
+        Assert.IsType<SizeConstraint.Fixed>(result.WidthConstraint);
+        Assert.IsType<SizeConstraint.Fixed>(result.HeightConstraint);
+    }
+
+    #region Test helpers
+
+    private class SpyLifecycleNode : LayoutNode
+    {
+        public int ActivateCount { get; private set; }
+        public int DeactivateCount { get; private set; }
+        public bool WasDisposed { get; private set; }
+
+        public override void OnActivate()
+        {
+            ActivateCount++;
+            base.OnActivate();
+        }
+
+        public override void OnDeactivate()
+        {
+            DeactivateCount++;
+            base.OnDeactivate();
+        }
+
+        public override void Dispose()
+        {
+            WasDisposed = true;
+            base.Dispose();
+        }
+
+        public override Size Measure(Size available) => new(10, 1);
+        public override void Render(IRenderContext context, Rect bounds) { }
+    }
+
+    private class SpyInvalidatingNode : LayoutNode, IInvalidatingNode
+    {
+        public Observable<Unit> Invalidated { get; }
+
+        public SpyInvalidatingNode(Observable<Unit> invalidated)
+        {
+            Invalidated = invalidated;
+        }
+
+        public override Size Measure(Size available) => new(10, 1);
+        public override void Render(IRenderContext context, Rect bounds) { }
+    }
+
+    #endregion
+}

--- a/tests/Termina.Tests/Layout/WizardNodeTests.cs
+++ b/tests/Termina.Tests/Layout/WizardNodeTests.cs
@@ -546,6 +546,85 @@ public class WizardNodeTests
         Assert.Equal(TestWizardStep.Auth, wizard.CurrentStep);
     }
 
+    [Fact]
+    public void SubStep_TryAdvance_PropagatesFocus()
+    {
+        var focusableA = new TestFocusableNode(_ => false);
+        var focusableB = new TestFocusableNode(_ => false);
+
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider",
+                () => Layouts.Vertical(focusableA),
+                subSteps: 2)
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("Auth"));
+
+        // Render to initialize content node, then focus wizard
+        var ctx = new NullRenderContext();
+        wizard.Render(ctx, new Rect(0, 0, 80, 24));
+        wizard.OnFocused();
+
+        Assert.True(focusableA.HasFocus);
+
+        // Advance sub-step
+        wizard.TryAdvance();
+
+        // Focus should have been re-propagated (blur old, find new focusable)
+        // Since the content factory returns the same node (same step), focusableA gets re-focused
+        Assert.True(focusableA.HasFocus);
+        Assert.Equal(1, wizard.CurrentSubStep);
+    }
+
+    [Fact]
+    public void SubStep_TryGoBack_PropagatesFocus()
+    {
+        var focusable = new TestFocusableNode(_ => false);
+
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider",
+                () => Layouts.Vertical(focusable),
+                subSteps: 2)
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("Auth"));
+
+        // Render, focus, advance to sub-step 1
+        var ctx = new NullRenderContext();
+        wizard.Render(ctx, new Rect(0, 0, 80, 24));
+        wizard.OnFocused();
+        wizard.TryAdvance(); // sub-step 0 -> 1
+
+        Assert.True(focusable.HasFocus);
+
+        // Go back within sub-steps
+        wizard.TryGoBack(); // sub-step 1 -> 0
+
+        Assert.Equal(0, wizard.CurrentSubStep);
+        Assert.True(focusable.HasFocus);
+    }
+
+    [Fact]
+    public void SubStep_AdvanceSubStep_PropagatesFocus()
+    {
+        var focusable = new TestFocusableNode(_ => false);
+
+        var wizard = Layouts.Wizard<TestWizardStep>()
+            .WithStep(TestWizardStep.Provider, "Provider",
+                () => Layouts.Vertical(focusable),
+                subSteps: 3)
+            .WithStep(TestWizardStep.Auth, "Auth", () => new TextNode("Auth"));
+
+        // Render, focus
+        var ctx = new NullRenderContext();
+        wizard.Render(ctx, new Rect(0, 0, 80, 24));
+        wizard.OnFocused();
+
+        Assert.True(focusable.HasFocus);
+
+        // AdvanceSubStep
+        wizard.AdvanceSubStep();
+
+        Assert.Equal(1, wizard.CurrentSubStep);
+        Assert.True(focusable.HasFocus);
+    }
+
     /// <summary>
     /// Test IFocusable that extends LayoutNode so it's discoverable by tree walk.
     /// </summary>


### PR DESCRIPTION
## Summary

- **DynamicLayoutNode is now invalidation-driven** — factory runs once on first render, then only on `Invalidate()`. Fixes silent state destruction (highlights, typed text, focus) when factory creates new instances each frame ([#155](https://github.com/Aaronontheweb/Termina/issues/155))
- **KeyedDynamicLayoutNode\<TKey\>** — new pit-of-success API for key-based content switching with automatic caching. `Layouts.KeyedDynamic<TKey>(keySelector, contentFactory)` factory method
- **WizardNode sub-step focus propagation** — `PropagateFocusToContent()` now called on sub-step changes, fixing stale focus ([#156](https://github.com/Aaronontheweb/Termina/issues/156)). WizardNode now uses `KeyedDynamicLayoutNode<int>` internally

## Changes

| File | Change |
|------|--------|
| `DynamicLayoutNode.cs` | Add `_needsEvaluation` dirty flag; factory is no-op when clean; `Invalidate()` eagerly evaluates; `OnActivate()` marks dirty |
| `KeyedDynamicLayoutNode.cs` | **New** — key-based caching, lifecycle management, eager invalidation |
| `Layout.cs` | Add `Layouts.KeyedDynamic<TKey>()` factory method |
| `WizardNode.cs` | Replace manual cache with `KeyedDynamicLayoutNode<int>`; add `Invalidate()` + focus propagation to all 6 navigation paths |
| `DynamicLayoutNodeTests.cs` | Fix 2 existing tests, add 3 new tests |
| `KeyedDynamicLayoutNodeTests.cs` | **New** — 9 tests |
| `WizardNodeTests.cs` | Add 3 sub-step focus propagation tests |
| Docs | Updated dynamic-layouts.md, wizard-app.md, focus-management.md, components/index.md |
| `RELEASE_NOTES.md` | Added 0.7.1 entries |

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 901 tests pass
- [x] Manual verification: SelectionListNode highlights visible and arrow keys work in wizard demo
- [x] Tab/Shift+Tab wizard navigation works
- [x] Sub-step focus propagation verified