### PR TITLE
Improve TextInputNode paste behavior with committed segments model

### DIFF
--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -22,7 +22,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     private readonly Subject<string> _textChanged = new();
     private readonly Subject<string> _submitted = new();
     private string _text = "";
-    private string? _pasteContent;  // full paste content (with newlines preserved)
+    private readonly List<CommittedSegment> _committedSegments = new();
     private int _cursorPosition;
     private int _selectionStart = -1;
     private int _scrollOffset;
@@ -87,37 +87,32 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// </summary>
     public string Text
     {
-        get => _text;
+        get => CommittedDisplayPrefix + _text;
         set
         {
             var newValue = value ?? "";
-            if (_text != newValue || _pasteContent != null)
+            _committedSegments.Clear();
+            if (newValue.Contains('\n'))
             {
-                // Multi-line content should display condensed, same as HandlePaste
-                if (newValue.Contains('\n'))
+                var lineCount = 1;
+                foreach (var c in newValue)
                 {
-                    _pasteContent = newValue;
-                    var lineCount = 1;
-                    foreach (var c in newValue)
-                    {
-                        if (c == '\n') lineCount++;
-                    }
-
-                    _text = lineCount > 1
-                        ? $"[Pasted {lineCount} lines, {newValue.Length} chars]"
-                        : $"[Pasted {newValue.Length} chars]";
-                }
-                else
-                {
-                    _pasteContent = null;
-                    _text = newValue;
+                    if (c == '\n') lineCount++;
                 }
 
-                _cursorPosition = Math.Min(_cursorPosition, _text.Length);
-                _selectionStart = -1;
-                _textChanged.OnNext(_text);
-                _invalidated.OnNext(Unit.Default);
+                var summary = $"[Pasted {lineCount} lines, {newValue.Length} chars] ";
+                _committedSegments.Add(new CommittedSegment(summary, newValue, SegmentKind.Pasted));
+                _text = "";
             }
+            else
+            {
+                _text = newValue;
+            }
+
+            _cursorPosition = Math.Min(_cursorPosition, _text.Length);
+            _selectionStart = -1;
+            _textChanged.OnNext(Text);
+            _invalidated.OnNext(Unit.Default);
         }
     }
 
@@ -372,9 +367,6 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             return true;
         }
 
-        // Any character input clears paste mode — return to normal editing
-        ClearPasteContent();
-
         // Check max length
         var addLength = HasSelection ? 1 - SelectedText.Length : 1;
         if (MaxLength > 0 && _text.Length + addLength > MaxLength)
@@ -389,28 +381,36 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         // Insert character
         _text = _text.Insert(_cursorPosition, c.ToString());
         _cursorPosition++;
-        _textChanged.OnNext(_text);
+        _textChanged.OnNext(Text);
         return true;
     }
 
     private bool HandleBackspace(ConsoleModifiers modifiers)
     {
-        // Backspace clears paste mode — return to normal editing with empty input
-        if (_pasteContent != null)
-        {
-            ClearPasteContent();
-            return true;
-        }
-
         if (HasSelection)
         {
             DeleteSelection();
-            _textChanged.OnNext(_text);
+            _textChanged.OnNext(Text);
             return true;
         }
 
         if (_cursorPosition == 0)
+        {
+            if (_committedSegments.Count > 0)
+            {
+                var last = _committedSegments[^1];
+                _committedSegments.RemoveAt(_committedSegments.Count - 1);
+                if (last.Kind == SegmentKind.Typed)
+                {
+                    _text = last.DisplayText + _text;
+                    _cursorPosition = last.DisplayText.Length;
+                }
+                // Pasted segments are just removed (cursor stays at 0)
+                _textChanged.OnNext(Text);
+                return true;
+            }
             return false;
+        }
 
         if (modifiers.HasFlag(ConsoleModifiers.Control))
         {
@@ -426,23 +426,16 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             _cursorPosition--;
         }
 
-        _textChanged.OnNext(_text);
+        _textChanged.OnNext(Text);
         return true;
     }
 
     private bool HandleDelete(ConsoleModifiers modifiers)
     {
-        // Delete clears paste mode — return to normal editing with empty input
-        if (_pasteContent != null)
-        {
-            ClearPasteContent();
-            return true;
-        }
-
         if (HasSelection)
         {
             DeleteSelection();
-            _textChanged.OnNext(_text);
+            _textChanged.OnNext(Text);
             return true;
         }
 
@@ -461,7 +454,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             _text = _text.Remove(_cursorPosition, 1);
         }
 
