### PR TITLE
Fix CVE-2026-40894: pin OpenTelemetry.Api to 1.15.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,12 @@
     <PackageVersion Include="Akka.Hosting" Version="1.5.64" />
     <PackageVersion Include="R3" Version="1.3.0" />
   </ItemGroup>
+  <!-- Transitive dependency override (security): Akka.Hosting pulls in
+       OpenTelemetry.Api 1.9.0 transitively, which is affected by CVE-2026-40894
+       (GHSA-g94r-2vxg-569j). Pin it up to the first patched release. -->
+  <ItemGroup>
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+  </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />

--- a/demos/Termina.Demo.Streaming/Termina.Demo.Streaming.csproj
+++ b/demos/Termina.Demo.Streaming/Termina.Demo.Streaming.csproj
@@ -18,6 +18,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Akka.Hosting" />
+    <!-- Not used directly: pins the transitive OpenTelemetry.Api (pulled in by
+         Akka.Hosting) above the vulnerable 1.9.0. See CVE-2026-40894. -->
+    <PackageReference Include="OpenTelemetry.Api" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

CI is currently red on **every branch, including `dev`** — all build/test/AOT jobs fail at restore:

```
Termina.Demo.Streaming.csproj : error NU1902: Warning As Error:
Package 'OpenTelemetry.Api' 1.9.0 has a known moderate severity vulnerability
```

`Akka.Hosting 1.5.64` transitively pulls in `OpenTelemetry.Api 1.9.0`:

```
Akka.Hosting 1.5.64 → OpenTelemetry 1.9.0 → OpenTelemetry.Api.ProviderBuilderExtensions 1.9.0 → OpenTelemetry.Api 1.9.0
```

`OpenTelemetry.Api < 1.15.3` is affected by **CVE-2026-40894** (GHSA-g94r-2vxg-569j) — excessive memory allocation in propagation header parsing. The repo treats NuGet audit findings (`NU1902`) as build errors, so it breaks every build.

## Fix

Add a direct `PackageReference` to `OpenTelemetry.Api` in `Termina.Demo.Streaming` — the only project with the transitive dependency — pinned to the first patched release, **1.15.3**. The direct reference overrides the transitive `1.9.0`.

Surgical on purpose: I did **not** enable `CentralPackageTransitivePinningEnabled` repo-wide, because the test project pulls `Microsoft.CodeAnalysis.CSharp 5.3.0` transitively while CPM pins `4.12.0` — flipping that flag on would trigger an `NU1605` downgrade error. This change alters package resolution for no other project.

## Verification

- `dotnet build Termina.slnx -c Release` → 0 warnings, 0 errors (was failing).
- `dotnet nuget why` confirms `OpenTelemetry.Api` resolves to `1.15.3` across the graph.
- `dotnet list package --vulnerable --include-transitive` → no vulnerable packages.

No impact on the shipped `Termina` package — the vulnerable dependency only ever reached `Termina.Demo.Streaming` (a non-packable demo), via `Akka.Hosting`, which the core library does not reference.

Unblocks CI for #208 and any other open PR once they pick up `dev`.