### PR TITLE
Harden TextAreaNode: fix cursor jump, submit clearing, and git workflow (#161)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,19 @@ public void AnimationChangesFrame()
 }
 ```
 
+## Git Workflow
+
+### NEVER Commit Directly to Protected Branches
+
+**Do NOT commit directly to `dev`, `main`, or `master`.** All changes must go through a feature branch and pull request — no exceptions, even for single-line fixes.
+
+1. **Before committing**, check which branch you're on with `git branch --show-current`
+2. If on `dev`, `main`, or `master`, **create a feature branch first**: `git checkout -b fix/descriptive-name` or `git checkout -b feature/descriptive-name`
+3. Commit on the feature branch, push, and open a PR to `dev`
+4. Never force-push to `dev`, `main`, or `master` unless explicitly correcting a prior mistake
+
+**This applies to ALL changes** — bug fixes, refactors, docs, tests, everything.
+
 ## Release Process
 
 ### Tag Naming Convention

--- a/src/Termina/Layout/TextAreaNode.cs
+++ b/src/Termina/Layout/TextAreaNode.cs
@@ -533,11 +533,11 @@ public sealed class TextAreaNode : TextInputBaseNode
             }
         }
 
-        // If text ends with \n, add an empty line
-        if (fullText.Length > 0 && fullText[^1] == '\n')
-        {
-            result.Add(new WrappedLine(fullText.Length, 0));
-        }
+        // NOTE: No separate trailing-newline check is needed here. When the text
+        // ends with '\n', the main loop's i == fullText.Length iteration already
+        // creates an empty WrappedLine for the content after the last newline.
+        // Adding another would create a duplicate, causing the cursor to appear
+        // one row too low and then "jump up" when the user starts typing.
 
         return result;
     }

--- a/src/Termina/Layout/TextInputBaseNode.cs
+++ b/src/Termina/Layout/TextInputBaseNode.cs
@@ -713,8 +713,8 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
         var content = SubmitContent;
         TerminaTrace.Input.Debug(this, "PerformSubmit: submitting text length={0} (segments={1})",
             content.Length, _committedSegments.Count);
-        _committedSegments.Clear();
 
+        // Record to history before clearing
         if (_history is not null && !string.IsNullOrWhiteSpace(content))
         {
             _history.Add(content);
@@ -725,7 +725,17 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
         _historyIndex = -1;
         _savedInput = null;
 
+        // Clear the entire input — segments, typed text, cursor, selection.
+        // Without this, committed segments (paste summaries) would vanish while
+        // manually typed text stayed, which is inconsistent.
+        _committedSegments.Clear();
+        _text = "";
+        _cursorPosition = 0;
+        _selectionStart = -1;
+        OnTextBufferChanged();
+
         _submitted.OnNext(content);
+        _textChanged.OnNext(Text);
     }
 
     #endregion

--- a/tests/Termina.Tests/Layout/TextAreaNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextAreaNodeTests.cs
@@ -143,6 +143,27 @@ public class TextAreaNodeTests : IDisposable
     }
 
     [Fact]
+    public void DoubleNewline_ThenType_CursorStaysOnCorrectLine()
+    {
+        // Regression: inserting two consecutive newlines followed by typing should
+        // place all typed characters on the third line — the cursor must not jump up.
+        TypeText("hello");
+        InsertNewline();
+        InsertNewline();
+
+        // At this point text is "hello\n\n" with cursor on the 3rd visual line.
+        // Measure to trigger line computation.
+        _node.Measure(new Size(80, 10));
+
+        TypeText("world");
+        Assert.Equal("hello\n\nworld", _node.Text);
+
+        // Measure again — should be exactly 3 visual lines
+        var size = _node.Measure(new Size(80, 10));
+        Assert.Equal(3, size.Height);
+    }
+
+    [Fact]
     public void AltEnter_InsertsNewline()
     {
         TypeText("hello");
@@ -619,6 +640,29 @@ public class TextAreaNodeTests : IDisposable
         TypeText("line2");
         InsertNewline();
         TypeText("line3");
+
+        var size = _node.Measure(new Size(80, 10));
+        Assert.Equal(3, size.Height);
+    }
+
+    [Fact]
+    public void Measure_TrailingNewline_CorrectLineCount()
+    {
+        // "hello\n" should be 2 lines (text line + empty line after newline)
+        TypeText("hello");
+        InsertNewline();
+
+        var size = _node.Measure(new Size(80, 10));
+        Assert.Equal(2, size.Height);
+    }
+
+    [Fact]
+    public void Measure_TwoTrailingNewlines_CorrectLineCount()
+    {
+        // "hello\n\n" should be 3 lines, not 4
+        TypeText("hello");
+        InsertNewline();
+        InsertNewline();
 
         var size = _node.Measure(new Size(80, 10));
         Assert.Equal(3, size.Height);

--- a/tests/Termina.Tests/Layout/TextAreaNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextAreaNodeTests.cs
@@ -281,6 +281,26 @@ public class TextAreaNodeTests : IDisposable
     }
 
     [Fact]
+    public void Enter_ClearsInputAfterSubmit()
+    {
+        TypeText("hello world");
+        Submit();
+
+        Assert.Equal("", _node.Text);
+    }
+
+    [Fact]
+    public void Enter_ClearsPasteAndTextAfterSubmit()
+    {
+        // Paste + type + submit should clear everything
+        _node.HandlePaste(new PasteEvent("pasted\ncontent"));
+        TypeText("typed");
+        Submit();
+
+        Assert.Equal("", _node.Text);
+    }
+
+    [Fact]
     public void Enter_SubmitsFullMultiLineContent()
     {
         string? submitted = null;

--- a/tests/Termina.Tests/Layout/TextInputNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextInputNodeTests.cs
@@ -40,16 +40,19 @@ public class TextInputNodeTests : IDisposable
     }
 
     [Fact]
-    public void HandleInput_Enter_DoesNotClearText()
+    public void HandleInput_Enter_ClearsTextAfterSubmit()
     {
         // Type some text
         TypeText("test text");
 
-        // Press Enter
+        string? submitted = null;
+        _node.Submitted.Subscribe(t => submitted = t);
+
+        // Press Enter — submits and clears
         _node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
 
-        // Text should NOT be cleared - ViewModel decides when to clear
-        Assert.Equal("test text", _node.Text);
+        Assert.Equal("test text", submitted);
+        Assert.Equal("", _node.Text);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fix cursor jumping up one line after consecutive Alt+Enter newlines — `ComputeWrappedLines` was creating a duplicate empty `WrappedLine` for trailing newlines
- Fix submit (Enter) clearing paste summaries but leaving typed text — `PerformSubmit()` now clears the entire input state (segments, text, cursor, selection)
- Add git workflow rules to CLAUDE.md to prevent direct commits to protected branches

Closes #161

## Test plan
- [x] Regression test: `DoubleNewline_ThenType_CursorStaysOnCorrectLine`
- [x] Measure accuracy: `Measure_TrailingNewline_CorrectLineCount`, `Measure_TwoTrailingNewlines_CorrectLineCount`
- [x] Submit clearing: `Enter_ClearsInputAfterSubmit`, `Enter_ClearsPasteAndTextAfterSubmit`
- [x] All 977 tests pass