-        _textChanged.OnNext(_text);
+        _textChanged.OnNext(Text);
         return true;
     }
 
@@ -548,7 +541,7 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         if (_historyIndex < 0)
         {
             // First press: save current input and jump to most recent
-            _savedInput = _pasteContent ?? _text;
+            _savedInput = SubmitContent;
             _historyIndex = _history.Count - 1;
         }
         else if (_historyIndex > 0)
@@ -594,11 +587,10 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     private bool HandleEnter()
     {
-        // When paste content is stored, submit the full paste (with newlines) instead of the summary
-        var content = _pasteContent ?? _text;
-        TerminaTrace.Input.Debug(this, "HandleEnter: submitting text length={0} (paste={1})",
-            content.Length, _pasteContent != null);
-        _pasteContent = null;
+        var content = SubmitContent;
+        TerminaTrace.Input.Debug(this, "HandleEnter: submitting text length={0} (segments={1})",
+            content.Length, _committedSegments.Count);
+        _committedSegments.Clear();
 
         // Auto-record to history when enabled
         if (_history is not null && !string.IsNullOrWhiteSpace(content))
@@ -621,35 +613,31 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// </summary>
     public void Clear()
     {
-        _pasteContent = null;
+        _committedSegments.Clear();
         _text = "";
         _cursorPosition = 0;
         _selectionStart = -1;
         _scrollOffset = 0;
-        _textChanged.OnNext(_text);
+        _textChanged.OnNext(Text);
         _invalidated.OnNext(Unit.Default);
     }
 
     private bool HandleEscape()
     {
-        // Escape clears paste mode
-        if (_pasteContent != null)
-        {
-            ClearPasteContent();
-            return true;
-        }
-
         if (HasSelection)
         {
             _selectionStart = -1;
             return true;
         }
 
-        if (!string.IsNullOrEmpty(_text))
+        if (_committedSegments.Count > 0 || !string.IsNullOrEmpty(_text))
         {
+            _committedSegments.Clear();
             _text = "";
             _cursorPosition = 0;
-            _textChanged.OnNext(_text);
+            _selectionStart = -1;
+            _scrollOffset = 0;
+            _textChanged.OnNext(Text);
             return true;
         }
 
@@ -661,14 +649,14 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The full paste content (including newlines) is preserved and will be submitted
-    /// verbatim when the user presses Enter. The input displays a summary placeholder
-    /// (e.g., <c>[Pasted 500 lines, 12345 chars]</c>) instead of the raw content.
+    /// Single-line pastes are inserted inline at the cursor position, just like typing.
+    /// Multi-line pastes commit the current text and display a summary placeholder
+    /// (e.g., <c>[Pasted 3 lines, 50 chars] </c>). The full paste content is preserved
+    /// and will be included verbatim when the user presses Enter.
     /// </para>
     /// <para>
-    /// Any subsequent character input, backspace, or delete clears the paste and returns
-    /// the input to normal editing mode. This matches the behavior of CLI tools like
-    /// Claude Code and OpenCode.
+    /// After pasting, the user can continue typing or paste again — content accumulates
+    /// as committed segments that are all concatenated on submission.
     /// </para>
     /// </remarks>
     /// <param name="paste">The paste event containing the text to insert.</param>
@@ -678,8 +666,41 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         if (string.IsNullOrEmpty(paste.Content))
             return false;
 
-        // Store the full paste content (newlines preserved) for submission
-        _pasteContent = paste.Content;
+        // Single-line paste: insert inline at cursor like typing
+        if (!paste.Content.Contains('\n'))
+        {
+            if (HasSelection)
+                DeleteSelection();
+
+            _text = _text.Insert(_cursorPosition, paste.Content);
+            _cursorPosition += paste.Content.Length;
+            _selectionStart = -1;
+            _textChanged.OnNext(Text);
+            _invalidated.OnNext(Unit.Default);
+            return true;
+        }
+
+        // Multi-line paste: commit current text and add paste segment
+        if (_cursorPosition >= _text.Length)
+        {
+            // Cursor at end — commit all of _text
+            if (_text.Length > 0)
+            {
+                _committedSegments.Add(new CommittedSegment(_text, _text, SegmentKind.Typed));
+            }
+            _text = "";
+        }
+        else
+        {
+            // Cursor in middle — commit prefix, keep suffix as new _text
+            var prefix = _text[.._cursorPosition];
+            var suffix = _text[_cursorPosition..];
+            if (prefix.Length > 0)
+            {
+                _committedSegments.Add(new CommittedSegment(prefix, prefix, SegmentKind.Typed));
+            }
+            _text = suffix;
+        }
 
         // Count lines for the summary display
         var lineCount = 1;
@@ -688,34 +709,14 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             if (c == '\n') lineCount++;
         }
 
-        // Show a summary in the input instead of the raw content
-        var summary = lineCount > 1
-            ? $"[Pasted {lineCount} lines, {paste.Content.Length} chars]"
-            : $"[Pasted {paste.Content.Length} chars]";
-
-        _text = summary;
-        _cursorPosition = _text.Length;
-        _selectionStart = -1;
-        _scrollOffset = 0;
-
-        _textChanged.OnNext(_text);
-        _invalidated.OnNext(Unit.Default);
-        return true;
-    }
-
-    /// <summary>
-    /// Clears paste content and resets the input to an empty state.
-    /// Called when the user starts editing (typing, backspace, delete, escape) after a paste.
-    /// </summary>
-    private void ClearPasteContent()
-    {
-        if (_pasteContent == null) return;
-        _pasteContent = null;
-        _text = "";
+        var summary = $"[Pasted {lineCount} lines, {paste.Content.Length} chars] ";
+        _committedSegments.Add(new CommittedSegment(summary, paste.Content, SegmentKind.Pasted));
         _cursorPosition = 0;
         _selectionStart = -1;
-        _scrollOffset = 0;
-        _textChanged.OnNext(_text);
+
+        _textChanged.OnNext(Text);
+        _invalidated.OnNext(Unit.Default);
+        return true;
     }
 
     private void SelectAll()
