### PR TITLE
Add clipboard copy UX and feedback APIs

### DIFF
--- a/benchmarks/Termina.Benchmarks/RenderingBenchmarks.cs
+++ b/benchmarks/Termina.Benchmarks/RenderingBenchmarks.cs
@@ -229,4 +229,5 @@ internal sealed class BenchmarkTerminal : IAnsiTerminal
     public void ExitAlternateScreen() { }
     public void EnableMouse() { }
     public void DisableMouse() { }
+    public void CopyToClipboard(string text) { }
 }

--- a/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryPage.cs
@@ -47,13 +47,13 @@ public sealed class ClipboardGalleryPage : ReactivePage<ClipboardGalleryViewMode
                 _clipboardService,
                 "https://auth.openai.com/oauth/authorize?client_id=demo-client&redirect_uri=http://localhost:5199/callback&scope=api.model.read%20model.request")
             .WithForeground(Color.White)
-            .WithHint("Press Enter to copy this URL");
+            .WithHint("Use Shift+Arrows to select, Enter or Ctrl+C to copy");
 
         _accessToken = new CopyableTextNode(
                 _clipboardService,
                 "sk-demo-4a0f8ea7f0b34d1e9a6cde8f4ab0f1c2")
             .WithForeground(Color.White)
-            .WithHint("Press Enter to copy this token");
+            .WithHint("Use Ctrl+A to select all, Enter or Ctrl+C to copy");
 
         _pasteInput = new TextInputNode()
             .WithPlaceholder("Paste text here with Ctrl+Shift+V or your terminal paste shortcut...");
@@ -79,10 +79,12 @@ public sealed class ClipboardGalleryPage : ReactivePage<ClipboardGalleryViewMode
                             .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_accessToken))
                             .WithChild(new EmptyNode().Height(1))
                             .WithChild(new TextNode("  Paste Validation Input").WithForeground(Color.BrightCyan).Height(1))
-                            .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_pasteInput).Height(1)))
+                            .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_pasteInput).Height(1))
+                            .WithChild(new EmptyNode().Height(1))
+                            .WithChild(new TextNode($"  Trace Log: {ViewModel.TraceFilePath}").WithForeground(Color.BrightBlack)))
                     .Fill())
             .WithChild(
-                new TextNode("[Tab/Shift+Tab] Switch focus  [Enter] Copy focused value  [Ctrl+Shift+V] Paste  [Esc] Menu")
+                new TextNode("[Tab/Shift+Tab] Focus  [Shift+Arrows] Select  [Ctrl+A] All  [Enter/Ctrl+C] Copy  [Ctrl+Shift+V] Paste  [Esc] Menu")
                     .WithForeground(Color.BrightBlack)
                     .NoWrap()
                     .Height(1))

--- a/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryPage.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Clipboard;
+using Termina.Extensions;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// Gallery page for clipboard copy and paste behavior.
+/// </summary>
+public sealed class ClipboardGalleryPage : ReactivePage<ClipboardGalleryViewModel>
+{
+    private readonly IClipboardService _clipboardService;
+    private CopyableTextNode _oauthUrl = null!;
+    private CopyableTextNode _accessToken = null!;
+    private TextInputNode _pasteInput = null!;
+
+    public ClipboardGalleryPage(IClipboardService clipboardService)
+    {
+        _clipboardService = clipboardService;
+    }
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+
+        KeyBindings.Register(ConsoleKey.Escape, () => Navigate("/menu"));
+        KeyBindings.Register(ConsoleKey.Tab, CycleFocusForward);
+        KeyBindings.Register(ConsoleKey.Tab, ConsoleModifiers.Shift, CycleFocusBackward);
+
+        _pasteInput.TextChanged
+            .Subscribe(text => ViewModel.SetStatus($"Input length: {text.Length}"))
+            .DisposeWith(Subscriptions);
+
+        Focus.SetFocus(_oauthUrl);
+    }
+
+    protected override void OnBound()
+    {
+        _oauthUrl = new CopyableTextNode(
+                _clipboardService,
+                "https://auth.openai.com/oauth/authorize?client_id=demo-client&redirect_uri=http://localhost:5199/callback&scope=api.model.read%20model.request")
+            .WithForeground(Color.White)
+            .WithHint("Press Enter to copy this URL");
+
+        _accessToken = new CopyableTextNode(
+                _clipboardService,
+                "sk-demo-4a0f8ea7f0b34d1e9a6cde8f4ab0f1c2")
+            .WithForeground(Color.White)
+            .WithHint("Press Enter to copy this token");
+
+        _pasteInput = new TextInputNode()
+            .WithPlaceholder("Paste text here with Ctrl+Shift+V or your terminal paste shortcut...");
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Clipboard Gallery")
+                    .WithBorder(BorderStyle.Double)
+                    .WithBorderColor(Color.Green)
+                    .WithContent(
+                        Layouts.Vertical()
+                            .WithChild(
+                                new TextNode("\n  Validate terminal-native clipboard copy and paste behavior.\n")
+                                    .WithForeground(Color.Gray))
+                            .WithChild(new TextNode("  OAuth URL").WithForeground(Color.BrightCyan).Height(1))
+                            .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_oauthUrl))
+                            .WithChild(new EmptyNode().Height(1))
+                            .WithChild(new TextNode("  Access Token").WithForeground(Color.BrightCyan).Height(1))
+                            .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_accessToken))
+                            .WithChild(new EmptyNode().Height(1))
+                            .WithChild(new TextNode("  Paste Validation Input").WithForeground(Color.BrightCyan).Height(1))
+                            .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_pasteInput).Height(1)))
+                    .Fill())
+            .WithChild(
+                new TextNode("[Tab/Shift+Tab] Switch focus  [Enter] Copy focused value  [Ctrl+Shift+V] Paste  [Esc] Menu")
+                    .WithForeground(Color.BrightBlack)
+                    .NoWrap()
+                    .Height(1))
+            .WithChild(
+                ViewModel.StatusMessage
+                    .Select<string, ILayoutNode>(msg => new TextNode(msg).WithForeground(Color.White))
+                    .AsLayout()
+                    .Height(1));
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryPage.cs
@@ -5,6 +5,7 @@ using R3;
 using Termina.Clipboard;
 using Termina.Extensions;
 using Termina.Layout;
+using Termina.Notifications;
 using Termina.Reactive;
 using Termina.Rendering;
 using Termina.Terminal;
@@ -17,13 +18,15 @@ namespace Termina.Demo.Gallery.Pages;
 public sealed class ClipboardGalleryPage : ReactivePage<ClipboardGalleryViewModel>
 {
     private readonly IClipboardService _clipboardService;
+    private readonly IToastService _toastService;
     private CopyableTextNode _oauthUrl = null!;
     private CopyableTextNode _accessToken = null!;
     private TextInputNode _pasteInput = null!;
 
-    public ClipboardGalleryPage(IClipboardService clipboardService)
+    public ClipboardGalleryPage(IClipboardService clipboardService, IToastService toastService)
     {
         _clipboardService = clipboardService;
+        _toastService = toastService;
     }
 
     public override void OnNavigatedTo()
@@ -45,14 +48,21 @@ public sealed class ClipboardGalleryPage : ReactivePage<ClipboardGalleryViewMode
     {
         _oauthUrl = new CopyableTextNode(
                 _clipboardService,
-                "https://auth.openai.com/oauth/authorize?client_id=demo-client&redirect_uri=http://localhost:5199/callback&scope=api.model.read%20model.request")
+                "https://auth.openai.com/oauth/authorize?client_id=demo-client&redirect_uri=http://localhost:5199/callback&scope=api.model.read%20model.request",
+                _toastService)
             .WithForeground(Color.White)
+            .WithFeedbackMode(CopyFeedbackMode.Toast)
+            .WithToastPosition(ToastPosition.TopRight)
             .WithHint("Use Shift+Arrows to select, Enter or Ctrl+C to copy");
 
         _accessToken = new CopyableTextNode(
                 _clipboardService,
-                "sk-demo-4a0f8ea7f0b34d1e9a6cde8f4ab0f1c2")
+                "sk-demo-4a0f8ea7f0b34d1e9a6cde8f4ab0f1c2",
+                _toastService)
             .WithForeground(Color.White)
+            .WithFeedbackMode(CopyFeedbackMode.InlineIndicator)
+            .WithInlineIndicator("✓ Copied", Color.BrightGreen)
+            .WithCopyBindings(new CopyKeyBinding(ConsoleKey.Enter), new CopyKeyBinding(ConsoleKey.C, ConsoleModifiers.Control))
             .WithHint("Use Ctrl+A to select all, Enter or Ctrl+C to copy");
 
         _pasteInput = new TextInputNode()
@@ -75,8 +85,12 @@ public sealed class ClipboardGalleryPage : ReactivePage<ClipboardGalleryViewMode
                             .WithChild(new TextNode("  OAuth URL").WithForeground(Color.BrightCyan).Height(1))
                             .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_oauthUrl))
                             .WithChild(new EmptyNode().Height(1))
+                            .WithChild(new TextNode("    Toast feedback at top-right").WithForeground(Color.BrightBlack).Height(1))
+                            .WithChild(new EmptyNode().Height(1))
                             .WithChild(new TextNode("  Access Token").WithForeground(Color.BrightCyan).Height(1))
                             .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_accessToken))
+                            .WithChild(new EmptyNode().Height(1))
+                            .WithChild(new TextNode("    Inline green check after copy").WithForeground(Color.BrightBlack).Height(1))
                             .WithChild(new EmptyNode().Height(1))
                             .WithChild(new TextNode("  Paste Validation Input").WithForeground(Color.BrightCyan).Height(1))
                             .WithChild(Layouts.Horizontal().WithChild(new TextNode("  ").Width(2)).WithChild(_pasteInput).Height(1))

--- a/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryViewModel.cs
@@ -11,7 +11,16 @@ namespace Termina.Demo.Gallery.Pages;
 /// </summary>
 public sealed class ClipboardGalleryViewModel : ReactiveViewModel
 {
+    private readonly TraceFileInfo _traceFileInfo;
+
+    public ClipboardGalleryViewModel(TraceFileInfo traceFileInfo)
+    {
+        _traceFileInfo = traceFileInfo;
+    }
+
     public ReactiveProperty<string> StatusMessage { get; } = new("Try copying one of the values or paste into the input field.");
+
+    public string TraceFilePath => _traceFileInfo.FilePath;
 
     public void SetStatus(string status)
     {

--- a/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryViewModel.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Reactive;
+
+namespace Termina.Demo.Gallery.Pages;
+
+/// <summary>
+/// ViewModel for the clipboard gallery page.
+/// </summary>
+public sealed class ClipboardGalleryViewModel : ReactiveViewModel
+{
+    public ReactiveProperty<string> StatusMessage { get; } = new("Try copying one of the values or paste into the input field.");
+
+    public void SetStatus(string status)
+    {
+        StatusMessage.Value = status;
+    }
+
+    public override void Dispose()
+    {
+        StatusMessage.Dispose();
+        base.Dispose();
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/GalleryMenuPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GalleryMenuPage.cs
@@ -65,7 +65,7 @@ public class GalleryMenuPage : ReactivePage<GalleryMenuViewModel>
                             .WithChild(_menuList))
                     .Fill())
             .WithChild(
-                new TextNode("[↑/↓] Navigate  [Enter] Select  [1-4] Quick Select  [Q] Quit")
+                new TextNode("[↑/↓] Navigate  [Enter] Select  [1-5] Quick Select  [Q] Quit")
                     .WithForeground(Color.BrightBlack)
                     .Height(1));
     }

--- a/demos/Termina.Demo.Gallery/Pages/GalleryMenuViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GalleryMenuViewModel.cs
@@ -14,6 +14,7 @@ public partial class GalleryMenuViewModel : ReactiveViewModel
     {
         new("Selection Lists", "Single/multi-select, numbered, Other option, rich content", "/selection"),
         new("Text Input", "Text fields, placeholder text, submission handling", "/textinput"),
+        new("Clipboard", "OSC 52 copy, toasts, and paste validation", "/clipboard"),
         new("Layouts", "Vertical, horizontal, grid, panels, borders", "/layouts"),
         new("Animations", "Spinners, streaming text, progress indicators", "/animations")
     };

--- a/demos/Termina.Demo.Gallery/Program.cs
+++ b/demos/Termina.Demo.Gallery/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddTermina("/menu", termina =>
     termina.RegisterRoute<GalleryMenuPage, GalleryMenuViewModel>("/menu", NavigationBehavior.PreserveState);
     termina.RegisterRoute<SelectionListGalleryPage, SelectionListGalleryViewModel>("/selection", NavigationBehavior.PreserveState);
     termina.RegisterRoute<TextInputGalleryPage, TextInputGalleryViewModel>("/textinput", NavigationBehavior.PreserveState);
+    termina.RegisterRoute<ClipboardGalleryPage, ClipboardGalleryViewModel>("/clipboard", NavigationBehavior.PreserveState);
     termina.RegisterRoute<LayoutGalleryPage, LayoutGalleryViewModel>("/layouts", NavigationBehavior.PreserveState);
     termina.RegisterRoute<AnimationsGalleryPage, AnimationsGalleryViewModel>("/animations", NavigationBehavior.PreserveState);
 });

