### PR TITLE
Fix garbled output when terminal isn't already UTF-8 at startup (#204)

### DIFF
--- a/src/Termina/Terminal/AnsiTerminal.cs
+++ b/src/Termina/Terminal/AnsiTerminal.cs
@@ -25,23 +25,24 @@ public sealed class AnsiTerminal : IAnsiTerminal, IDisposable
     /// </summary>
     /// <param name="useAlternateScreen">Whether to use alternate screen buffer on startup.</param>
     public AnsiTerminal(bool useAlternateScreen = true)
-        : this(Console.Out, useAlternateScreen)
+        : this(null, useAlternateScreen)
     {
     }
 
     /// <summary>
-    /// Create an AnsiTerminal writing to a specific TextWriter.
+    /// Create an AnsiTerminal. A specific TextWriter may be specified, or null for stdout.
     /// </summary>
-    internal AnsiTerminal(TextWriter output, bool useAlternateScreen = true)
+    internal AnsiTerminal(TextWriter? output, bool useAlternateScreen = true)
     {
-        _output = output;
+        // Set console to UTF-8.  (N.B. This may replace Console.Out.)
+        Console.OutputEncoding = Encoding.UTF8;
+        
+        _output = output ?? Console.Out;
+
         _useAlternateScreen = useAlternateScreen;
 
         TerminaTrace.Platform.Debug(this, "AnsiTerminal created: output={0}, useAlternateScreen={1}",
-            output.GetType().Name, useAlternateScreen);
-
-        // Set console to UTF-8
-        Console.OutputEncoding = Encoding.UTF8;
+            _output.GetType().Name, useAlternateScreen);
 
         if (_useAlternateScreen)
         {


### PR DESCRIPTION
* Fix garbled output when terminal isn't already UTF-8 at startup (#204)

Setting Console.OutputEncoding replaces Console.Out with a new TextWriter.  We need to save the new TextWriter if we're going to write through it later - otherwise, if the old one was not UTF-8, any characters written through it that are out of range for its encoding will be replaced with a replacement character (e.g. U+FFFD).

Fixes #204

## Changes

Re-jig `AnsiConsole` ctors so that we don't capture `Console.Out` before we change the console encoding (and hence replace `Console.Out`)

## Checklist

(Akka.NET template ignored - I did make an effort to follow relevant guidance in the CONTRIBUTORS file but will double-check on that since I moved the code a little since then)

### Latest `dev` Benchmarks / This PR's Benchmarks

(More from the Akka.NET template here but happy to follow up if there's also benchmark guidelines here)