@@ -771,7 +772,8 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// <inheritdoc />
     public override Size Measure(Size available)
     {
-        var width = WidthConstraint.Compute(available.Width, _text.Length + 1, available.Width);
+        var prefixWidth = CommittedDisplayPrefix.Length;
+        var width = WidthConstraint.Compute(available.Width, prefixWidth + _text.Length + 1, available.Width);
         return new Size(width, 1);
     }
 
@@ -784,17 +786,23 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         // Create a sub-context so coordinates are relative to this node's bounds
         var inputContext = context.CreateSubContext(bounds);
 
-        var displayText = _text;
-        var displayCursor = _cursorPosition;
+        var prefix = CommittedDisplayPrefix;
+        var prefixWidth = prefix.Length;
+        var activeText = _text;
 
-        // Apply password masking
-        if (IsPassword && displayText.Length > 0)
+        // Apply password masking to active text only
+        if (IsPassword && activeText.Length > 0)
         {
-            displayText = new string(PasswordChar, displayText.Length);
+            activeText = new string(PasswordChar, activeText.Length);
         }
 
-        // Show placeholder if empty
-        if (string.IsNullOrEmpty(displayText) && !string.IsNullOrEmpty(Placeholder))
+        // The full display text combines prefix and active text
+        var fullDisplayText = prefix + activeText;
+        // Cursor position in the full display coordinate space
+        var displayCursor = prefixWidth + _cursorPosition;
+
+        // Show placeholder if both prefix and text are empty
+        if (fullDisplayText.Length == 0 && !string.IsNullOrEmpty(Placeholder))
         {
             inputContext.SetForeground(PlaceholderColor);
             var placeholder = Placeholder.Length > bounds.Width
@@ -823,59 +831,88 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             _scrollOffset = displayCursor - bounds.Width + 1;
         }
 