--- a/demos/Termina.Demo.Gallery/Program.cs
+++ b/demos/Termina.Demo.Gallery/Program.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Termina.Demo.Gallery;
+using Termina.Diagnostics;
 using Termina.Demo.Gallery.Pages;
 using Termina.Hosting;
 using Termina.Input;
@@ -8,6 +11,13 @@ using Termina.Pages;
 var testMode = args.Contains("--test");
 
 var builder = Host.CreateApplicationBuilder(args);
+
+var traceDir = Path.Combine(Path.GetTempPath(), "termina-logs");
+Directory.CreateDirectory(traceDir);
+var traceFile = Path.Combine(traceDir, $"gallery-trace-{DateTime.Now:yyyyMMdd-HHmmss}.log");
+
+builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+builder.Services.AddSingleton(new TraceFileInfo(traceFile));
 
 // Set up input source based on mode
 VirtualInputSource? scriptedInput = null;

--- a/demos/Termina.Demo.Gallery/TraceFileInfo.cs
+++ b/demos/Termina.Demo.Gallery/TraceFileInfo.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Demo.Gallery;
+
+/// <summary>
+/// Holds the gallery trace file location for display in the UI.
+/// </summary>
+public sealed record TraceFileInfo(string FilePath);

--- a/docs/advanced/clipboard-and-feedback.md
+++ b/docs/advanced/clipboard-and-feedback.md
@@ -1,0 +1,63 @@
+# Clipboard And Feedback
+
+Termina's clipboard support is terminal-native first. It is designed to work in local terminals, remote SSH sessions, and tmux-based workflows without dropping into platform-specific clipboard commands.
+
+## Clipboard Architecture
+
+Clipboard requests flow through `IClipboardService`, which fans out to one or more transports.
+
+- `Osc52ClipboardTransport` sends OSC 52 clipboard sequences through the active terminal
+- `TmuxClipboardTransport` integrates with tmux when the `TMUX` environment variable is present
+
+This keeps the application-facing API simple:
+
+```csharp
+var copied = clipboardService.Copy(url);
+```
+
+The service returns `true` when at least one transport reports success.
+
+## Why Multiple Transports?
+
+Terminal clipboard behavior varies across terminal emulators and multiplexers.
+
+- OSC 52 is the clean terminal-native path
+- tmux often needs explicit clipboard handoff even when OSC 52 is emitted correctly
+
+Using transports lets Termina keep those concerns out of pages and components.
+
+## Toast Notifications
+
+`IToastService` exposes a single active toast as an observable. `TerminaApplication` hosts the overlay globally, so pages do not need to render their own popup shell.
+
+```csharp
+toastService.Show(
+    "Copied to clipboard",
+    new ToastOptions(
+        Duration: TimeSpan.FromSeconds(2),
+        Position: ToastPosition.TopRight));
+```
+
+This keeps feedback decoupled from the component that triggered it.
+
+## Inline Feedback
+
+If you do not want a global toast, components like `CopyableTextNode` can show local feedback instead.
+
+Examples:
+
+- a green check mark beside the copied value
+- a short `Copied` label near the field
+- both inline feedback and a toast
+
+## Diagnostics
+
+When file tracing is enabled, clipboard operations produce trace output through `TerminaTrace`.
+
+Useful trace points include:
+
+- focused copyable node input handling
+- clipboard transport selection and success
+- toast emission and rendering
+
+The gallery demo enables file tracing and surfaces the trace log path on the Clipboard page for easier troubleshooting.

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -16,6 +16,10 @@ Learn to write automated tests for your Termina applications using `VirtualInput
 
 Build reusable custom layout nodes that integrate with Termina's rendering and measurement systems.
 
+### [Clipboard And Feedback](/advanced/clipboard-and-feedback)
+
+Understand Termina's terminal-native clipboard transports, toast notifications, and inline copy feedback patterns.
+
 ### [AOT Compilation](/advanced/aot)
 
 Configure your Termina application for Native AOT publishing, enabling single-file executables with fast startup.

--- a/docs/components/copyable-text-node.md
+++ b/docs/components/copyable-text-node.md
@@ -1,0 +1,104 @@
+# CopyableTextNode
+
+`CopyableTextNode` is a focusable, read-only text component for values users need to copy out of a TUI: OAuth URLs, tokens, connection strings, and diagnostic output.
+
+It supports keyboard selection, configurable copy shortcuts, and copy feedback via toast notifications, inline indicators, or both.
+
+## Basic Usage
+
+```csharp
+public sealed class AuthPage : ReactivePage<AuthViewModel>
+{
+    private readonly IClipboardService _clipboard;
+    private readonly IToastService _toasts;
+
+    public AuthPage(IClipboardService clipboard, IToastService toasts)
+    {
+        _clipboard = clipboard;
+        _toasts = toasts;
+    }
+
+    protected override ILayoutNode BuildLayout()
+    {
+        return new CopyableTextNode(
+                _clipboard,
+                ViewModel.DeviceCodeUrl,
+                _toasts)
+            .WithHint("Press Enter to copy this URL");
+    }
+}
+```
+
+## Keyboard Behavior
+
+| Key | Action |
+|-----|--------|
+| `Left/Right` | Move the caret |
+| `Shift+Left/Right` | Extend selection |
+| `Home/End` | Jump to start or end |
+| `Ctrl+A` | Select all |
+| `Enter` | Copy selected text, or the full value when nothing is selected |
+| `Ctrl+C` | Copy selected text, or the full value when nothing is selected |
+| `Escape` | Clear the current selection |
+
+## Custom Copy Bindings
+
+You can override the default `Enter` and `Ctrl+C` bindings per node.
+
+```csharp
+new CopyableTextNode(_clipboard, ViewModel.Token, _toasts)
+    .WithCopyBindings(
+        new CopyKeyBinding(ConsoleKey.F5),
+        new CopyKeyBinding(ConsoleKey.Enter));
+```
+
+## Copy Feedback Modes
+
+`CopyableTextNode` separates the copy action from how success is shown.
+
+```csharp
+new CopyableTextNode(_clipboard, ViewModel.Token, _toasts)
+    .WithFeedbackMode(CopyFeedbackMode.ToastAndInline)
+    .WithToastPosition(ToastPosition.TopRight)
+    .WithInlineIndicator("✓ Copied", Color.BrightGreen)
+    .WithFeedbackDuration(TimeSpan.FromSeconds(1.5));
+```
+
+Available feedback modes:
+
+- `CopyFeedbackMode.None`
+- `CopyFeedbackMode.Toast`
+- `CopyFeedbackMode.InlineIndicator`
+- `CopyFeedbackMode.ToastAndInline`
+
+## Toast Placement
+
+Toasts are rendered globally by `TerminaApplication`, but placement is configurable per toast request.
+
+Supported positions:
+
+- `ToastPosition.BottomRight`
+- `ToastPosition.BottomCenter`
+- `ToastPosition.BottomLeft`
+- `ToastPosition.TopRight`
+- `ToastPosition.TopCenter`
+- `ToastPosition.TopLeft`
+
+## Transport Behavior
+
+Clipboard writes go through `IClipboardService`, which can use multiple transports.
+
+- `OSC 52` terminal clipboard transport for terminal-native copy
+- `tmux` clipboard transport when running inside tmux
+
+`CopyableTextNode` does not know or care which transport succeeded. It only reacts to the boolean success returned by the clipboard service.
+
+## When to Use It
+
+Use `CopyableTextNode` when:
+
+- the content is read-only
+- users need to copy all or part of a value
+- you want focusable keyboard selection without exposing a text editor
+
+Use `TextInputNode` or `TextAreaNode` when the content should be editable.

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -17,6 +17,7 @@ Termina provides a set of built-in layout nodes (components) for building termin
 |-----------|-------------|
 | [TextInputNode](/components/text-input-node) | Single-line text input with cursor |
 | [TextAreaNode](/components/text-area-node) | Multi-line text input with word wrap and vertical scrolling |
+| [CopyableTextNode](/components/copyable-text-node) | Read-only text with keyboard selection and clipboard support |
 | [SelectionListNode](/components/selection-list-node) | Interactive list selection with keyboard navigation |
 
 ## Container Components

--- a/docs/concepts/input-handling.md
+++ b/docs/concepts/input-handling.md
@@ -369,6 +369,25 @@ Input.OfType<PasteEvent>()
 If the focused component implements `IPasteReceiver` (like `TextInputNode`), paste events are routed directly to it. `TextInputNode` shows a summary placeholder and submits the full content on Enter. The event only reaches `ViewModel.Input` if no `IPasteReceiver` component has focus.
 :::
 
+## Clipboard Copy
+
+Termina also supports terminal-native clipboard copy for read-only values through `IClipboardService` and components such as `CopyableTextNode`.
+
+```csharp
+var node = new CopyableTextNode(clipboardService, ViewModel.AuthUrl, toastService)
+    .WithFeedbackMode(CopyFeedbackMode.Toast)
+    .WithToastPosition(ToastPosition.TopRight);
+```
+
+`CopyableTextNode` handles its own keyboard interactions when focused:
+
+- caret movement with `Left/Right`
+- selection with `Shift+Left/Right`
+- copy with configurable bindings such as `Enter` and `Ctrl+C`
+- optional success feedback via toast, inline indicator, or both
+
+Clipboard transport details live behind `IClipboardService`, so pages do not need to branch on `tmux`, `ssh`, or terminal type.
+
 ## Input Filtering with Rx
 
 ### Filter by Type

--- a/src/Termina/Clipboard/IClipboardService.cs
+++ b/src/Termina/Clipboard/IClipboardService.cs
@@ -1,0 +1,12 @@
+namespace Termina.Clipboard;
+
+/// <summary>
+/// Copies text to the user's clipboard using the active terminal.
+/// </summary>
+public interface IClipboardService
+{
+    /// <summary>
+    /// Copy the provided text to the clipboard.
+    /// </summary>
+    void Copy(string text);
+}

--- a/src/Termina/Clipboard/IClipboardService.cs
+++ b/src/Termina/Clipboard/IClipboardService.cs
@@ -8,5 +8,6 @@ public interface IClipboardService
     /// <summary>
     /// Copy the provided text to the clipboard.
     /// </summary>
-    void Copy(string text);
+    /// <returns>True when at least one transport reported success.</returns>
+    bool Copy(string text);
 }

--- a/src/Termina/Clipboard/IClipboardTransport.cs
+++ b/src/Termina/Clipboard/IClipboardTransport.cs
@@ -1,0 +1,22 @@
+namespace Termina.Clipboard;
+
+/// <summary>
+/// A clipboard transport capable of sending copy requests through a specific channel.
+/// </summary>
+internal interface IClipboardTransport
+{
+    /// <summary>
+    /// Human-readable transport name for tracing.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Whether this transport applies in the current environment.
+    /// </summary>
+    bool CanHandle();
+
+    /// <summary>
+    /// Attempt to copy the provided text. Returns true on known success.
+    /// </summary>
+    bool TryCopy(string text);
+}

--- a/src/Termina/Clipboard/Osc52ClipboardTransport.cs
+++ b/src/Termina/Clipboard/Osc52ClipboardTransport.cs
@@ -1,0 +1,27 @@
+using Termina.Diagnostics;
+using Termina.Terminal;
+
+namespace Termina.Clipboard;
+
+internal sealed class Osc52ClipboardTransport : IClipboardTransport
+{
+    private readonly IAnsiTerminal _terminal;
+
+    public Osc52ClipboardTransport(IAnsiTerminal terminal)
+    {
+        _terminal = terminal;
+    }
+
+    public string Name => "osc52";
+
+    public bool CanHandle() => true;
+
+    public bool TryCopy(string text)
+    {
+        TerminaTrace.Platform.Info(this, "OSC52 clipboard transport: textLength={0}", text.Length);
+        _terminal.CopyToClipboard(text);
+        _terminal.Flush();
+        TerminaTrace.Platform.Debug(this, "OSC52 clipboard transport flushed");
+        return true;
+    }
+}

--- a/src/Termina/Clipboard/TerminalClipboardService.cs
+++ b/src/Termina/Clipboard/TerminalClipboardService.cs
@@ -1,22 +1,46 @@
+using Termina.Diagnostics;
 using Termina.Notifications;
-using Termina.Terminal;
 
 namespace Termina.Clipboard;
 
 internal sealed class TerminalClipboardService : IClipboardService
 {
-    private readonly IAnsiTerminal _terminal;
+    private readonly IReadOnlyList<IClipboardTransport> _transports;
     private readonly IToastService _toastService;
 
-    public TerminalClipboardService(IAnsiTerminal terminal, IToastService toastService)
+    public TerminalClipboardService(IEnumerable<IClipboardTransport> transports, IToastService toastService)
     {
-        _terminal = terminal;
+        _transports = transports.ToList();
         _toastService = toastService;
     }
 
     public void Copy(string text)
     {
-        _terminal.CopyToClipboard(text);
+        TerminaTrace.Platform.Info(this, "Clipboard copy requested: textLength={0}", text.Length);
+
+        var attempted = false;
+        var successful = false;
+
+        foreach (var transport in _transports)
+        {
+            if (!transport.CanHandle())
+                continue;
+
+            attempted = true;
+            var copied = transport.TryCopy(text);
+            successful |= copied;
+            TerminaTrace.Platform.Debug(this, "Clipboard transport {0} attempted, success={1}", transport.Name, copied);
+        }
+
+        if (!attempted)
+        {
+            TerminaTrace.Platform.Warning(this, "No clipboard transports were available");
+        }
+        else
+        {
+            TerminaTrace.Platform.Info(this, "Clipboard transports completed: success={0}", successful);
+        }
+
         _toastService.Show("Copied to clipboard");
     }
 }

--- a/src/Termina/Clipboard/TerminalClipboardService.cs
+++ b/src/Termina/Clipboard/TerminalClipboardService.cs
@@ -1,0 +1,22 @@
+using Termina.Notifications;
+using Termina.Terminal;
+
+namespace Termina.Clipboard;
+
+internal sealed class TerminalClipboardService : IClipboardService
+{
+    private readonly IAnsiTerminal _terminal;
+    private readonly IToastService _toastService;
+
+    public TerminalClipboardService(IAnsiTerminal terminal, IToastService toastService)
+    {
+        _terminal = terminal;
+        _toastService = toastService;
+    }
+
+    public void Copy(string text)
+    {
+        _terminal.CopyToClipboard(text);
+        _toastService.Show("Copied to clipboard");
+    }
+}

--- a/src/Termina/Clipboard/TerminalClipboardService.cs
+++ b/src/Termina/Clipboard/TerminalClipboardService.cs
@@ -1,20 +1,17 @@
 using Termina.Diagnostics;
-using Termina.Notifications;
 
 namespace Termina.Clipboard;
 
 internal sealed class TerminalClipboardService : IClipboardService
 {
     private readonly IReadOnlyList<IClipboardTransport> _transports;
-    private readonly IToastService _toastService;
 
-    public TerminalClipboardService(IEnumerable<IClipboardTransport> transports, IToastService toastService)
+    public TerminalClipboardService(IEnumerable<IClipboardTransport> transports)
     {
         _transports = transports.ToList();
-        _toastService = toastService;
     }
 
-    public void Copy(string text)
+    public bool Copy(string text)
     {
         TerminaTrace.Platform.Info(this, "Clipboard copy requested: textLength={0}", text.Length);
 
@@ -41,6 +38,6 @@ internal sealed class TerminalClipboardService : IClipboardService
             TerminaTrace.Platform.Info(this, "Clipboard transports completed: success={0}", successful);
         }
 
-        _toastService.Show("Copied to clipboard");
+        return successful;
     }
 }

--- a/src/Termina/Clipboard/TmuxClipboardTransport.cs
+++ b/src/Termina/Clipboard/TmuxClipboardTransport.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using Termina.Diagnostics;
+
+namespace Termina.Clipboard;
+
+internal sealed class TmuxClipboardTransport : IClipboardTransport
+{
+    public string Name => "tmux";
+
+    public bool CanHandle() => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TMUX"));
+
+    public bool TryCopy(string text)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo("tmux")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            startInfo.ArgumentList.Add("set-buffer");
+            startInfo.ArgumentList.Add("-w");
+            startInfo.ArgumentList.Add("--");
+            startInfo.ArgumentList.Add(text);
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                TerminaTrace.Platform.Warning(this, "tmux clipboard transport could not start");
+                return false;
+            }
+
+            process.WaitForExit(1000);
+            if (!process.HasExited)
+            {
+                TerminaTrace.Platform.Warning(this, "tmux clipboard transport timed out");
+                try
+                {
+                    process.Kill();
+                }
+                catch
+                {
+                }
+
+                return false;
+            }
+
+            if (process.ExitCode == 0)
+            {
+                TerminaTrace.Platform.Debug(this, "tmux clipboard transport completed successfully");
+                return true;
+            }
+
+            var error = process.StandardError.ReadToEnd();
+            TerminaTrace.Platform.Warning(this, "tmux clipboard transport failed: exitCode={0}, error={1}", process.ExitCode, error);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            TerminaTrace.Platform.Warning(this, "tmux clipboard transport threw: {0}", ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/Termina/Hosting/TerminaServiceCollectionExtensions.cs
+++ b/src/Termina/Hosting/TerminaServiceCollectionExtensions.cs
@@ -3,7 +3,9 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Termina.Clipboard;
 using Termina.Input;
+using Termina.Notifications;
 using Termina.Terminal;
 
 namespace Termina.Hosting;
@@ -52,6 +54,8 @@ public static class TerminaServiceCollectionExtensions
 
         // Register IAnsiTerminal if not already registered
         services.TryAddSingleton<IAnsiTerminal, AnsiTerminal>();
+        services.TryAddSingleton<IToastService, ToastService>();
+        services.TryAddSingleton<IClipboardService, TerminalClipboardService>();
 
         // Register TerminaApplication
         services.AddSingleton<TerminaApplication>(sp =>

--- a/src/Termina/Hosting/TerminaServiceCollectionExtensions.cs
+++ b/src/Termina/Hosting/TerminaServiceCollectionExtensions.cs
@@ -55,6 +55,8 @@ public static class TerminaServiceCollectionExtensions
         // Register IAnsiTerminal if not already registered
         services.TryAddSingleton<IAnsiTerminal, AnsiTerminal>();
         services.TryAddSingleton<IToastService, ToastService>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IClipboardTransport, Osc52ClipboardTransport>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IClipboardTransport, TmuxClipboardTransport>());
         services.TryAddSingleton<IClipboardService, TerminalClipboardService>();
 
         // Register TerminaApplication

--- a/src/Termina/Layout/CopyFeedbackMode.cs
+++ b/src/Termina/Layout/CopyFeedbackMode.cs
@@ -1,0 +1,12 @@
+namespace Termina.Layout;
+
+/// <summary>
+/// How a copyable node should acknowledge a successful copy action.
+/// </summary>
+public enum CopyFeedbackMode
+{
+    None,
+    Toast,
+    InlineIndicator,
+    ToastAndInline
+}

--- a/src/Termina/Layout/CopyKeyBinding.cs
+++ b/src/Termina/Layout/CopyKeyBinding.cs
@@ -1,0 +1,6 @@
+namespace Termina.Layout;
+
+/// <summary>
+/// Keyboard gesture for copy actions inside a copyable text node.
+/// </summary>
+public sealed record CopyKeyBinding(ConsoleKey Key, ConsoleModifiers Modifiers = 0);

--- a/src/Termina/Layout/CopyableTextNode.cs
+++ b/src/Termina/Layout/CopyableTextNode.cs
@@ -1,6 +1,7 @@
 using R3;
 using Termina.Clipboard;
 using Termina.Diagnostics;
+using Termina.Notifications;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -12,15 +13,26 @@ namespace Termina.Layout;
 public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
 {
     private readonly IClipboardService _clipboardService;
+    private readonly IToastService? _toastService;
     private readonly Subject<Unit> _invalidated = new();
+    private readonly TimeProvider _timeProvider;
+    private IDisposable? _inlineIndicatorSubscription;
+    private IReadOnlyList<CopyKeyBinding> _copyBindings =
+    [
+        new(ConsoleKey.Enter),
+        new(ConsoleKey.C, ConsoleModifiers.Control)
+    ];
     private int _cursorPosition;
     private int _selectionStart = -1;
+    private bool _showInlineIndicator;
     private bool _hasFocus;
     private bool _disposed;
 
-    public CopyableTextNode(IClipboardService clipboardService, string content)
+    public CopyableTextNode(IClipboardService clipboardService, string content, IToastService? toastService = null, TimeProvider? timeProvider = null)
     {
         _clipboardService = clipboardService;
+        _toastService = toastService;
+        _timeProvider = timeProvider ?? TimeProvider.System;
         Content = content ?? string.Empty;
         WidthConstraint = new SizeConstraint.Fill();
         HeightConstraint = SizeConstraint.AutoSize();
@@ -39,6 +51,16 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
     public Color SelectionForeground { get; private set; } = Color.Black;
 
     public Color SelectionBackground { get; private set; } = Color.BrightYellow;
+
+    public Color InlineIndicatorForeground { get; private set; } = Color.BrightGreen;
+
+    public string InlineIndicatorText { get; private set; } = "✓";
+
+    public CopyFeedbackMode FeedbackMode { get; private set; } = CopyFeedbackMode.Toast;
+
+    public ToastPosition ToastPosition { get; private set; } = ToastPosition.BottomRight;
+
+    public TimeSpan FeedbackDuration { get; private set; } = TimeSpan.FromSeconds(2);
 
     public bool CanFocus => true;
 
@@ -100,6 +122,40 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         return this;
     }
 
+    public CopyableTextNode WithCopyBindings(params CopyKeyBinding[] bindings)
+    {
+        _copyBindings = bindings is { Length: > 0 }
+            ? bindings.ToList()
+            : [new(ConsoleKey.Enter), new(ConsoleKey.C, ConsoleModifiers.Control)];
+        return this;
+    }
+
+    public CopyableTextNode WithFeedbackMode(CopyFeedbackMode mode)
+    {
+        FeedbackMode = mode;
+        return this;
+    }
+
+    public CopyableTextNode WithToastPosition(ToastPosition position)
+    {
+        ToastPosition = position;
+        return this;
+    }
+
+    public CopyableTextNode WithFeedbackDuration(TimeSpan duration)
+    {
+        FeedbackDuration = duration;
+        return this;
+    }
+
+    public CopyableTextNode WithInlineIndicator(string text, Color? foreground = null)
+    {
+        InlineIndicatorText = text;
+        if (foreground.HasValue)
+            InlineIndicatorForeground = foreground.Value;
+        return this;
+    }
+
     public void OnFocused()
     {
         _hasFocus = true;
@@ -126,7 +182,7 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
             SelectAll();
             handled = true;
         }
-        else if (key.Modifiers.HasFlag(ConsoleModifiers.Control) && key.Key == ConsoleKey.C)
+        else if (IsCopyBinding(key))
         {
             CopySelectionOrContent();
             handled = true;
@@ -135,7 +191,6 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         {
             handled = key.Key switch
             {
-                ConsoleKey.Enter => CopySelectionOrContent(),
                 ConsoleKey.LeftArrow => MoveCursor(-1, key.Modifiers),
                 ConsoleKey.RightArrow => MoveCursor(1, key.Modifiers),
                 ConsoleKey.Home => MoveToBoundary(0, key.Modifiers),
@@ -182,6 +237,15 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
 
         nodeContext.ResetColors();
 
+        if (_showInlineIndicator && bounds.Width > 0 && lineCount > 0)
+        {
+            var inlineText = InlineIndicatorText.Length > bounds.Width ? InlineIndicatorText[..bounds.Width] : InlineIndicatorText;
+            var indicatorX = Math.Max(0, bounds.Width - inlineText.Length);
+            nodeContext.SetForeground(InlineIndicatorForeground);
+            nodeContext.WriteAt(indicatorX, 0, inlineText);
+            nodeContext.ResetColors();
+        }
+
         if (hasHint && bounds.Height > lineCount)
         {
             nodeContext.SetForeground(_hasFocus ? Color.BrightBlack : Color.Gray);
@@ -196,6 +260,7 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
             return;
 
         _disposed = true;
+        _inlineIndicatorSubscription?.Dispose();
         _invalidated.OnCompleted();
         _invalidated.Dispose();
         base.Dispose();
@@ -205,8 +270,40 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
     {
         var textToCopy = HasSelection ? SelectedText : Content;
         TerminaTrace.Input.Info(this, "CopyableTextNode copy requested: contentLength={0}, selectionLength={1}", Content.Length, textToCopy.Length);
-        _clipboardService.Copy(textToCopy);
+        var success = _clipboardService.Copy(textToCopy);
+        ShowFeedback(success);
         return true;
+    }
+
+    private bool IsCopyBinding(ConsoleKeyInfo key)
+    {
+        return _copyBindings.Any(binding => binding.Key == key.Key && binding.Modifiers == key.Modifiers);
+    }
+
+    private void ShowFeedback(bool success)
+    {
+        if (!success)
+            return;
+
+        if (FeedbackMode is CopyFeedbackMode.Toast or CopyFeedbackMode.ToastAndInline)
+        {
+            _toastService?.Show("Copied to clipboard", new ToastOptions(FeedbackDuration, ToastPosition));
+        }
+
+        if (FeedbackMode is CopyFeedbackMode.InlineIndicator or CopyFeedbackMode.ToastAndInline)
+        {
+            _showInlineIndicator = true;
+            _inlineIndicatorSubscription?.Dispose();
+            _inlineIndicatorSubscription = Observable
+                .Interval(FeedbackDuration, _timeProvider)
+                .Take(1)
+                .Subscribe(_ =>
+                {
+                    _showInlineIndicator = false;
+                    Invalidate();
+                });
+            Invalidate();
+        }
     }
 
     private bool MoveCursor(int delta, ConsoleModifiers modifiers)

--- a/src/Termina/Layout/CopyableTextNode.cs
+++ b/src/Termina/Layout/CopyableTextNode.cs
@@ -1,0 +1,162 @@
+using R3;
+using Termina.Clipboard;
+using Termina.Components.Streaming;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// A focusable read-only text node that copies its full content when Enter is pressed.
+/// </summary>
+public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
+{
+    private readonly IClipboardService _clipboardService;
+    private readonly Subject<Unit> _invalidated = new();
+    private bool _hasFocus;
+    private bool _disposed;
+
+    public CopyableTextNode(IClipboardService clipboardService, string content)
+    {
+        _clipboardService = clipboardService;
+        Content = content ?? string.Empty;
+        WidthConstraint = new SizeConstraint.Fill();
+        HeightConstraint = SizeConstraint.AutoSize();
+    }
+
+    public string Content { get; private set; }
+
+    public string? Hint { get; private set; } = "Press Enter to copy";
+
+    public Color Foreground { get; private set; } = Color.White;
+
+    public Color FocusedForeground { get; private set; } = Color.Black;
+
+    public Color FocusedBackground { get; private set; } = Color.Cyan;
+
+    public bool CanFocus => true;
+
+    public bool HasFocus => _hasFocus;
+
+    public int FocusPriority => 5;
+
+    public Observable<Unit> Invalidated => _invalidated;
+
+    public CopyableTextNode WithContent(string content)
+    {
+        Content = content ?? string.Empty;
+        Invalidate();
+        return this;
+    }
+
+    public CopyableTextNode WithHint(string? hint)
+    {
+        Hint = hint;
+        Invalidate();
+        return this;
+    }
+
+    public CopyableTextNode WithForeground(Color color)
+    {
+        Foreground = color;
+        return this;
+    }
+
+    public CopyableTextNode WithFocusedColors(Color foreground, Color background)
+    {
+        FocusedForeground = foreground;
+        FocusedBackground = background;
+        return this;
+    }
+
+    public void OnFocused()
+    {
+        _hasFocus = true;
+        Invalidate();
+    }
+
+    public void OnBlurred()
+    {
+        _hasFocus = false;
+        Invalidate();
+    }
+
+    public bool HandleInput(ConsoleKeyInfo key)
+    {
+        if (key.Key != ConsoleKey.Enter)
+            return false;
+
+        _clipboardService.Copy(Content);
+        return true;
+    }
+
+    public override Size Measure(Size available)
+    {
+        var lines = GetLines(available.Width > 0 ? available.Width : Content.Length);
+        var hintHeight = string.IsNullOrWhiteSpace(Hint) ? 0 : 1;
+        return new Size(available.Width, lines.Count + hintHeight);
+    }
+
+    public override void Render(IRenderContext context, Rect bounds)
+    {
+        if (!bounds.HasArea)
+            return;
+
+        var nodeContext = context.CreateSubContext(bounds);
+        var lines = GetLines(bounds.Width);
+        var hasHint = !string.IsNullOrWhiteSpace(Hint);
+        var lineCount = hasHint
+            ? Math.Min(lines.Count, Math.Max(0, bounds.Height - 1))
+            : Math.Min(lines.Count, bounds.Height);
+
+        if (_hasFocus)
+        {
+            nodeContext.SetForeground(FocusedForeground);
+            nodeContext.SetBackground(FocusedBackground);
+            nodeContext.Fill(0, 0, bounds.Width, lineCount, ' ');
+        }
+        else
+        {
+            nodeContext.SetForeground(Foreground);
+        }
+
+        for (var i = 0; i < lineCount; i++)
+        {
+            nodeContext.WriteAt(0, i, lines[i]);
+        }
+
+        nodeContext.ResetColors();
+
+        if (hasHint && bounds.Height > lineCount)
+        {
+            nodeContext.SetForeground(_hasFocus ? Color.BrightBlack : Color.Gray);
+            nodeContext.WriteAt(0, lineCount, Hint!.Length > bounds.Width ? Hint[..bounds.Width] : Hint);
+            nodeContext.ResetColors();
+        }
+    }
+
+    public override void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        base.Dispose();
+    }
+
+    private List<string> GetLines(int width)
+    {
+        if (width <= 0)
+            return [string.Empty];
+
+        return WordWrapper.WrapLines(Content.Split('\n'), width);
+    }
+
+    private void Invalidate()
+    {
+        if (!_disposed)
+            _invalidated.OnNext(Unit.Default);
+    }
+}

--- a/src/Termina/Layout/CopyableTextNode.cs
+++ b/src/Termina/Layout/CopyableTextNode.cs
@@ -1,6 +1,6 @@
 using R3;
 using Termina.Clipboard;
-using Termina.Components.Streaming;
+using Termina.Diagnostics;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -13,6 +13,8 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
 {
     private readonly IClipboardService _clipboardService;
     private readonly Subject<Unit> _invalidated = new();
+    private int _cursorPosition;
+    private int _selectionStart = -1;
     private bool _hasFocus;
     private bool _disposed;
 
@@ -34,6 +36,10 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
 
     public Color FocusedBackground { get; private set; } = Color.Cyan;
 
+    public Color SelectionForeground { get; private set; } = Color.Black;
+
+    public Color SelectionBackground { get; private set; } = Color.BrightYellow;
+
     public bool CanFocus => true;
 
     public bool HasFocus => _hasFocus;
@@ -42,9 +48,27 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
 
     public Observable<Unit> Invalidated => _invalidated;
 
+    public bool HasSelection => _selectionStart >= 0 && _selectionStart != _cursorPosition;
+
+    public string SelectedText
+    {
+        get
+        {
+            if (!HasSelection)
+                return string.Empty;
+
+            var start = Math.Min(_selectionStart, _cursorPosition);
+            var end = Math.Max(_selectionStart, _cursorPosition);
+            return Content[start..end];
+        }
+    }
+
     public CopyableTextNode WithContent(string content)
     {
         Content = content ?? string.Empty;
+        _cursorPosition = Math.Min(_cursorPosition, Content.Length);
+        if (_selectionStart > Content.Length)
+            _selectionStart = -1;
         Invalidate();
         return this;
     }
@@ -69,30 +93,69 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         return this;
     }
 
+    public CopyableTextNode WithSelectionColors(Color foreground, Color background)
+    {
+        SelectionForeground = foreground;
+        SelectionBackground = background;
+        return this;
+    }
+
     public void OnFocused()
     {
         _hasFocus = true;
+        _cursorPosition = Math.Min(_cursorPosition, Content.Length);
+        TerminaTrace.Focus.Debug(this, "CopyableTextNode focused: contentLength={0}", Content.Length);
         Invalidate();
     }
 
     public void OnBlurred()
     {
         _hasFocus = false;
+        TerminaTrace.Focus.Debug(this, "CopyableTextNode blurred");
         Invalidate();
     }
 
     public bool HandleInput(ConsoleKeyInfo key)
     {
-        if (key.Key != ConsoleKey.Enter)
-            return false;
+        TerminaTrace.Input.Trace(this, "CopyableTextNode.HandleInput: key={0}, hasFocus={1}", key.Key, _hasFocus);
 
-        _clipboardService.Copy(Content);
-        return true;
+        bool handled;
+
+        if (key.Modifiers.HasFlag(ConsoleModifiers.Control) && (key.KeyChar == 'a' || key.KeyChar == 'A'))
+        {
+            SelectAll();
+            handled = true;
+        }
+        else if (key.Modifiers.HasFlag(ConsoleModifiers.Control) && key.Key == ConsoleKey.C)
+        {
+            CopySelectionOrContent();
+            handled = true;
+        }
+        else
+        {
+            handled = key.Key switch
+            {
+                ConsoleKey.Enter => CopySelectionOrContent(),
+                ConsoleKey.LeftArrow => MoveCursor(-1, key.Modifiers),
+                ConsoleKey.RightArrow => MoveCursor(1, key.Modifiers),
+                ConsoleKey.Home => MoveToBoundary(0, key.Modifiers),
+                ConsoleKey.End => MoveToBoundary(Content.Length, key.Modifiers),
+                ConsoleKey.Escape => ClearSelection(),
+                _ => false
+            };
+        }
+
+        if (handled)
+        {
+            Invalidate();
+        }
+
+        return handled;
     }
 
     public override Size Measure(Size available)
     {
-        var lines = GetLines(available.Width > 0 ? available.Width : Content.Length);
+        var lines = BuildRenderedLines(available.Width > 0 ? available.Width : Math.Max(1, Content.Length));
         var hintHeight = string.IsNullOrWhiteSpace(Hint) ? 0 : 1;
         return new Size(available.Width, lines.Count + hintHeight);
     }
@@ -103,26 +166,18 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
             return;
 
         var nodeContext = context.CreateSubContext(bounds);
-        var lines = GetLines(bounds.Width);
+        var lines = BuildRenderedLines(bounds.Width);
         var hasHint = !string.IsNullOrWhiteSpace(Hint);
         var lineCount = hasHint
             ? Math.Min(lines.Count, Math.Max(0, bounds.Height - 1))
             : Math.Min(lines.Count, bounds.Height);
 
-        if (_hasFocus)
-        {
-            nodeContext.SetForeground(FocusedForeground);
-            nodeContext.SetBackground(FocusedBackground);
-            nodeContext.Fill(0, 0, bounds.Width, lineCount, ' ');
-        }
-        else
-        {
-            nodeContext.SetForeground(Foreground);
-        }
+        nodeContext.SetForeground(Foreground);
+        nodeContext.Fill(0, 0, bounds.Width, lineCount, ' ');
 
         for (var i = 0; i < lineCount; i++)
         {
-            nodeContext.WriteAt(0, i, lines[i]);
+            RenderLine(nodeContext, i, lines[i], bounds.Width);
         }
 
         nodeContext.ResetColors();
@@ -146,12 +201,139 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         base.Dispose();
     }
 
-    private List<string> GetLines(int width)
+    private bool CopySelectionOrContent()
+    {
+        var textToCopy = HasSelection ? SelectedText : Content;
+        TerminaTrace.Input.Info(this, "CopyableTextNode copy requested: contentLength={0}, selectionLength={1}", Content.Length, textToCopy.Length);
+        _clipboardService.Copy(textToCopy);
+        return true;
+    }
+
+    private bool MoveCursor(int delta, ConsoleModifiers modifiers)
+    {
+        if (Content.Length == 0)
+            return false;
+
+        var newPosition = Math.Clamp(_cursorPosition + delta, 0, Content.Length);
+        UpdateSelectionForMove(modifiers, newPosition);
+        return true;
+    }
+
+    private bool MoveToBoundary(int position, ConsoleModifiers modifiers)
+    {
+        var newPosition = Math.Clamp(position, 0, Content.Length);
+        UpdateSelectionForMove(modifiers, newPosition);
+        return true;
+    }
+
+    private bool ClearSelection()
+    {
+        if (!HasSelection)
+            return false;
+
+        _selectionStart = -1;
+        return true;
+    }
+
+    private void SelectAll()
+    {
+        _selectionStart = 0;
+        _cursorPosition = Content.Length;
+    }
+
+    private void UpdateSelectionForMove(ConsoleModifiers modifiers, int newPosition)
+    {
+        if (modifiers.HasFlag(ConsoleModifiers.Shift))
+        {
+            if (_selectionStart < 0)
+                _selectionStart = _cursorPosition;
+        }
+        else
+        {
+            _selectionStart = -1;
+        }
+
+        _cursorPosition = newPosition;
+    }
+
+    private void RenderLine(IRenderContext context, int row, RenderedLine line, int width)
+    {
+        for (var column = 0; column < line.Text.Length && column < width; column++)
+        {
+            var sourceIndex = line.StartIndex + column;
+            var isSelected = IsSelected(sourceIndex);
+            var isCursor = _hasFocus && !HasSelection && sourceIndex == _cursorPosition;
+
+            if (isSelected)
+            {
+                context.SetForeground(SelectionForeground);
+                context.SetBackground(SelectionBackground);
+            }
+            else if (isCursor)
+            {
+                context.SetForeground(FocusedForeground);
+                context.SetBackground(FocusedBackground);
+            }
+            else
+            {
+                context.SetForeground(Foreground);
+                context.SetBackground(Color.Default);
+            }
+
+            context.WriteAt(column, row, line.Text[column]);
+        }
+
+        if (_hasFocus && !HasSelection && line.Text.Length < width && _cursorPosition == line.StartIndex + line.Text.Length)
+        {
+            context.SetForeground(FocusedForeground);
+            context.SetBackground(FocusedBackground);
+            context.WriteAt(line.Text.Length, row, ' ');
+        }
+
+        context.ResetColors();
+    }
+
+    private bool IsSelected(int sourceIndex)
+    {
+        if (!HasSelection)
+            return false;
+
+        var start = Math.Min(_selectionStart, _cursorPosition);
+        var end = Math.Max(_selectionStart, _cursorPosition);
+        return sourceIndex >= start && sourceIndex < end;
+    }
+
+    private List<RenderedLine> BuildRenderedLines(int width)
     {
         if (width <= 0)
-            return [string.Empty];
+            return [new RenderedLine(string.Empty, 0)];
 
-        return WordWrapper.WrapLines(Content.Split('\n'), width);
+        var rendered = new List<RenderedLine>();
+        var sourceLines = Content.Split('\n');
+        var sourceOffset = 0;
+
+        for (var i = 0; i < sourceLines.Length; i++)
+        {
+            var line = sourceLines[i];
+            if (line.Length == 0)
+            {
+                rendered.Add(new RenderedLine(string.Empty, sourceOffset));
+            }
+            else
+            {
+                for (var chunkStart = 0; chunkStart < line.Length; chunkStart += width)
+                {
+                    var chunkLength = Math.Min(width, line.Length - chunkStart);
+                    rendered.Add(new RenderedLine(line.Substring(chunkStart, chunkLength), sourceOffset + chunkStart));
+                }
+            }
+
+            sourceOffset += line.Length;
+            if (i < sourceLines.Length - 1)
+                sourceOffset += 1;
+        }
+
+        return rendered;
     }
 
     private void Invalidate()
@@ -159,4 +341,6 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         if (!_disposed)
             _invalidated.OnNext(Unit.Default);
     }
+
+    private sealed record RenderedLine(string Text, int StartIndex);
 }

--- a/src/Termina/Notifications/IToastService.cs
+++ b/src/Termina/Notifications/IToastService.cs
@@ -15,5 +15,5 @@ public interface IToastService
     /// <summary>
     /// Show a toast for the configured duration.
     /// </summary>
-    void Show(string message, TimeSpan? duration = null);
+    void Show(string message, ToastOptions? options = null);
 }

--- a/src/Termina/Notifications/IToastService.cs
+++ b/src/Termina/Notifications/IToastService.cs
@@ -1,0 +1,19 @@
+using R3;
+
+namespace Termina.Notifications;
+
+/// <summary>
+/// Shows transient toast notifications.
+/// </summary>
+public interface IToastService
+{
+    /// <summary>
+    /// Current toast, if any.
+    /// </summary>
+    Observable<ToastMessage?> CurrentToast { get; }
+
+    /// <summary>
+    /// Show a toast for the configured duration.
+    /// </summary>
+    void Show(string message, TimeSpan? duration = null);
+}

--- a/src/Termina/Notifications/ToastMessage.cs
+++ b/src/Termina/Notifications/ToastMessage.cs
@@ -3,4 +3,4 @@ namespace Termina.Notifications;
 /// <summary>
 /// A transient toast message.
 /// </summary>
-public sealed record ToastMessage(string Message);
+public sealed record ToastMessage(string Message, ToastPosition Position = ToastPosition.BottomRight);

--- a/src/Termina/Notifications/ToastMessage.cs
+++ b/src/Termina/Notifications/ToastMessage.cs
@@ -1,0 +1,6 @@
+namespace Termina.Notifications;
+
+/// <summary>
+/// A transient toast message.
+/// </summary>
+public sealed record ToastMessage(string Message);

--- a/src/Termina/Notifications/ToastOptions.cs
+++ b/src/Termina/Notifications/ToastOptions.cs
@@ -1,0 +1,8 @@
+namespace Termina.Notifications;
+
+/// <summary>
+/// Optional display settings for a toast notification.
+/// </summary>
+public sealed record ToastOptions(
+    TimeSpan? Duration = null,
+    ToastPosition Position = ToastPosition.BottomRight);

--- a/src/Termina/Notifications/ToastOverlayNode.cs
+++ b/src/Termina/Notifications/ToastOverlayNode.cs
@@ -41,8 +41,7 @@ internal sealed class ToastOverlayNode : LayoutNode, IInvalidatingNode
         if (width <= 0 || bounds.Height < height)
             return;
 
-        var x = Math.Max(0, bounds.Width - width - 1);
-        var y = Math.Max(0, bounds.Height - height - 1);
+        var (x, y) = CalculatePosition(bounds, width, height, _currentToast.Position);
         var panelBounds = new Rect(x, y, width, height);
         var panelContext = context.CreateSubContext(panelBounds);
 
@@ -63,6 +62,24 @@ internal sealed class ToastOverlayNode : LayoutNode, IInvalidatingNode
         panelContext.WriteAt(1, 2, new string('─', Math.Max(0, width - 2)));
         panelContext.WriteAt(width - 1, 2, '╯');
         panelContext.ResetColors();
+    }
+
+    private static (int X, int Y) CalculatePosition(Rect bounds, int width, int height, ToastPosition position)
+    {
+        var x = position switch
+        {
+            ToastPosition.BottomLeft or ToastPosition.TopLeft => 1,
+            ToastPosition.BottomCenter or ToastPosition.TopCenter => Math.Max(0, (bounds.Width - width) / 2),
+            _ => Math.Max(0, bounds.Width - width - 1)
+        };
+
+        var y = position switch
+        {
+            ToastPosition.TopLeft or ToastPosition.TopCenter or ToastPosition.TopRight => 1,
+            _ => Math.Max(0, bounds.Height - height - 1)
+        };
+
+        return (x, y);
     }
 
     public override void Dispose()

--- a/src/Termina/Notifications/ToastOverlayNode.cs
+++ b/src/Termina/Notifications/ToastOverlayNode.cs
@@ -1,0 +1,79 @@
+using R3;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Notifications;
+
+internal sealed class ToastOverlayNode : LayoutNode, IInvalidatingNode
+{
+    private readonly IToastService _toastService;
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly IDisposable _subscription;
+    private ToastMessage? _currentToast;
+    private bool _disposed;
+
+    public ToastOverlayNode(IToastService toastService)
+    {
+        _toastService = toastService;
+        WidthConstraint = new SizeConstraint.Fill();
+        HeightConstraint = new SizeConstraint.Fill();
+
+        _subscription = _toastService.CurrentToast.Subscribe(toast =>
+        {
+            _currentToast = toast;
+            _invalidated.OnNext(Unit.Default);
+        });
+    }
+
+    public Observable<Unit> Invalidated => _invalidated;
+
+    public override Size Measure(Size available) => available;
+
+    public override void Render(IRenderContext context, Rect bounds)
+    {
+        if (!bounds.HasArea || _currentToast is null)
+            return;
+
+        var message = $" {char.ConvertFromUtf32(0x2713)} {_currentToast.Message} ";
+        var width = Math.Min(bounds.Width, message.Length + 2);
+        var height = 3;
+        if (width <= 0 || bounds.Height < height)
+            return;
+
+        var x = Math.Max(0, bounds.Width - width - 1);
+        var y = Math.Max(0, bounds.Height - height - 1);
+        var panelBounds = new Rect(x, y, width, height);
+        var panelContext = context.CreateSubContext(panelBounds);
+
+        panelContext.SetForeground(Color.BrightGreen);
+        panelContext.WriteAt(0, 0, '╭');
+        panelContext.WriteAt(1, 0, new string('─', Math.Max(0, width - 2)));
+        panelContext.WriteAt(width - 1, 0, '╮');
+
+        panelContext.WriteAt(0, 1, '│');
+        panelContext.SetBackground(Color.Black);
+        panelContext.SetForeground(Color.White);
+        panelContext.WriteAt(1, 1, message.Length > width - 2 ? message[..(width - 2)] : message.PadRight(width - 2));
+        panelContext.ResetColors();
+        panelContext.SetForeground(Color.BrightGreen);
+        panelContext.WriteAt(width - 1, 1, '│');
+
+        panelContext.WriteAt(0, 2, '╰');
+        panelContext.WriteAt(1, 2, new string('─', Math.Max(0, width - 2)));
+        panelContext.WriteAt(width - 1, 2, '╯');
+        panelContext.ResetColors();
+    }
+
+    public override void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _subscription.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Termina/Notifications/ToastPosition.cs
+++ b/src/Termina/Notifications/ToastPosition.cs
@@ -1,0 +1,14 @@
+namespace Termina.Notifications;
+
+/// <summary>
+/// Placement for transient toast notifications.
+/// </summary>
+public enum ToastPosition
+{
+    BottomRight,
+    BottomCenter,
+    BottomLeft,
+    TopRight,
+    TopCenter,
+    TopLeft
+}

--- a/src/Termina/Notifications/ToastService.cs
+++ b/src/Termina/Notifications/ToastService.cs
@@ -16,16 +16,17 @@ public sealed class ToastService : IToastService, IDisposable
 
     public Observable<ToastMessage?> CurrentToast => _currentToast;
 
-    public void Show(string message, TimeSpan? duration = null)
+    public void Show(string message, ToastOptions? options = null)
     {
         if (_disposed)
             return;
 
-        _currentToast.Value = new ToastMessage(message);
+        var resolvedOptions = options ?? new ToastOptions();
+        _currentToast.Value = new ToastMessage(message, resolvedOptions.Position);
 
         _dismissSubscription?.Dispose();
         _dismissSubscription = Observable
-            .Interval(duration ?? TimeSpan.FromSeconds(2), _timeProvider)
+            .Interval(resolvedOptions.Duration ?? TimeSpan.FromSeconds(2), _timeProvider)
             .Take(1)
             .Subscribe(_ => _currentToast.Value = null);
     }

--- a/src/Termina/Notifications/ToastService.cs
+++ b/src/Termina/Notifications/ToastService.cs
@@ -1,0 +1,42 @@
+using R3;
+
+namespace Termina.Notifications;
+
+public sealed class ToastService : IToastService, IDisposable
+{
+    private readonly TimeProvider _timeProvider;
+    private readonly ReactiveProperty<ToastMessage?> _currentToast = new(null);
+    private IDisposable? _dismissSubscription;
+    private bool _disposed;
+
+    public ToastService(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public Observable<ToastMessage?> CurrentToast => _currentToast;
+
+    public void Show(string message, TimeSpan? duration = null)
+    {
+        if (_disposed)
+            return;
+
+        _currentToast.Value = new ToastMessage(message);
+
+        _dismissSubscription?.Dispose();
+        _dismissSubscription = Observable
+            .Interval(duration ?? TimeSpan.FromSeconds(2), _timeProvider)
+            .Take(1)
+            .Subscribe(_ => _currentToast.Value = null);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _dismissSubscription?.Dispose();
+        _currentToast.Dispose();
+    }
+}

--- a/src/Termina/Properties/AssemblyInfo.cs
+++ b/src/Termina/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Termina.Tests")]

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -9,6 +9,7 @@ using Termina.Hosting;
 using Termina.Input;
 using Termina.Layout;
 using Termina.Navigation;
+using Termina.Notifications;
 using Termina.Pages;
 using Termina.Platform;
 using Termina.Reactive;
@@ -49,6 +50,9 @@ public sealed class TerminaApplication
     private readonly Stack<(string Path, IReadOnlyDictionary<string, object>? Parameters)> _history = new();
     private readonly List<IInputSource> _inputSources = new();
     private readonly FocusManager _focusManager = new();
+    private readonly IToastService? _toastService;
+    private readonly ToastOverlayNode? _toastOverlay;
+    private readonly IDisposable? _toastInvalidationSubscription;
 
     private string? _currentPath;
     private IReadOnlyDictionary<string, object>? _currentParameters;
@@ -90,6 +94,9 @@ public sealed class TerminaApplication
 
         _serviceProvider = serviceProvider;
         _eventChannel = Channel.CreateUnbounded<object>();
+        _toastService = serviceProvider?.GetService<IToastService>();
+        _toastOverlay = _toastService != null ? new ToastOverlayNode(_toastService) : null;
+        _toastInvalidationSubscription = _toastOverlay?.Invalidated.Subscribe(_ => RequestRedraw());
 
         // If using DI, check for registered input sources
         if (serviceProvider != null)
@@ -504,11 +511,17 @@ public sealed class TerminaApplication
             case PasteEvent pasteEvent:
                 if (_focusManager.CurrentFocus is IPasteReceiver focused)
                 {
-                    focused.HandlePaste(pasteEvent);
+                    if (focused.HandlePaste(pasteEvent))
+                    {
+                        ShowPasteToast(pasteEvent.Content);
+                    }
                 }
                 else if (FindPasteReceiver(GetCurrentLayoutRoot()) is { } fallback)
                 {
-                    fallback.HandlePaste(pasteEvent);
+                    if (fallback.HandlePaste(pasteEvent))
+                    {
+                        ShowPasteToast(pasteEvent.Content);
+                    }
                 }
                 else
                 {
@@ -595,6 +608,10 @@ public sealed class TerminaApplication
     private void RenderCurrentPage()
     {
         var layoutRoot = GetCurrentLayoutRoot() ?? new TextNode("No page active");
+        if (_toastOverlay != null)
+        {
+            layoutRoot = new StackLayout([layoutRoot, new DeferredNode(() => _toastOverlay)]);
+        }
 
         // Clear the pending buffer (DiffingTerminal) or screen (other terminals)
         _terminal.ClearScreen();
@@ -631,6 +648,19 @@ public sealed class TerminaApplication
 
         // Fall back to building the layout fresh
         return _currentPage.BuildLayout();
+    }
+
+    private void ShowPasteToast(string content)
+    {
+        if (_toastService is null)
+            return;
+
+        var lineCount = content.Count(c => c == '\n') + 1;
+        var message = lineCount > 1
+            ? $"Pasted {lineCount} lines"
+            : $"Pasted {content.Length} characters";
+
+        _toastService.Show(message);
     }
 
     /// <summary>
@@ -670,6 +700,9 @@ public sealed class TerminaApplication
             if (source is IDisposable disposable)
                 disposable.Dispose();
         }
+
+        _toastInvalidationSubscription?.Dispose();
+        _toastOverlay?.Dispose();
     }
 }
 

--- a/src/Termina/Terminal/AnsiCodes.cs
+++ b/src/Termina/Terminal/AnsiCodes.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Termina.Terminal;
 
 /// <summary>
@@ -267,6 +269,16 @@ public static class AnsiCodes
         // DCS passthrough syntax: ESC P tmux; ESC <seq-with-doubled-ESCs> ESC \
         var doubled = seq.Replace("\x1b", "\x1b\x1b");
         return $"\x1bPtmux;\x1b{doubled}\x1b\\";
+    }
+
+    /// <summary>
+    /// Build an OSC 52 clipboard write sequence for the provided text.
+    /// Format: ESC ] 52 ; c ; {base64(utf8 text)} BEL
+    /// </summary>
+    public static string Osc52Clipboard(string text)
+    {
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(text));
+        return $"\x1b]52;c;{base64}\x07";
     }
 
     // Mouse tracking

--- a/src/Termina/Terminal/AnsiCodes.cs
+++ b/src/Termina/Terminal/AnsiCodes.cs
@@ -277,8 +277,19 @@ public static class AnsiCodes
     /// </summary>
     public static string Osc52Clipboard(string text)
     {
+        return Osc52Clipboard(text, useStringTerminator: false);
+    }
+
+    /// <summary>
+    /// Build an OSC 52 clipboard write sequence for the provided text.
+    /// Format: ESC ] 52 ; c ; {base64(utf8 text)} (BEL or ST)
+    /// </summary>
+    public static string Osc52Clipboard(string text, bool useStringTerminator)
+    {
         var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(text));
-        return $"\x1b]52;c;{base64}\x07";
+        return useStringTerminator
+            ? $"\x1b]52;c;{base64}\x1b\\"
+            : $"\x1b]52;c;{base64}\x07";
     }
 
     // Mouse tracking

--- a/src/Termina/Terminal/AnsiTerminal.cs
+++ b/src/Termina/Terminal/AnsiTerminal.cs
@@ -236,13 +236,25 @@ public sealed class AnsiTerminal : IAnsiTerminal, IDisposable
     /// <inheritdoc />
     public void CopyToClipboard(string text)
     {
-        var sequence = AnsiCodes.Osc52Clipboard(text);
+        var belSequence = AnsiCodes.Osc52Clipboard(text);
+        var stSequence = AnsiCodes.Osc52Clipboard(text, useStringTerminator: true);
+        TerminaTrace.Platform.Info(this, "AnsiTerminal.CopyToClipboard: textLength={0}, tmux={1}", text.Length, Environment.GetEnvironmentVariable("TMUX") is not null);
+        TerminaTrace.Platform.Debug(this, "OSC52 lengths: bel={0}, st={1}", belSequence.Length, stSequence.Length);
         if (Environment.GetEnvironmentVariable("TMUX") is not null)
         {
-            sequence = AnsiCodes.TmuxPassthrough(sequence);
+            // Emit both OSC terminators and both tmux delivery modes to maximize
+            // compatibility across tmux versions and terminal emulators.
+            _buffer.Append(belSequence);
+            _buffer.Append(stSequence);
+            _buffer.Append(AnsiCodes.TmuxPassthrough(belSequence));
+            _buffer.Append(AnsiCodes.TmuxPassthrough(stSequence));
+            TerminaTrace.Platform.Debug(this, "Queued OSC52 BEL/ST plain + tmux passthrough sequences");
+            return;
         }
 
-        _buffer.Append(sequence);
+        _buffer.Append(belSequence);
+        _buffer.Append(stSequence);
+        TerminaTrace.Platform.Debug(this, "Queued OSC52 BEL/ST plain sequences");
     }
 
     /// <summary>

--- a/src/Termina/Terminal/AnsiTerminal.cs
+++ b/src/Termina/Terminal/AnsiTerminal.cs
@@ -233,6 +233,18 @@ public sealed class AnsiTerminal : IAnsiTerminal, IDisposable
         }
     }
 
+    /// <inheritdoc />
+    public void CopyToClipboard(string text)
+    {
+        var sequence = AnsiCodes.Osc52Clipboard(text);
+        if (Environment.GetEnvironmentVariable("TMUX") is not null)
+        {
+            sequence = AnsiCodes.TmuxPassthrough(sequence);
+        }
+
+        _buffer.Append(sequence);
+    }
+
     /// <summary>
     /// Dispose the terminal, restoring original state.
     /// </summary>

--- a/src/Termina/Terminal/DiffingTerminal.cs
+++ b/src/Termina/Terminal/DiffingTerminal.cs
@@ -402,6 +402,12 @@ public sealed class DiffingTerminal : IAnsiTerminal, IDisposable
     }
 
     /// <inheritdoc />
+    public void CopyToClipboard(string text)
+    {
+        _inner.CopyToClipboard(text);
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_inner is IDisposable disposable)

--- a/src/Termina/Terminal/IAnsiTerminal.cs
+++ b/src/Termina/Terminal/IAnsiTerminal.cs
@@ -98,4 +98,9 @@ public interface IAnsiTerminal
     /// Disable mouse tracking.
     /// </summary>
     void DisableMouse();
+
+    /// <summary>
+    /// Request that the terminal copy text to the user's clipboard.
+    /// </summary>
+    void CopyToClipboard(string text);
 }

--- a/src/Termina/Terminal/VirtualTerminal.cs
+++ b/src/Termina/Terminal/VirtualTerminal.cs
@@ -228,6 +228,12 @@ public sealed class VirtualTerminal : IAnsiTerminal
         MouseEnabled = false;
     }
 
+    /// <inheritdoc />
+    public void CopyToClipboard(string text)
+    {
+        _rawOutput.Add(AnsiCodes.Osc52Clipboard(text));
+    }
+
     /// <summary>
     /// Clear the entire buffer.
     /// </summary>

--- a/tests/Termina.Tests/Clipboard/TerminalClipboardServiceTests.cs
+++ b/tests/Termina.Tests/Clipboard/TerminalClipboardServiceTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Clipboard;
+using Termina.Notifications;
+
+namespace Termina.Tests.Clipboard;
+
+public class TerminalClipboardServiceTests
+{
+    [Fact]
+    public void Copy_InvokesAllApplicableTransports_AndShowsToast()
+    {
+        var first = new TestTransport("first", canHandle: true, result: true);
+        var second = new TestTransport("second", canHandle: true, result: true);
+        var toast = new TestToastService();
+        var service = new TerminalClipboardService([first, second], toast);
+
+        service.Copy("hello");
+
+        Assert.Equal(["hello"], first.CopiedTexts);
+        Assert.Equal(["hello"], second.CopiedTexts);
+        Assert.Equal("Copied to clipboard", toast.LastMessage);
+    }
+
+    [Fact]
+    public void Copy_SkipsUnavailableTransport()
+    {
+        var skipped = new TestTransport("skip", canHandle: false, result: true);
+        var used = new TestTransport("use", canHandle: true, result: true);
+        var service = new TerminalClipboardService([skipped, used], new TestToastService());
+
+        service.Copy("hello");
+
+        Assert.Empty(skipped.CopiedTexts);
+        Assert.Equal(["hello"], used.CopiedTexts);
+    }
+
+    private sealed class TestTransport : IClipboardTransport
+    {
+        private readonly bool _canHandle;
+        private readonly bool _result;
+
+        public TestTransport(string name, bool canHandle, bool result)
+        {
+            Name = name;
+            _canHandle = canHandle;
+            _result = result;
+        }
+
+        public string Name { get; }
+
+        public List<string> CopiedTexts { get; } = [];
+
+        public bool CanHandle() => _canHandle;
+
+        public bool TryCopy(string text)
+        {
+            CopiedTexts.Add(text);
+            return _result;
+        }
+    }
+
+    private sealed class TestToastService : IToastService
+    {
+        private readonly Subject<ToastMessage?> _subject = new();
+
+        public string? LastMessage { get; private set; }
+
+        public Observable<ToastMessage?> CurrentToast => _subject;
+
+        public void Show(string message, TimeSpan? duration = null)
+        {
+            LastMessage = message;
+            _subject.OnNext(new ToastMessage(message));
+        }
+    }
+}

--- a/tests/Termina.Tests/Clipboard/TerminalClipboardServiceTests.cs
+++ b/tests/Termina.Tests/Clipboard/TerminalClipboardServiceTests.cs
@@ -14,14 +14,13 @@ public class TerminalClipboardServiceTests
     {
         var first = new TestTransport("first", canHandle: true, result: true);
         var second = new TestTransport("second", canHandle: true, result: true);
-        var toast = new TestToastService();
-        var service = new TerminalClipboardService([first, second], toast);
+        var service = new TerminalClipboardService([first, second]);
 
-        service.Copy("hello");
+        var copied = service.Copy("hello");
 
+        Assert.True(copied);
         Assert.Equal(["hello"], first.CopiedTexts);
         Assert.Equal(["hello"], second.CopiedTexts);
-        Assert.Equal("Copied to clipboard", toast.LastMessage);
     }
 
     [Fact]
@@ -29,12 +28,24 @@ public class TerminalClipboardServiceTests
     {
         var skipped = new TestTransport("skip", canHandle: false, result: true);
         var used = new TestTransport("use", canHandle: true, result: true);
-        var service = new TerminalClipboardService([skipped, used], new TestToastService());
+        var service = new TerminalClipboardService([skipped, used]);
 
-        service.Copy("hello");
+        var copied = service.Copy("hello");
 
+        Assert.True(copied);
         Assert.Empty(skipped.CopiedTexts);
         Assert.Equal(["hello"], used.CopiedTexts);
+    }
+
+    [Fact]
+    public void Copy_ReturnsFalse_WhenNoTransportSucceeds()
+    {
+        var transport = new TestTransport("fail", canHandle: true, result: false);
+        var service = new TerminalClipboardService([transport]);
+
+        var copied = service.Copy("hello");
+
+        Assert.False(copied);
     }
 
     private sealed class TestTransport : IClipboardTransport
@@ -59,21 +70,6 @@ public class TerminalClipboardServiceTests
         {
             CopiedTexts.Add(text);
             return _result;
-        }
-    }
-
-    private sealed class TestToastService : IToastService
-    {
-        private readonly Subject<ToastMessage?> _subject = new();
-
-        public string? LastMessage { get; private set; }
-
-        public Observable<ToastMessage?> CurrentToast => _subject;
-
-        public void Show(string message, TimeSpan? duration = null)
-        {
-            LastMessage = message;
-            _subject.OnNext(new ToastMessage(message));
         }
     }
 }

--- a/tests/Termina.Tests/Input/PasteToastRoutingTests.cs
+++ b/tests/Termina.Tests/Input/PasteToastRoutingTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Notifications;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Input;
+
+public class PasteToastRoutingTests
+{
+    [Fact]
+    public void ProcessEvent_ShowsToast_WhenFocusedPasteReceiverHandlesPaste()
+    {
+        var toastService = new TestToastService();
+        var services = new TestServiceProvider(toastService);
+        var app = new TerminaApplication(new VirtualTerminal(), services);
+        app.RegisterRoute<TestPastePage, TestPasteViewModel>("/paste");
+        app.NavigateTo("/paste");
+
+        InvokeProcessEvent(app, new PasteEvent("hello"));
+
+        Assert.Equal("Pasted 5 characters", toastService.LastMessage);
+    }
+
+    private static void InvokeProcessEvent(TerminaApplication app, object evt)
+    {
+        var method = typeof(TerminaApplication).GetMethod(
+            "ProcessEvent",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        Assert.NotNull(method);
+        method!.Invoke(app, [evt]);
+    }
+
+    private sealed class TestToastService : IToastService
+    {
+        private readonly Subject<ToastMessage?> _current = new();
+
+        public string? LastMessage { get; private set; }
+
+        public Observable<ToastMessage?> CurrentToast => _current;
+
+        public void Show(string message, TimeSpan? duration = null)
+        {
+            LastMessage = message;
+            _current.OnNext(new ToastMessage(message));
+        }
+    }
+
+    private sealed class TestServiceProvider : IServiceProvider
+    {
+        private readonly IToastService _toastService;
+
+        public TestServiceProvider(IToastService toastService)
+        {
+            _toastService = toastService;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IToastService))
+                return _toastService;
+
+            if (serviceType == typeof(IEnumerable<IInputSource>))
+                return Array.Empty<IInputSource>();
+
+            return null;
+        }
+    }
+
+    private sealed class TestPastePage : ReactivePage<TestPasteViewModel>
+    {
+        private readonly TextInputNode _input = new();
+
+        public override void OnNavigatedTo()
+        {
+            base.OnNavigatedTo();
+            Focus.PushFocus(_input);
+        }
+
+        public override ILayoutNode BuildLayout() => _input;
+    }
+
+    private sealed class TestPasteViewModel : ReactiveViewModel
+    {
+    }
+}

--- a/tests/Termina.Tests/Input/PasteToastRoutingTests.cs
+++ b/tests/Termina.Tests/Input/PasteToastRoutingTests.cs
@@ -45,10 +45,10 @@ public class PasteToastRoutingTests
 
         public Observable<ToastMessage?> CurrentToast => _current;
 
-        public void Show(string message, TimeSpan? duration = null)
+        public void Show(string message, ToastOptions? options = null)
         {
             LastMessage = message;
-            _current.OnNext(new ToastMessage(message));
+            _current.OnNext(new ToastMessage(message, options?.Position ?? ToastPosition.BottomRight));
         }
     }
 

--- a/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
+++ b/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
@@ -36,6 +36,49 @@ public class CopyableTextNodeTests
     }
 
     [Fact]
+    public void ShiftArrow_SelectsText_AndEnterCopiesSelection()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "abcd");
+
+        node.OnFocused();
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, true, false, false));
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, true, false, false));
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal("ab", clipboard.LastCopiedText);
+    }
+
+    [Fact]
+    public void CtrlA_SelectsAll_AndCtrlCCopiesSelection()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "select all");
+
+        node.OnFocused();
+        node.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, true));
+        node.HandleInput(new ConsoleKeyInfo('\u0003', ConsoleKey.C, false, false, true));
+
+        Assert.Equal("select all", clipboard.LastCopiedText);
+    }
+
+    [Fact]
+    public void Escape_ClearsSelection()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "abcd");
+
+        node.OnFocused();
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, true, false, false));
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, true, false, false));
+
+        var handled = node.HandleInput(new ConsoleKeyInfo('\u001b', ConsoleKey.Escape, false, false, false));
+
+        Assert.True(handled);
+        Assert.False(node.HasSelection);
+    }
+
+    [Fact]
     public void FocusChanges_RaiseInvalidation()
     {
         var clipboard = new TestClipboardService();
@@ -62,6 +105,24 @@ public class CopyableTextNodeTests
 
         Assert.Contains("copy me", terminal.ToString());
         Assert.Contains("Press Enter to copy", terminal.ToString());
+    }
+
+    [Fact]
+    public void Render_WithSelection_HighlightsSelectedCharacters()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "abcd");
+        var terminal = new VirtualTerminal(10, 3);
+        var context = new RegionRenderContext(terminal, 0, 0, 10, 3);
+
+        node.OnFocused();
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, true, false, false));
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, true, false, false));
+        node.Render(context, new Rect(0, 0, 10, 3));
+
+        Assert.Equal(Color.BrightYellow, terminal.GetBackground(0, 0));
+        Assert.Equal(Color.BrightYellow, terminal.GetBackground(1, 0));
+        Assert.NotEqual(Color.BrightYellow, terminal.GetBackground(2, 0));
     }
 
     private sealed class TestClipboardService : IClipboardService

--- a/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
+++ b/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using R3;
+using Microsoft.Extensions.Time.Testing;
 using Termina.Clipboard;
 using Termina.Layout;
+using Termina.Notifications;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -125,13 +127,74 @@ public class CopyableTextNodeTests
         Assert.NotEqual(Color.BrightYellow, terminal.GetBackground(2, 0));
     }
 
+    [Fact]
+    public void CustomCopyBinding_TriggersCopy()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "hello")
+            .WithCopyBindings(new CopyKeyBinding(ConsoleKey.F5));
+
+        var handled = node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.F5, false, false, false));
+
+        Assert.True(handled);
+        Assert.Equal("hello", clipboard.LastCopiedText);
+    }
+
+    [Fact]
+    public void InlineIndicator_RendersAfterSuccessfulCopy()
+    {
+        var clipboard = new TestClipboardService();
+        var timeProvider = new FakeTimeProvider();
+        var node = new CopyableTextNode(clipboard, "hello", timeProvider: timeProvider)
+            .WithFeedbackMode(CopyFeedbackMode.InlineIndicator)
+            .WithInlineIndicator("OK");
+        var terminal = new VirtualTerminal(10, 3);
+        var context = new RegionRenderContext(terminal, 0, 0, 10, 3);
+
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+        node.Render(context, new Rect(0, 0, 10, 3));
+
+        Assert.Equal('O', terminal.GetChar(8, 0));
+        Assert.Equal('K', terminal.GetChar(9, 0));
+    }
+
+    [Fact]
+    public void ToastFeedback_UsesConfiguredPlacement()
+    {
+        var clipboard = new TestClipboardService();
+        var toastService = new TestToastService();
+        var node = new CopyableTextNode(clipboard, "hello", toastService)
+            .WithToastPosition(ToastPosition.TopLeft)
+            .WithFeedbackMode(CopyFeedbackMode.Toast);
+
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.Equal(ToastPosition.TopLeft, toastService.LastToast?.Position);
+    }
+
     private sealed class TestClipboardService : IClipboardService
     {
         public string? LastCopiedText { get; private set; }
 
-        public void Copy(string text)
+        public bool Copy(string text)
         {
             LastCopiedText = text;
+            return true;
+        }
+    }
+
+    private sealed class TestToastService : IToastService
+    {
+        private readonly Subject<ToastMessage?> _subject = new();
+
+        public ToastMessage? LastToast { get; private set; }
+
+        public Observable<ToastMessage?> CurrentToast => _subject;
+
+        public void Show(string message, ToastOptions? options = null)
+        {
+            LastToast = new ToastMessage(message, options?.Position ?? ToastPosition.BottomRight);
+            _subject.OnNext(LastToast);
         }
     }
 }

--- a/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
+++ b/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Clipboard;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+public class CopyableTextNodeTests
+{
+    [Fact]
+    public void Enter_CopiesFullContent()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "https://example.com");
+
+        var handled = node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        Assert.True(handled);
+        Assert.Equal("https://example.com", clipboard.LastCopiedText);
+    }
+
+    [Fact]
+    public void NonEnterKey_IsNotHandled()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "abc");
+
+        var handled = node.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false));
+
+        Assert.False(handled);
+        Assert.Null(clipboard.LastCopiedText);
+    }
+
+    [Fact]
+    public void FocusChanges_RaiseInvalidation()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "abc");
+        var invalidations = 0;
+        using var subscription = node.Invalidated.Subscribe(_ => invalidations++);
+
+        node.OnFocused();
+        node.OnBlurred();
+
+        Assert.Equal(2, invalidations);
+    }
+
+    [Fact]
+    public void Render_WhenFocused_ShowsHint()
+    {
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, "copy me");
+        var terminal = new VirtualTerminal(40, 4);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 4);
+
+        node.OnFocused();
+        node.Render(context, new Rect(0, 0, 40, 4));
+
+        Assert.Contains("copy me", terminal.ToString());
+        Assert.Contains("Press Enter to copy", terminal.ToString());
+    }
+
+    private sealed class TestClipboardService : IClipboardService
+    {
+        public string? LastCopiedText { get; private set; }
+
+        public void Copy(string text)
+        {
+            LastCopiedText = text;
+        }
+    }
+}

--- a/tests/Termina.Tests/Notifications/ToastOverlayNodeTests.cs
+++ b/tests/Termina.Tests/Notifications/ToastOverlayNodeTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Layout;
+using Termina.Notifications;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Notifications;
+
+public class ToastOverlayNodeTests
+{
+    [Fact]
+    public void Render_UsesTopLeftPlacement_WhenConfigured()
+    {
+        var toastService = new TestToastService();
+        var node = new ToastOverlayNode(toastService);
+        var terminal = new VirtualTerminal(40, 8);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 8);
+
+        toastService.Show("Copied", new ToastOptions(Position: ToastPosition.TopLeft));
+        node.Render(context, new Rect(0, 0, 40, 8));
+
+        Assert.Equal('╭', terminal.GetChar(1, 1));
+    }
+
+    [Fact]
+    public void Render_UsesBottomCenterPlacement_WhenConfigured()
+    {
+        var toastService = new TestToastService();
+        var node = new ToastOverlayNode(toastService);
+        var terminal = new VirtualTerminal(40, 8);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 8);
+
+        toastService.Show("Copied", new ToastOptions(Position: ToastPosition.BottomCenter));
+        node.Render(context, new Rect(0, 0, 40, 8));
+
+        var expectedX = (40 - 12) / 2;
+        Assert.Equal('╭', terminal.GetChar(expectedX, 4));
+    }
+
+    private sealed class TestToastService : IToastService
+    {
+        private readonly Subject<ToastMessage?> _subject = new();
+
+        public Observable<ToastMessage?> CurrentToast => _subject;
+
+        public void Show(string message, ToastOptions? options = null)
+        {
+            _subject.OnNext(new ToastMessage(message, options?.Position ?? ToastPosition.BottomRight));
+        }
+    }
+}

--- a/tests/Termina.Tests/Notifications/ToastServiceTests.cs
+++ b/tests/Termina.Tests/Notifications/ToastServiceTests.cs
@@ -23,6 +23,19 @@ public class ToastServiceTests
     }
 
     [Fact]
+    public void Show_AppliesConfiguredPosition()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var service = new ToastService(timeProvider);
+        ToastMessage? current = null;
+        using var subscription = service.CurrentToast.Subscribe(toast => current = toast);
+
+        service.Show("Copied to clipboard", new ToastOptions(Position: ToastPosition.TopLeft));
+
+        Assert.Equal(ToastPosition.TopLeft, current?.Position);
+    }
+
+    [Fact]
     public void Show_ClearsToastAfterDuration()
     {
         var timeProvider = new FakeTimeProvider();
@@ -30,7 +43,7 @@ public class ToastServiceTests
         ToastMessage? current = null;
         using var subscription = service.CurrentToast.Subscribe(toast => current = toast);
 
-        service.Show("Copied to clipboard", TimeSpan.FromSeconds(2));
+        service.Show("Copied to clipboard", new ToastOptions(Duration: TimeSpan.FromSeconds(2)));
         timeProvider.Advance(TimeSpan.FromSeconds(2));
 
         Assert.Null(current);

--- a/tests/Termina.Tests/Notifications/ToastServiceTests.cs
+++ b/tests/Termina.Tests/Notifications/ToastServiceTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Time.Testing;
+using R3;
+using Termina.Notifications;
+
+namespace Termina.Tests.Notifications;
+
+public class ToastServiceTests
+{
+    [Fact]
+    public void Show_SetsCurrentToast()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var service = new ToastService(timeProvider);
+        ToastMessage? current = null;
+        using var subscription = service.CurrentToast.Subscribe(toast => current = toast);
+
+        service.Show("Copied to clipboard");
+
+        Assert.Equal("Copied to clipboard", current?.Message);
+    }
+
+    [Fact]
+    public void Show_ClearsToastAfterDuration()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var service = new ToastService(timeProvider);
+        ToastMessage? current = null;
+        using var subscription = service.CurrentToast.Subscribe(toast => current = toast);
+
+        service.Show("Copied to clipboard", TimeSpan.FromSeconds(2));
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+
+        Assert.Null(current);
+    }
+}

--- a/tests/Termina.Tests/Terminal/AnsiCodesTests.cs
+++ b/tests/Termina.Tests/Terminal/AnsiCodesTests.cs
@@ -336,6 +336,12 @@ public class AnsiCodesTests
     }
 
     [Fact]
+    public void Osc52Clipboard_WithStringTerminator_EncodesUtf8Text()
+    {
+        Assert.Equal("\x1b]52;c;SGVsbG8=\x1b\\", AnsiCodes.Osc52Clipboard("Hello", useStringTerminator: true));
+    }
+
+    [Fact]
     public void TmuxPassthrough_WrapsOsc52Sequence()
     {
         var wrapped = AnsiCodes.TmuxPassthrough(AnsiCodes.Osc52Clipboard("Hello"));

--- a/tests/Termina.Tests/Terminal/AnsiCodesTests.cs
+++ b/tests/Termina.Tests/Terminal/AnsiCodesTests.cs
@@ -328,4 +328,19 @@ public class AnsiCodesTests
     {
         Assert.Equal($"{Csi}18t", AnsiCodes.QueryTerminalSize);
     }
+
+    [Fact]
+    public void Osc52Clipboard_EncodesUtf8Text()
+    {
+        Assert.Equal("\x1b]52;c;SGVsbG8=\x07", AnsiCodes.Osc52Clipboard("Hello"));
+    }
+
+    [Fact]
+    public void TmuxPassthrough_WrapsOsc52Sequence()
+    {
+        var wrapped = AnsiCodes.TmuxPassthrough(AnsiCodes.Osc52Clipboard("Hello"));
+        Assert.StartsWith("\x1bPtmux;\x1b", wrapped);
+        Assert.EndsWith("\x1b\\", wrapped);
+        Assert.Contains("]52;c;SGVsbG8=\x07", wrapped.Replace("\x1b\x1b", "\x1b"));
+    }
 }

--- a/tests/Termina.Tests/Terminal/DiffingTerminalTests.cs
+++ b/tests/Termina.Tests/Terminal/DiffingTerminalTests.cs
@@ -324,6 +324,26 @@ public class DiffingTerminalTests
     }
 
     [Fact]
+    public void CopyToClipboard_PassesThroughWithoutChangingFrame()
+    {
+        var inner = new VirtualTerminal(80, 24);
+        var diffing = new DiffingTerminal(inner);
+
+        diffing.MoveTo(0, 0);
+        diffing.Write("Hello");
+        diffing.Flush();
+
+        var screenBeforeCopy = inner.ToString();
+        var rawCountBeforeCopy = inner.RawOutput.Count;
+
+        diffing.CopyToClipboard("https://example.com/oauth");
+
+        Assert.Equal(screenBeforeCopy, inner.ToString());
+        Assert.Equal(rawCountBeforeCopy + 1, inner.RawOutput.Count);
+        Assert.Contains("]52;c;", inner.RawOutput[^1]);
+    }
+
+    [Fact]
     public void Write_HandlesNewlines()
     {
         var inner = new VirtualTerminal(80, 24);

--- a/tests/Termina.Tests/Terminal/VirtualTerminalTests.cs
+++ b/tests/Termina.Tests/Terminal/VirtualTerminalTests.cs
@@ -418,6 +418,17 @@ public class VirtualTerminalTests
     }
 
     [Fact]
+    public void CopyToClipboard_CapturesOsc52SequenceInRawOutput()
+    {
+        var terminal = new VirtualTerminal();
+
+        terminal.CopyToClipboard("Hello");
+
+        Assert.Single(terminal.RawOutput);
+        Assert.Equal("\x1b]52;c;SGVsbG8=\x07", terminal.RawOutput[0]);
+    }
+
+    [Fact]
     public void Flush_IsNoOp()
     {
         var terminal = new VirtualTerminal();


### PR DESCRIPTION
## Summary
- add terminal-native clipboard support with OSC 52 plus tmux transport fallback, global toast infrastructure, and copy/paste feedback hooks
- introduce `CopyableTextNode` with keyboard selection, customizable copy bindings, and configurable success feedback via toast or inline indicators
- expand the gallery demo and docs to cover clipboard transports, feedback configuration, and manual validation workflows

## Verification
- `\"/home/petabridge/.dotnet/dotnet\" test tests/Termina.Tests/Termina.Tests.csproj --filter \"FullyQualifiedName~AnsiCodesTests|FullyQualifiedName~DiffingTerminalTests|FullyQualifiedName~VirtualTerminalTests|FullyQualifiedName~CopyableTextNodeTests|FullyQualifiedName~ToastServiceTests|FullyQualifiedName~ToastOverlayNodeTests|FullyQualifiedName~PasteToastRoutingTests|FullyQualifiedName~TerminalClipboardServiceTests\"`
- `\"/home/petabridge/.dotnet/dotnet\" build demos/Termina.Demo.Gallery/Termina.Demo.Gallery.csproj`