### PR TITLE
Extract only latest release block for GitHub release body

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -40,11 +40,22 @@ jobs:
     - name: Push Packages
       run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
 
+    - name: "Extract latest release notes"
+      shell: pwsh
+      run: |
+        $content = Get-Content RELEASE_NOTES.md -Raw
+        # Match from the first #### heading to just before the second one
+        if ($content -match '(?s)(####.+?)(?=\n####|\z)') {
+          $Matches[1].Trim() | Set-Content RELEASE_NOTES_LATEST.md
+        } else {
+          $content | Set-Content RELEASE_NOTES_LATEST.md
+        }
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
         name: 'Termina ${{ github.ref_name }}'
-        body_path: RELEASE_NOTES.md
+        body_path: RELEASE_NOTES_LATEST.md
         draft: false
         prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}
         files: |


### PR DESCRIPTION
## Summary
- GitHub releases were including the entire `RELEASE_NOTES.md` as the release body, causing every release to contain the full changelog history
- Added a PowerShell step that extracts only the first `####` block (the latest release) into a temp file `RELEASE_NOTES_LATEST.md`
- Release action now uses `RELEASE_NOTES_LATEST.md` instead of the full file

## Test plan
- [ ] Verify the regex correctly extracts only the top release block from `RELEASE_NOTES.md`
- [ ] Confirm next tagged release on GitHub shows only the current version's notes