-        // Set colors
-        if (Foreground.HasValue)
-            inputContext.SetForeground(Foreground.Value);
-        if (Background.HasValue)
-            inputContext.SetBackground(Background.Value);
+        // Render segments with appropriate colors
+        // Build per-character rendering info for the visible portion
+        var visStart = _scrollOffset;
+        var visEnd = Math.Min(fullDisplayText.Length, _scrollOffset + bounds.Width);
 
-        // Get visible portion
-        var visibleText = displayText.Length > _scrollOffset
-            ? displayText[_scrollOffset..]
-            : "";
-        if (visibleText.Length > bounds.Width)
-            visibleText = visibleText[..bounds.Width];
-
-        // Draw selection background
-        if (HasSelection)
+        // Determine segment boundaries for coloring
+        // Walk through committed segments to find which chars are paste vs typed
+        var segOffset = 0;
+        var x = 0;
+        foreach (var seg in _committedSegments)
         {
-            var selStart = Math.Min(_selectionStart, _cursorPosition);
-            var selEnd = Math.Max(_selectionStart, _cursorPosition);
-            var visSelStart = Math.Max(0, selStart - _scrollOffset);
-            var visSelEnd = Math.Min(bounds.Width, selEnd - _scrollOffset);
+            var segStart = segOffset;
+            var segEnd = segOffset + seg.DisplayText.Length;
 
-            if (visSelEnd > visSelStart)
+            // Determine visible overlap
+            var drawStart = Math.Max(segStart, visStart);
+            var drawEnd = Math.Min(segEnd, visEnd);
+
+            if (drawStart < drawEnd)
             {
-                inputContext.SetBackground(SelectionColor);
-                for (var x = visSelStart; x < visSelEnd && x < visibleText.Length; x++)
-                {
-                    inputContext.WriteAt(x, 0, visibleText[x]);
-                }
-
-                // Draw non-selected portions
-                inputContext.ResetColors();
-                if (Foreground.HasValue)
+                if (seg.Kind == SegmentKind.Pasted)
+                    inputContext.SetForeground(Color.BrightBlack);
+                else if (Foreground.HasValue)
                     inputContext.SetForeground(Foreground.Value);
+                else
+                    inputContext.ResetColors();
+
                 if (Background.HasValue)
                     inputContext.SetBackground(Background.Value);
 
-                if (visSelStart > 0)
+                var text = seg.DisplayText[(drawStart - segStart)..(drawEnd - segStart)];
+                inputContext.WriteAt(drawStart - _scrollOffset, 0, text);
+                x = drawEnd - _scrollOffset;
+            }
+
+            segOffset = segEnd;
+        }
+
+        // Render active _text portion
+        var activeStart = prefixWidth;
+        var activeEnd = prefixWidth + activeText.Length;
+        var activeDrawStart = Math.Max(activeStart, visStart);
+        var activeDrawEnd = Math.Min(activeEnd, visEnd);
+
+        if (activeDrawStart < activeDrawEnd)
+        {
+            inputContext.ResetColors();
+            if (Foreground.HasValue)
+                inputContext.SetForeground(Foreground.Value);
+            if (Background.HasValue)
+                inputContext.SetBackground(Background.Value);
+
+            // Handle selection within active text
+            if (HasSelection)
+            {
+                var selStart = Math.Min(_selectionStart, _cursorPosition) + prefixWidth;
+                var selEnd = Math.Max(_selectionStart, _cursorPosition) + prefixWidth;
+
+                for (var i = activeDrawStart; i < activeDrawEnd; i++)
                 {
-                    inputContext.WriteAt(0, 0, visibleText[..visSelStart]);
-                }
-                if (visSelEnd < visibleText.Length)
-                {
-                    inputContext.WriteAt(visSelEnd, 0, visibleText[visSelEnd..]);
+                    if (i >= selStart && i < selEnd)
+                    {
+                        inputContext.SetBackground(SelectionColor);
+                    }
+                    else
+                    {
+                        if (Background.HasValue)
+                            inputContext.SetBackground(Background.Value);
+                        else
+                            inputContext.ResetColors();
+                        if (Foreground.HasValue)
+                            inputContext.SetForeground(Foreground.Value);
+                    }
+
+                    inputContext.WriteAt(i - _scrollOffset, 0, fullDisplayText[i]);
                 }
             }
             else
             {
-                inputContext.WriteAt(0, 0, visibleText);
+                var text = activeText[(activeDrawStart - activeStart)..(activeDrawEnd - activeStart)];
+                inputContext.WriteAt(activeDrawStart - _scrollOffset, 0, text);
             }
-        }
-        else
-        {
-            inputContext.WriteAt(0, 0, visibleText);
         }
 
         inputContext.ResetColors();
