### PR TITLE
Fix garbled output when terminal isn't UTF-8 at startup (#204)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+#### 0.8.1 May 17th 2026 ####
+
+**Bug Fixes**:
+- **Fixed garbled output when the terminal does not start in UTF-8** ([#204](https://github.com/Aaronontheweb/termina/issues/204))
+  - `AnsiTerminal` no longer caches `Console.Out`. Setting `Console.OutputEncoding` replaces `Console.Out` with a new `TextWriter`, so a cached reference could be left bound to a stale, non-UTF-8 encoding — rendering Unicode box-drawing characters as `U+FFFD`. The output writer is now resolved on every flush.
+  - Consolidated UTF-8 output-encoding setup into a single owner (`ConsoleEnvironment.EnsureUtf8Output`, invoked by the platform console) instead of three separate call sites.
+  - Original problem diagnosed by [@logical-intent](https://github.com/logical-intent) in [#204](https://github.com/Aaronontheweb/termina/issues/204) / [#205](https://github.com/Aaronontheweb/termina/pull/205).
+
+---
+
 #### 0.8.0 March 17th 2026 ####
 
 **New Features**:

--- a/src/Termina/Platform/ConsoleEnvironment.cs
+++ b/src/Termina/Platform/ConsoleEnvironment.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Termina.Platform;
+
+/// <summary>
+/// Single owner of process-global console environment configuration.
+/// </summary>
+internal static class ConsoleEnvironment
+{
+    /// <summary>
+    /// Ensures the console uses UTF-8 output encoding so Unicode glyphs (box-drawing
+    /// characters, symbols, emoji) render instead of being replaced with U+FFFD.
+    /// Invoked once by the platform console during initialization; idempotent.
+    /// </summary>
+    /// <remarks>
+    /// Setting <see cref="Console.OutputEncoding"/> replaces <see cref="Console.Out"/>
+    /// with a new <see cref="TextWriter"/> bound to the new encoding. Callers must not
+    /// cache <see cref="Console.Out"/> across this call. See issue #204.
+    /// </remarks>
+    public static void EnsureUtf8Output()
+    {
+        Console.OutputEncoding = Encoding.UTF8;
+    }
+}

--- a/src/Termina/Platform/FallbackConsole.cs
+++ b/src/Termina/Platform/FallbackConsole.cs
@@ -35,8 +35,8 @@ public sealed class FallbackConsole : IPlatformConsole
     /// <inheritdoc />
     public void Initialize()
     {
-        // Set UTF-8 encoding for proper Unicode support
-        Console.OutputEncoding = System.Text.Encoding.UTF8;
+        // Set UTF-8 encoding for proper Unicode support (single owner: ConsoleEnvironment)
+        ConsoleEnvironment.EnsureUtf8Output();
 
         // Capture initial dimensions
         try

--- a/src/Termina/Platform/WindowsConsole.cs
+++ b/src/Termina/Platform/WindowsConsole.cs
@@ -310,8 +310,8 @@ public sealed class WindowsConsole : IPlatformConsole
             }
         }
 
-        // Ensure UTF-8 output encoding
-        Console.OutputEncoding = System.Text.Encoding.UTF8;
+        // Ensure UTF-8 output encoding (single owner: ConsoleEnvironment)
+        ConsoleEnvironment.EnsureUtf8Output();
         TerminaTrace.Platform.Debug(this, "Set Console.OutputEncoding to UTF-8");
 
         // Capture initial window size for resize event deduplication

--- a/src/Termina/Terminal/AnsiTerminal.cs
+++ b/src/Termina/Terminal/AnsiTerminal.cs
@@ -12,7 +12,12 @@ namespace Termina.Terminal;
 /// </summary>
 public sealed class AnsiTerminal : IAnsiTerminal, IDisposable
 {
-    private readonly TextWriter _output;
+    /// <summary>
+    /// Explicit output writer for tests/benchmarks, or <c>null</c> to write to
+    /// <see cref="Console.Out"/>. A cached <see cref="Console.Out"/> is deliberately
+    /// never stored here — see <see cref="Output"/>.
+    /// </summary>
+    private readonly TextWriter? _explicitOutput;
     private readonly StringBuilder _buffer = new();
     private readonly bool _useAlternateScreen;
     private bool _inAlternateScreen;
@@ -25,23 +30,26 @@ public sealed class AnsiTerminal : IAnsiTerminal, IDisposable
     /// </summary>
     /// <param name="useAlternateScreen">Whether to use alternate screen buffer on startup.</param>
     public AnsiTerminal(bool useAlternateScreen = true)
-        : this(Console.Out, useAlternateScreen)
+        : this(null, useAlternateScreen)
     {
     }
 
     /// <summary>
-    /// Create an AnsiTerminal writing to a specific TextWriter.
+    /// Create an AnsiTerminal. Pass an explicit <paramref name="output"/> writer for
+    /// tests/benchmarks, or <c>null</c> to write to <see cref="Console.Out"/>.
     /// </summary>
-    internal AnsiTerminal(TextWriter output, bool useAlternateScreen = true)
+    internal AnsiTerminal(TextWriter? output, bool useAlternateScreen = true)
     {
-        _output = output;
+        _explicitOutput = output;
         _useAlternateScreen = useAlternateScreen;
 
         TerminaTrace.Platform.Debug(this, "AnsiTerminal created: output={0}, useAlternateScreen={1}",
-            output.GetType().Name, useAlternateScreen);
+            output?.GetType().Name ?? "Console.Out", useAlternateScreen);
 
-        // Set console to UTF-8
-        Console.OutputEncoding = Encoding.UTF8;
+        // NOTE: UTF-8 output encoding is configured once by the platform console
+        // (ConsoleEnvironment.EnsureUtf8Output). This terminal deliberately does not
+        // set Console.OutputEncoding and never caches Console.Out, because that setter
+        // replaces Console.Out with a new TextWriter — see issue #204.
 
         if (_useAlternateScreen)
         {
@@ -50,6 +58,14 @@ public sealed class AnsiTerminal : IAnsiTerminal, IDisposable
 
         TerminaTrace.Platform.Debug(this, "AnsiTerminal initialization complete");
     }
+
+    /// <summary>
+    /// The writer used for output. Resolved on every access — never cached — because
+    /// setting <see cref="Console.OutputEncoding"/> replaces <see cref="Console.Out"/>
+    /// with a new <see cref="TextWriter"/>. Caching it risks writing through a writer
+    /// bound to a stale encoding, garbling non-ASCII output. See issue #204.
+    /// </summary>
+    private TextWriter Output => _explicitOutput ?? Console.Out;
 
     /// <inheritdoc />
     public int Width => GetConsoleWidth();
@@ -181,8 +197,10 @@ public sealed class AnsiTerminal : IAnsiTerminal, IDisposable
                 _flushCount, content.Length, byteCount);
             TerminaTrace.Render.Debug(this, "Content preview: {0}", preview);
 
-            _output.Write(content);
-            _output.Flush();
+            // Resolve Console.Out fresh on every flush — never cache it (see Output).
+            var output = Output;
+            output.Write(content);
+            output.Flush();
             _buffer.Clear();
 
             TerminaTrace.Render.Debug(this, "Flush #{0} complete", _flushCount);

--- a/tests/Termina.Tests/Terminal/AnsiTerminalTests.cs
+++ b/tests/Termina.Tests/Terminal/AnsiTerminalTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Termina.Terminal;
+
+namespace Termina.Tests.Terminal;
+
+/// <summary>
+/// Regression tests for how <see cref="AnsiTerminal"/> resolves its output writer.
+/// </summary>
+/// <remarks>
+/// These tests mutate process-global <see cref="Console.Out"/>. They share a
+/// collection so they never run concurrently with other console-touching tests.
+/// </remarks>
+[Collection("Console serialization")]
+public class AnsiTerminalTests
+{
+    [Fact]
+    public void Flush_writes_to_current_ConsoleOut_not_a_stale_reference()
+    {
+        // Regression test for #204: AnsiTerminal used to capture Console.Out at
+        // construction. Setting Console.OutputEncoding (done by the platform console
+        // during startup) replaces Console.Out with a new TextWriter, so the captured
+        // reference went stale — on a non-UTF-8 console this garbled Unicode output.
+        var original = Console.Out;
+        try
+        {
+            // Terminal constructed BEFORE Console.Out is replaced.
+            using var terminal = new AnsiTerminal(useAlternateScreen: false);
+
+            // Replace Console.Out, exactly as setting Console.OutputEncoding does at startup.
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+
+            terminal.Write("┌──┐");
+            terminal.Flush();
+
+            // A terminal that cached Console.Out would have written to the pre-swap
+            // writer, leaving `captured` empty.
+            Assert.Contains("┌──┐", captured.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+
+    [Fact]
+    public void Flush_uses_explicit_writer_when_one_is_provided()
+    {
+        // The internal constructor's explicit-writer seam must bypass Console.Out entirely.
+        var explicitWriter = new StringWriter();
+        var consoleSink = new StringWriter();
+        var original = Console.Out;
+        try
+        {
+            Console.SetOut(consoleSink);
+
+            using var terminal = new AnsiTerminal(explicitWriter, useAlternateScreen: false);
+            terminal.Write("hello");
+            terminal.Flush();
+
+            Assert.Contains("hello", explicitWriter.ToString());
+            Assert.Empty(consoleSink.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #204. Supersedes #205.

## Problem

Setting `Console.OutputEncoding` **replaces `Console.Out` with a brand-new `TextWriter`** bound to the new encoding. `AnsiTerminal` captured `Console.Out` in its constructor, so on a console that did not start in UTF-8 (e.g. code page 850, the VS debugger case in #204) the cached writer stayed bound to the *old* encoding. Unicode box-drawing characters written through it were replaced with `U+FFFD`.

Credit to @logical-intent for diagnosing this precisely and proposing the original fix in #205.

## Approach

#205 fixes this by reordering the constructor so `Console.Out` is captured *after* the encoding flip. That works for the reported case, but it still **caches** `Console.Out` — and `Console.OutputEncoding` is set again later by `WindowsConsole`/`FallbackConsole.Initialize()`, which invalidates the cached writer. The cache is correct only as long as every encoding flip in the process happens to be UTF-8 and is timed just right.

This PR removes the coupling instead of timing around it:

- **`AnsiTerminal` no longer caches `Console.Out`.** The output writer is resolved on every flush via a private `Output` property (`_explicitOutput ?? Console.Out`). It always reflects the *current* `Console.Out`, regardless of when — or how often — the encoding changes. The explicit-writer seam for tests/benchmarks is preserved.
- **One owner for encoding setup.** UTF-8 configuration is consolidated into `ConsoleEnvironment.EnsureUtf8Output()`, invoked by the platform console during `Initialize()`, replacing the three separate `Console.OutputEncoding =` call sites (`AnsiTerminal`, `WindowsConsole`, `FallbackConsole`).

Performance is unchanged: `Console.Out`'s getter is a single volatile static read in steady state, resolved once per `Flush()` (once per frame) — negligible against the `ToString()`/encode/syscall the flush already does.

## Tests

Added `AnsiTerminalTests` with a deterministic regression test: construct an `AnsiTerminal`, swap `Console.Out` via `Console.SetOut` (exactly what setting `Console.OutputEncoding` does), then assert the flush lands in the *new* writer. This fails against both the original code and #205's caching approach, and passes only with non-caching. No real terminal or code-page juggling required.

All 1004 tests pass locally.

## Notes for reviewer

- **Behavior change:** `AnsiTerminal` no longer sets `Console.OutputEncoding` itself — the platform console owns it. In practice `AnsiTerminal` is always used via `TerminaApplication`, whose `RunAsync` calls `platformConsole.Initialize()` before the first render, so this is covered. A standalone `new AnsiTerminal()` used without a platform console would no longer force UTF-8; flag if that path should be supported.
- **Version/date** in `RELEASE_NOTES.md` (`0.8.1`, today) is a guess — adjust to match release cadence.
- CI will be red on the unrelated `OpenTelemetry.Api` `NU1902` advisory in `Termina.Demo.Streaming` — pre-existing on `dev`, not introduced here.
- A follow-up worth filing: move `AnsiTerminal`'s remaining constructor side effect (`EnterAlternateScreen`) into an explicit `Initialize()`/`Dispose()` lifecycle so setup ordering is explicit rather than emergent from the DI graph.