### PR TITLE
Add F6 selection mode to hand mouse back to terminal

### DIFF
--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -270,8 +270,8 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
                         (isGenerating, showDecision) => showDecision
                             ? "[↑/↓] Navigate [Enter] Select [1-4] Quick Select [Esc] Skip"
                             : isGenerating
-                                ? "[Esc] Cancel  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit"
-                                : "[Enter] Send  [Ctrl+Shift+V] Paste  [↑/↓] History  [PgUp/PgDn/Wheel] Scroll  [Esc] Clear/Quit  [Ctrl+Q] Quit")
+                                ? "[Esc] Cancel  [PgUp/PgDn/Wheel] Scroll  [F6] Select Text  [Ctrl+Q] Quit"
+                                : "[Enter] Send  [Ctrl+Shift+V] Paste  [↑/↓] History  [PgUp/PgDn/Wheel] Scroll  [F6] Select Text  [Esc] Clear/Quit  [Ctrl+Q] Quit")
                     .Select<string, ILayoutNode>(text => new TextNode(text).WithForeground(Color.BrightBlack).NoWrap())
                     .AsLayout()
                     .Height(1))

--- a/src/Termina/Layout/SelectionModeIndicatorNode.cs
+++ b/src/Termina/Layout/SelectionModeIndicatorNode.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Overlay node that renders a "SELECTION MODE" banner at the top-center of the screen
+/// whenever selection mode is active on the application.
+/// </summary>
+/// <remarks>
+/// Designed to overlay the current page via <see cref="StackLayout"/> — does not consume
+/// space, only paints a single row at the top of its bounds.
+/// </remarks>
+internal sealed class SelectionModeIndicatorNode : LayoutNode, IInvalidatingNode
+{
+    private const string Message = " SELECTION MODE — drag to select, Esc to exit ";
+
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly IDisposable _subscription;
+    private bool _active;
+    private bool _disposed;
+
+    public SelectionModeIndicatorNode(Observable<bool> activeState)
+    {
+        WidthConstraint = new SizeConstraint.Fill();
+        HeightConstraint = new SizeConstraint.Fill();
+
+        _subscription = activeState.Subscribe(active =>
+        {
+            _active = active;
+            _invalidated.OnNext(Unit.Default);
+        });
+    }
+
+    public Observable<Unit> Invalidated => _invalidated;
+
+    public override Size Measure(Size available) => available;
+
+    public override void Render(IRenderContext context, Rect bounds)
+    {
+        if (_active && bounds.HasArea && bounds.Height >= 1)
+        {
+            var width = Math.Min(bounds.Width, Message.Length);
+            var x = Math.Max(0, (bounds.Width - width) / 2);
+            var text = width < Message.Length ? Message[..width] : Message;
+
+            context.SetBackground(Color.Yellow);
+            context.SetForeground(Color.Black);
+            context.SetDecoration(TextDecoration.Bold);
+            context.WriteAt(x, 0, text);
+            context.ResetColors();
+        }
+    }
+
+    public override void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _subscription.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -53,6 +53,9 @@ public sealed class TerminaApplication
     private readonly IToastService? _toastService;
     private readonly ToastOverlayNode? _toastOverlay;
     private readonly IDisposable? _toastInvalidationSubscription;
+    private readonly ReactiveProperty<bool> _selectionModeActive = new(false);
+    private readonly SelectionModeIndicatorNode _selectionModeIndicator;
+    private readonly IDisposable _selectionModeIndicatorSubscription;
 
     private string? _currentPath;
     private IReadOnlyDictionary<string, object>? _currentParameters;
@@ -97,6 +100,8 @@ public sealed class TerminaApplication
         _toastService = serviceProvider?.GetService<IToastService>();
         _toastOverlay = _toastService != null ? new ToastOverlayNode(_toastService) : null;
         _toastInvalidationSubscription = _toastOverlay?.Invalidated.Subscribe(_ => RequestRedraw());
+        _selectionModeIndicator = new SelectionModeIndicatorNode(_selectionModeActive);
+        _selectionModeIndicatorSubscription = _selectionModeIndicator.Invalidated.Subscribe(_ => RequestRedraw());
 
         // If using DI, check for registered input sources
         if (serviceProvider != null)
@@ -113,6 +118,55 @@ public sealed class TerminaApplication
     /// Observable stream of input events. ViewModels subscribe to this.
     /// </summary>
     public Observable<IInputEvent> Input => _inputSubject.AsObservable();
+
+    /// <summary>
+    /// Observable that emits whenever selection mode is toggled on or off.
+    /// Emits the new state (<c>true</c> = active, <c>false</c> = inactive).
+    /// </summary>
+    /// <remarks>
+    /// When selection mode is active, Termina temporarily hands mouse input back to the
+    /// terminal emulator by disabling its own mouse tracking. This lets the user use the
+    /// terminal's native click-and-drag selection and copy, at the cost of losing mouse
+    /// scroll-wheel support while the mode is active. Press <c>F6</c> or <c>Escape</c> to
+    /// exit — or call <see cref="ExitSelectionMode"/> programmatically.
+    /// </remarks>
+    public Observable<bool> SelectionModeActive => _selectionModeActive;
+
+    /// <summary>
+    /// Whether selection mode is currently active.
+    /// </summary>
+    public bool IsSelectionModeActive => _selectionModeActive.Value;
+
+    /// <summary>
+    /// Enters selection mode if not already active. Disables app-level mouse tracking so
+    /// the user's terminal emulator can handle click-and-drag selection natively, with
+    /// native visual feedback and OS clipboard integration.
+    /// </summary>
+    public void EnterSelectionMode()
+    {
+        if (_selectionModeActive.Value)
+            return;
+
+        TerminaTrace.Input.Info(this, "Entering selection mode — disabling mouse tracking");
+        _terminal.DisableMouse();
+        _terminal.Flush();
+        _selectionModeActive.Value = true;
+    }
+
+    /// <summary>
+    /// Exits selection mode if active. Re-enables app-level mouse tracking so mouse
+    /// scroll-wheel events resume being delivered to the app.
+    /// </summary>
+    public void ExitSelectionMode()
+    {
+        if (!_selectionModeActive.Value)
+            return;
+
+        TerminaTrace.Input.Info(this, "Exiting selection mode — re-enabling mouse tracking");
+        _terminal.EnableMouse();
+        _terminal.Flush();
+        _selectionModeActive.Value = false;
+    }
 
     /// <summary>
     /// Gets the focus manager for routing input to focused components.
@@ -550,6 +604,14 @@ public sealed class TerminaApplication
             {
                 TerminaTrace.Input.Trace(this, "KeyPressed: key={0}, mods={1}", keyPressed.KeyInfo.Key, keyPressed.KeyInfo.Modifiers);
 
+                // FRAMEWORK CAPTURE: selection-mode toggle runs before any page handler
+                // so it can never be shadowed by page-level key bindings.
+                if (HandleSelectionModeKey(keyPressed.KeyInfo))
+                {
+                    TerminaTrace.Input.Trace(this, "Key consumed by selection-mode handler");
+                    return;
+                }
+
                 // CAPTURE PHASE: Page-level key bindings get first chance
                 // This allows pages to intercept keys (like Escape) before focused components consume them
                 if (_currentPage is IBindablePage bindablePage)
@@ -573,6 +635,35 @@ public sealed class TerminaApplication
             TerminaTrace.Input.Trace(this, "Routing input to ViewModel");
             _inputSubject.OnNext(inputEvent);
         }
+    }
+
+    /// <summary>
+    /// Framework-level handler that intercepts selection-mode toggles before any page
+    /// or focused-component handler sees the key. Returns <c>true</c> if the key was
+    /// consumed and should not propagate further.
+    /// </summary>
+    private bool HandleSelectionModeKey(ConsoleKeyInfo keyInfo)
+    {
+        // F6 toggles selection mode from any state. Picked for universal compatibility:
+        // works without the kitty keyboard protocol and bypasses tmux escape-passthrough.
+        if (keyInfo.Key == ConsoleKey.F6 && keyInfo.Modifiers == 0)
+        {
+            if (_selectionModeActive.Value)
+                ExitSelectionMode();
+            else
+                EnterSelectionMode();
+            return true;
+        }
+
+        // Escape while in selection mode always exits it — do not let pages see the key,
+        // otherwise a page-level Escape binding could navigate away unexpectedly.
+        if (keyInfo.Key == ConsoleKey.Escape && _selectionModeActive.Value)
+        {
+            ExitSelectionMode();
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -608,10 +699,15 @@ public sealed class TerminaApplication
     private void RenderCurrentPage()
     {
         var layoutRoot = GetCurrentLayoutRoot() ?? new TextNode("No page active");
+
+        // Compose overlays on top of the page, in paint order: toast below, selection-mode
+        // indicator above. The indicator always participates so transitions flip state
+        // cleanly; it renders nothing when selection mode is inactive.
+        var children = new List<ILayoutNode> { layoutRoot };
         if (_toastOverlay != null)
-        {
-            layoutRoot = new StackLayout([layoutRoot, new DeferredNode(() => _toastOverlay)]);
-        }
+            children.Add(new DeferredNode(() => _toastOverlay));
+        children.Add(_selectionModeIndicator);
+        layoutRoot = new StackLayout(children);
 
         // Clear the pending buffer (DiffingTerminal) or screen (other terminals)
         _terminal.ClearScreen();
@@ -703,6 +799,9 @@ public sealed class TerminaApplication
 
         _toastInvalidationSubscription?.Dispose();
         _toastOverlay?.Dispose();
+        _selectionModeIndicatorSubscription.Dispose();
+        _selectionModeIndicator.Dispose();
+        _selectionModeActive.Dispose();
     }
 }
 

--- a/tests/Termina.Tests/Input/SelectionModeToggleTests.cs
+++ b/tests/Termina.Tests/Input/SelectionModeToggleTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Terminal;
+
+namespace Termina.Tests.Input;
+
+/// <summary>
+/// Tests for the framework-level selection mode toggle in <see cref="TerminaApplication"/>.
+/// Selection mode hands mouse input back to the terminal emulator by calling
+/// <see cref="IAnsiTerminal.DisableMouse"/>, allowing native click-drag selection.
+/// </summary>
+public class SelectionModeToggleTests
+{
+    [Fact]
+    public void EnterSelectionMode_DisablesTerminalMouseTracking()
+    {
+        var terminal = new VirtualTerminal();
+        terminal.EnableMouse();
+        Assert.True(terminal.MouseEnabled);
+
+        var app = NewApp(terminal);
+        app.EnterSelectionMode();
+
+        Assert.False(terminal.MouseEnabled);
+        Assert.True(app.IsSelectionModeActive);
+    }
+
+    [Fact]
+    public void ExitSelectionMode_ReenablesTerminalMouseTracking()
+    {
+        var terminal = new VirtualTerminal();
+        var app = NewApp(terminal);
+
+        app.EnterSelectionMode();
+        app.ExitSelectionMode();
+
+        Assert.True(terminal.MouseEnabled);
+        Assert.False(app.IsSelectionModeActive);
+    }
+
+    [Fact]
+    public void EnterSelectionMode_IsIdempotent()
+    {
+        var terminal = new VirtualTerminal();
+        var app = NewApp(terminal);
+
+        app.EnterSelectionMode();
+        app.EnterSelectionMode();
+
+        Assert.True(app.IsSelectionModeActive);
+        Assert.False(terminal.MouseEnabled);
+    }
+
+    [Fact]
+    public void ExitSelectionMode_IsIdempotent()
+    {
+        var terminal = new VirtualTerminal();
+        var app = NewApp(terminal);
+
+        app.ExitSelectionMode();
+
+        Assert.False(app.IsSelectionModeActive);
+    }
+
+    [Fact]
+    public void F6_Toggles_SelectionMode_On_Then_Off()
+    {
+        var terminal = new VirtualTerminal();
+        var app = NewApp(terminal);
+        RegisterMinimalPage(app);
+
+        ProcessKey(app, ConsoleKey.F6);
+        Assert.True(app.IsSelectionModeActive);
+        Assert.False(terminal.MouseEnabled);
+
+        ProcessKey(app, ConsoleKey.F6);
+        Assert.False(app.IsSelectionModeActive);
+        Assert.True(terminal.MouseEnabled);
+    }
+
+    [Fact]
+    public void Escape_ExitsSelectionMode_And_IsSwallowed()
+    {
+        var terminal = new VirtualTerminal();
+        var app = NewApp(terminal);
+        var page = RegisterMinimalPage(app);
+
+        app.EnterSelectionMode();
+        page.EscapeCount = 0;
+
+        ProcessKey(app, ConsoleKey.Escape);
+
+        Assert.False(app.IsSelectionModeActive);
+        Assert.Equal(0, page.EscapeCount);
+    }
+
+    [Fact]
+    public void Escape_OutsideSelectionMode_ReachesPage()
+    {
+        var terminal = new VirtualTerminal();
+        var app = NewApp(terminal);
+        var page = RegisterMinimalPage(app);
+
+        page.EscapeCount = 0;
+        ProcessKey(app, ConsoleKey.Escape);
+
+        Assert.Equal(1, page.EscapeCount);
+    }
+
+    [Fact]
+    public void F6_WithModifier_IsNotIntercepted()
+    {
+        var terminal = new VirtualTerminal();
+        var app = NewApp(terminal);
+        RegisterMinimalPage(app);
+
+        // Shift+F6 should NOT toggle selection mode — only bare F6.
+        InvokeProcessEvent(app, new KeyPressed(
+            new ConsoleKeyInfo('\0', ConsoleKey.F6, shift: true, alt: false, control: false)));
+
+        Assert.False(app.IsSelectionModeActive);
+    }
+
+    private static TerminaApplication NewApp(VirtualTerminal terminal) => new(terminal);
+
+    private static TestPage RegisterMinimalPage(TerminaApplication app)
+    {
+        app.RegisterRoute<TestPage, TestViewModel>("/test");
+        app.NavigateTo("/test");
+        return GetActivePage(app);
+    }
+
+    private static TestPage GetActivePage(TerminaApplication app)
+    {
+        var field = typeof(TerminaApplication).GetField("_currentPage",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(field);
+        var page = field!.GetValue(app);
+        return Assert.IsType<TestPage>(page);
+    }
+
+    private static void ProcessKey(TerminaApplication app, ConsoleKey key)
+    {
+        InvokeProcessEvent(app, new KeyPressed(new ConsoleKeyInfo('\0', key, false, false, false)));
+    }
+
+    private static void InvokeProcessEvent(TerminaApplication app, object evt)
+    {
+        var method = typeof(TerminaApplication).GetMethod(
+            "ProcessEvent",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(method);
+        method!.Invoke(app, [evt]);
+    }
+
+    public sealed class TestPage : ReactivePage<TestViewModel>
+    {
+        public int EscapeCount { get; set; }
+
+        public override ILayoutNode BuildLayout() => new TextNode("test");
+
+        public override bool HandlePageInput(ConsoleKeyInfo keyInfo)
+        {
+            if (keyInfo.Key == ConsoleKey.Escape)
+            {
+                EscapeCount++;
+                return true;
+            }
+            return base.HandlePageInput(keyInfo);
+        }
+    }
+
+    public sealed class TestViewModel : ReactiveViewModel
+    {
+    }
+}


### PR DESCRIPTION
## Summary

- Framework-level **F6** toggle temporarily disables app-side SGR mouse tracking so the terminal emulator can handle native click-and-drag text selection, with its own visual feedback and OS clipboard integration.
- Yellow banner overlay signals the mode is active; **Escape** or **F6** again exits. Escape is swallowed while active so page-level Escape bindings (e.g. navigate back, cancel generation) don't fire on exit.
- Key interception runs before page capture so pages cannot shadow it. `EnterSelectionMode()` / `ExitSelectionMode()` are also exposed publicly for programmatic control.

Fixes #192. Supersedes and closes #193 (the previous PR attempted app-owned selection via `HandleMouseEvent`, but the escape-sequence parser silently consumes clicks/drags and the terminal wasn't configured for drag motion, so that code path was unreachable end-to-end on Linux).

## Why terminal-native selection instead of app-owned

SGR mouse mode is all-or-nothing — there's no way to subscribe only to the scroll wheel without also capturing clicks and drags. The simplest fix for the Netclaw use case is to temporarily *hand the mouse back* to the terminal on demand, which gets us working selection with zero coordinate math, no tmux passthrough gymnastics, and no custom highlight rendering. The tradeoff is that scroll wheel stops working while selection mode is active — pages with scrollable content already expose PgUp/PgDn keyboard equivalents.

### Why F6 and not Ctrl+Shift+S

F6 is a bare function key with a standard escape sequence that `Console.ReadKey` parses universally. It works without the kitty keyboard protocol and survives tmux without requiring passthrough config. Ctrl+Shift+S would only be distinguishable from Ctrl+S on kitty-protocol-capable terminals — in plain GNOME Terminal or tmux it'd collapse to XOFF.

## Test plan

- [x] `dotnet test` — full suite 1010/1010 passing, including 8 new `SelectionModeToggleTests` covering direct API idempotency, F6 toggle through `ProcessEvent`, Escape-in-mode exits + swallows, Escape-outside still reaches the page, Shift+F6 not intercepted.
- [ ] Manual test in `Termina.Demo.Streaming`: press F6, verify banner appears, click-drag selection works in host terminal (GNOME Terminal / Kitty / WezTerm), scroll wheel disabled while mode is active, F6/Esc exits, scroll wheel resumes.
- [ ] Manual test inside tmux to confirm F6 reaches the app and mouse hand-off works through tmux's own mouse handling.