@@ -888,7 +925,9 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             {
                 inputContext.SetBackground(CursorColor);
                 inputContext.SetForeground(Background ?? Color.Black);
-                var cursorChar = cursorX < visibleText.Length ? visibleText[cursorX] : ' ';
+                var cursorChar = cursorX < fullDisplayText.Length - _scrollOffset
+                    ? fullDisplayText[cursorX + _scrollOffset]
+                    : ' ';
                 inputContext.WriteAt(cursorX, 0, cursorChar);
                 inputContext.ResetColors();
             }
@@ -932,4 +971,13 @@ public sealed class TextInputNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
         base.Dispose();
     }
+
+    private enum SegmentKind { Typed, Pasted }
+    private sealed record CommittedSegment(string DisplayText, string SubmitText, SegmentKind Kind);
+
+    private string CommittedDisplayPrefix =>
+        _committedSegments.Count == 0 ? "" : string.Concat(_committedSegments.Select(s => s.DisplayText));
+
+    private string SubmitContent =>
+        string.Concat(_committedSegments.Select(s => s.SubmitText)) + _text;
 }

--- a/tests/Termina.Tests/TextInputNodePasteTests.cs
+++ b/tests/Termina.Tests/TextInputNodePasteTests.cs
@@ -18,7 +18,8 @@ public class TextInputNodePasteTests
         var node = new TextInputNode();
         var result = node.HandlePaste(new PasteEvent("hello world"));
         Assert.True(result);
-        Assert.Equal("[Pasted 11 chars]", node.Text);
+        // Single-line paste inserts inline (no summary)
+        Assert.Equal("hello world", node.Text);
     }
 
     [Fact]
@@ -26,7 +27,7 @@ public class TextInputNodePasteTests
     {
         var node = new TextInputNode();
         node.HandlePaste(new PasteEvent("hello\nworld\nthird"));
-        Assert.Equal("[Pasted 3 lines, 17 chars]", node.Text);
+        Assert.Equal("[Pasted 3 lines, 17 chars] ", node.Text);
     }
 
     [Fact]
@@ -72,46 +73,48 @@ public class TextInputNodePasteTests
     }
 
     [Fact]
-    public void HandlePaste_TypingClearsPaste_ReturnsToNormalEditing()
+    public void HandlePaste_TypingAfterPaste_AccumulatesContent()
     {
         var node = new TextInputNode();
         node.HandlePaste(new PasteEvent("pasted content\nwith newlines"));
 
-        // Type a character — should clear paste and start fresh
+        // Type a character — appends to active text after paste segment
         node.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false));
 
-        Assert.Equal("a", node.Text);
+        // Display shows paste summary + typed char
+        Assert.Equal("[Pasted 2 lines, 28 chars] a", node.Text);
 
-        // Now Enter submits "a", not the paste content
+        // Enter submits the full paste content + typed text
         string? submitted = null;
         node.Submitted.Subscribe(t => submitted = t);
         node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
 
-        Assert.Equal("a", submitted);
+        Assert.Equal("pasted content\nwith newlinesa", submitted);
     }
 
     [Fact]
-    public void HandlePaste_BackspaceClearsPaste()
+    public void HandlePaste_BackspaceSingleLine_DeletesCharacter()
     {
         var node = new TextInputNode();
         node.HandlePaste(new PasteEvent("pasted stuff"));
 
-        // Backspace should clear paste and return to empty
+        // Single-line paste inserted inline — backspace deletes last char
         node.HandleInput(new ConsoleKeyInfo('\b', ConsoleKey.Backspace, false, false, false));
 
-        Assert.Equal("", node.Text);
+        Assert.Equal("pasted stuf", node.Text);
     }
 
     [Fact]
-    public void HandlePaste_DeleteClearsPaste()
+    public void HandlePaste_DeleteSingleLine_NoOpAtEnd()
     {
         var node = new TextInputNode();
         node.HandlePaste(new PasteEvent("pasted stuff"));
 
-        // Delete should clear paste and return to empty
-        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false));
+        // Single-line paste inserted inline — cursor at end, delete is no-op
+        var result = node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false));
 
-        Assert.Equal("", node.Text);
+        Assert.False(result);
+        Assert.Equal("pasted stuff", node.Text);
     }
 
     [Fact]
@@ -120,7 +123,7 @@ public class TextInputNodePasteTests
         var node = new TextInputNode();
         node.HandlePaste(new PasteEvent("pasted stuff"));
 
-        // Escape should clear paste and return to empty
+        // Escape should clear everything
         node.HandleInput(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false));
 
         Assert.Equal("", node.Text);
@@ -151,10 +154,10 @@ public class TextInputNodePasteTests
         string? lastText = null;
         node.TextChanged.Subscribe(t => lastText = t);
 
+        // Single-line paste emits the raw text (inserted inline)
         node.HandlePaste(new PasteEvent("test"));
 
-        // TextChanged gets the summary, not the raw content
-        Assert.Equal("[Pasted 4 chars]", lastText);
+        Assert.Equal("test", lastText);
     }
 
     [Fact]
@@ -167,30 +170,31 @@ public class TextInputNodePasteTests
     }
 
     [Fact]
-    public void HandlePaste_ReplacesExistingText()
+    public void HandlePaste_SingleLine_InsertsAtCursorPosition()
     {
         var node = new TextInputNode();
         node.Text = "existing text";
 
-        node.HandlePaste(new PasteEvent("new paste"));
+        // Move cursor to position 8 ("existing|text" -> "existing| text")
+        // We need to simulate pressing Home then Right 8 times, or just set directly
+        // Instead, let's type some text, then paste in the middle
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false));
+        // Now cursor is at 0. Move right 8 times to after "existing"
+        for (var i = 0; i < 8; i++)
+            node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, false, false, false));
 
-        Assert.Equal("[Pasted 9 chars]", node.Text);
+        node.HandlePaste(new PasteEvent(" new"));
 
-        // Enter submits the paste content
-        string? submitted = null;
-        node.Submitted.Subscribe(t => submitted = t);
-        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
-
-        Assert.Equal("new paste", submitted);
+        Assert.Equal("existing new text", node.Text);
     }
 
     [Fact]
     public void HandlePaste_TextPropertySetterClearsPaste()
     {
         var node = new TextInputNode();
-        node.HandlePaste(new PasteEvent("pasted stuff"));
+        node.HandlePaste(new PasteEvent("pasted\nstuff"));
 
-        // Setting Text property programmatically should clear paste
+        // Setting Text property programmatically should clear committed segments
         node.Text = "manual text";
 
         Assert.Equal("manual text", node.Text);
@@ -211,7 +215,7 @@ public class TextInputNodePasteTests
         // Simulate history recall of previously-pasted multi-line content
         node.Text = "line 1\nline 2\nline 3";
 
-        Assert.Equal("[Pasted 3 lines, 20 chars]", node.Text);
+        Assert.Equal("[Pasted 3 lines, 20 chars] ", node.Text);
     }
 
     [Fact]
@@ -234,5 +238,209 @@ public class TextInputNodePasteTests
     {
         var node = new TextInputNode();
         Assert.IsAssignableFrom<IPasteReceiver>(node);
+    }
+
+    // === New tests for committed segments model ===
+
+    [Fact]
+    public void MultiLinePaste_ThenType_ThenSubmit_CombinesAllContent()
+    {
+        var node = new TextInputNode();
+
+        // Paste multi-line content
+        node.HandlePaste(new PasteEvent("line1\nline2"));
+        // Type some text after
+        node.HandleInput(new ConsoleKeyInfo('x', ConsoleKey.X, false, false, false));
+        node.HandleInput(new ConsoleKeyInfo('y', ConsoleKey.Y, false, false, false));
+
+        // Submit should combine paste + typed
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("line1\nline2xy", submitted);
+    }
+
+    [Fact]
+    public void MultiSegment_Paste_Type_Paste_Type_Submit()
+    {
+        var node = new TextInputNode();
+
+        // Paste multi-line
+        node.HandlePaste(new PasteEvent("a\nb"));
+        // Type some
+        node.HandleInput(new ConsoleKeyInfo('X', ConsoleKey.X, false, false, false));
+        // Paste multi-line again — commits "X" as typed segment first
+        node.HandlePaste(new PasteEvent("c\nd"));
+        // Type more
+        node.HandleInput(new ConsoleKeyInfo('Y', ConsoleKey.Y, false, false, false));
+
+        // Submit should be all concatenated
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("a\nbXc\ndY", submitted);
+    }
+
+    [Fact]
+    public void BackspaceAtPos0_PopsPasteSegment()
+    {
+        var node = new TextInputNode();
+
+        // Paste multi-line (creates paste committed segment)
+        node.HandlePaste(new PasteEvent("hello\nworld"));
+
+        // Cursor is at 0, no active text. Backspace should pop the paste segment.
+        node.HandleInput(new ConsoleKeyInfo('\b', ConsoleKey.Backspace, false, false, false));
+
+        Assert.Equal("", node.Text);
+
+        // Submit should yield nothing
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("", submitted);
+    }
+
+    [Fact]
+    public void BackspaceAtPos0_MergesTypedSegmentBack()
+    {
+        var node = new TextInputNode();
+
+        // Type text, then paste multi-line (which commits typed text as a segment)
+        node.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false));
+        node.HandleInput(new ConsoleKeyInfo('b', ConsoleKey.B, false, false, false));
+        node.HandlePaste(new PasteEvent("x\ny"));
+
+        // Now we have: committed["ab" typed], committed[paste], _text=""
+        // Backspace should pop the paste segment
+        node.HandleInput(new ConsoleKeyInfo('\b', ConsoleKey.Backspace, false, false, false));
+
+        // Now: committed["ab" typed], _text=""
+        // Backspace again at pos 0 should merge "ab" back into _text
+        node.HandleInput(new ConsoleKeyInfo('\b', ConsoleKey.Backspace, false, false, false));
+
+        Assert.Equal("ab", node.Text);
+
+        // Submit should yield "ab"
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("ab", submitted);
+    }
+
+    [Fact]
+    public void EscapeClearsAllCommittedSegments()
+    {
+        var node = new TextInputNode();
+
+        // Build up segments
+        node.HandlePaste(new PasteEvent("a\nb"));
+        node.HandleInput(new ConsoleKeyInfo('X', ConsoleKey.X, false, false, false));
+        node.HandlePaste(new PasteEvent("c\nd"));
+        node.HandleInput(new ConsoleKeyInfo('Y', ConsoleKey.Y, false, false, false));
+
+        // Escape should clear everything
+        node.HandleInput(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false));
+
+        Assert.Equal("", node.Text);
+
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("", submitted);
+    }
+
+    [Fact]
+    public void History_SavesFullCombinedContent()
+    {
+        var node = new TextInputNode().WithHistory();
+
+        // Build up multi-segment input
+        node.HandlePaste(new PasteEvent("hello\nworld"));
+        node.HandleInput(new ConsoleKeyInfo('!', ConsoleKey.D1, false, false, false));
+
+        // Submit (should record "hello\nworld!" to history)
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+        node.Clear();
+
+        // Navigate up in history
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false));
+
+        // The recalled content should be the multi-line + "!" — displayed as summary
+        // When recalled via Text setter, multi-line shows as summary
+        Assert.Contains("[Pasted", node.Text);
+
+        // Submit should give back the original content
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("hello\nworld!", submitted);
+    }
+
+    [Fact]
+    public void MultiLinePaste_WithExistingText_CommitsExistingFirst()
+    {
+        var node = new TextInputNode();
+
+        // Type some text first
+        node.HandleInput(new ConsoleKeyInfo('h', ConsoleKey.H, false, false, false));
+        node.HandleInput(new ConsoleKeyInfo('i', ConsoleKey.I, false, false, false));
+
+        // Paste multi-line — should commit "hi" as typed segment first
+        node.HandlePaste(new PasteEvent("foo\nbar"));
+
+        // Display should show typed prefix + paste summary
+        Assert.Equal("hi[Pasted 2 lines, 7 chars] ", node.Text);
+
+        // Submit should yield "hi" + "foo\nbar"
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("hifoo\nbar", submitted);
+    }
+
+    [Fact]
+    public void MultiLinePaste_CursorInMiddle_SplitsText()
+    {
+        var node = new TextInputNode();
+
+        // Type "abcd"
+        node.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false));
+        node.HandleInput(new ConsoleKeyInfo('b', ConsoleKey.B, false, false, false));
+        node.HandleInput(new ConsoleKeyInfo('c', ConsoleKey.C, false, false, false));
+        node.HandleInput(new ConsoleKeyInfo('d', ConsoleKey.D, false, false, false));
+
+        // Move cursor left 2 — cursor at position 2 (between b and c)
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false));
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false));
+
+        // Paste multi-line — should commit "ab" as typed, paste segment, _text = "cd"
+        node.HandlePaste(new PasteEvent("x\ny"));
+
+        // Submit should yield "ab" + "x\ny" + "cd"
+        string? submitted = null;
+        node.Submitted.Subscribe(t => submitted = t);
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("abx\nycd", submitted);
+    }
+
+    [Fact]
+    public void HandlePaste_EscapeAfterMultiLinePaste_ClearsAll()
+    {
+        var node = new TextInputNode();
+        node.HandlePaste(new PasteEvent("hello\nworld"));
+
+        // Escape clears all committed segments + text
+        node.HandleInput(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false));
+
+        Assert.Equal("", node.Text);
     }
 }


### PR DESCRIPTION
## Summary

- **Single-line pastes now insert inline** at the cursor position (like typing) instead of showing an unnecessary `[Pasted N chars]` summary placeholder.
- **Content accumulates after pasting** — typing after a paste appends to the input rather than clearing it. Users can paste, type, paste again, and all segments concatenate on submission.
- **Multi-line pastes still show a summary** (e.g., `[Pasted 3 lines, 50 chars]`) with the full content preserved for submission.

### Architecture

Replaces the single `_pasteContent` field with a `List<CommittedSegment>` model. Each segment tracks its display text, submit text, and kind (Typed vs Pasted). The cursor operates only within the active `_text` at the end, while committed segments form an immutable prefix.

| Action | Behavior |
|---|---|
| Paste single-line | Insert at cursor in `_text` (like typing) |
| Paste multi-line | Commit current text, add paste segment, reset `_text` |
| Type after paste | Characters go into `_text` normally |
| Backspace at pos 0 | Pop last committed segment (merge if typed, discard if paste) |
| Escape | Clear everything (all segments + `_text`) |
| Enter | Submit concatenation of all segments' submit text + `_text` |

## Test plan

- [x] `dotnet build` compiles cleanly
- [x] `dotnet test --filter TextInputNodePaste` — 26 paste tests pass (9 updated + 8 new + 9 unchanged)
- [x] `dotnet test` — full 910-test suite passes
- [x] Manual verification in streaming demo: single-line inline insert, multi-line summary, type-after-paste accumulation, Enter submits combined content