### PR TITLE
SelectionListNode: add WithFillHeight() for full-height list mode

### DIFF
--- a/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
@@ -18,6 +18,7 @@ namespace Termina.Demo.Gallery.Pages;
 /// - "Other" option with fixed UX (Issue #102 fix)
 /// - Both single and multi-select modes
 /// - Rich multi-line content with styling
+/// - WithFillHeight() expanding a long list to fill its column (Issue #207 fix)
 /// </summary>
 public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewModel>
 {
@@ -98,13 +99,14 @@ public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewMod
             .WithHighlightColors(Color.Black, Color.Yellow)
             .WithVisibleRows(8);
 
-        // Scrolling list with 12 items in 6 visible rows
+        // Fill-height list with 100 items - expands to fill the column instead of
+        // being capped at the 10-row default (Issue #207).
         _numberedList = Layouts.SelectionList(
-            Enumerable.Range(1, 12).Select(i => $"Item number {i}"))
+            Enumerable.Range(1, 100).Select(i => $"Item number {i}"))
             .WithMode(SelectionMode.Single)
             .WithShowNumbers(true)
             .WithHighlightColors(Color.Black, Color.Cyan)
-            .WithVisibleRows(6);
+            .WithFillHeight();
 
         return Layouts.Vertical()
             .WithChild(BuildHeader())
@@ -163,16 +165,16 @@ public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewMod
                         .Height(2))
                 .WithChild(_multiSelectRichList));
 
-        // Column 3: Scrolling numbered list (12 items)
+        // Column 3: Fill-height numbered list (100 items)
         grid.SetCell(0, 2,
             Layouts.Vertical()
                 .WithChild(
-                    new TextNode("Scrolling List")
+                    new TextNode("Fill-Height List")
                         .WithForeground(Color.BrightCyan)
                         .Bold()
                         .Height(1))
                 .WithChild(
-                    new TextNode("12 items in 6 visible rows")
+                    new TextNode("100 items, WithFillHeight() fills the column")
                         .WithForeground(Color.DarkGray)
                         .Height(2))
                 .WithChild(_numberedList));

--- a/docs/components/selection-list-node.md
+++ b/docs/components/selection-list-node.md
@@ -179,14 +179,22 @@ var items = Enumerable.Range(1, 100).Select(i => "Item " + i);
 var list = Layouts.SelectionList(items)
     .WithFillHeight();
 
-// WithFillHeight() is also useful inside scrollable containers or panels
+// WithFillHeight() is also useful inside scrollable containers or panels.
+// Give the panel a Fill height so it claims the full height for the list to fill.
 var panel = Layouts.Panel()
     .WithTitle("Approvals")
     .WithBorder(BorderStyle.Rounded)
-    .WithChild(list);
+    .WithChild(list)
+    .Fill();
 ```
 
-When fill height is enabled, the node measures its height from `available.Height` at layout time, keeping scroll offsets and the scrollbar accurate. Calling `WithVisibleRows()` after `WithFillHeight()` disables fill mode and restores the fixed row count.
+When fill height is enabled, the node syncs its visible-row count from the height its parent allocates at layout time, keeping scroll offsets and the scrollbar accurate.
+
+A few details worth knowing:
+
+- Fill mode caps the measured height at the item count. If the list has fewer items than the available height, it sizes to its content rather than leaving empty rows — the list never reports a height taller than it can fill.
+- To truly fill a container, the container must allocate the full height. A `Fill`-constrained parent (e.g. a `VerticalLayout` slot or a `Fill()` panel) does this; an auto-sized parent shrinks to the list's content.
+- `WithFillHeight(false)` disables fill mode, as does calling `WithVisibleRows()` afterward — both restore the fixed row count.
 
 ## Styling
 

--- a/docs/components/selection-list-node.md
+++ b/docs/components/selection-list-node.md
@@ -169,6 +169,25 @@ list.OtherSelected.Subscribe(customText => {
 
 When the user navigates to or selects the "Other" option, a text input appears immediately inline, allowing them to type without pressing Enter first.
 
+## Sizing
+
+By default, `SelectionListNode` auto-sizes to its content with a maximum of 10 visible rows. Use `WithFillHeight()` to make the list expand and fill its parent's available vertical space — ideal for long lists in full-height panels:
+
+```csharp
+// 100 items filling the available height
+var items = Enumerable.Range(1, 100).Select(i => "Item " + i);
+var list = Layouts.SelectionList(items)
+    .WithFillHeight();
+
+// WithFillHeight() is also useful inside scrollable containers or panels
+var panel = Layouts.Panel()
+    .WithTitle("Approvals")
+    .WithBorder(BorderStyle.Rounded)
+    .WithChild(list);
+```
+
+When fill height is enabled, the node measures its height from `available.Height` at layout time, keeping scroll offsets and the scrollbar accurate. Calling `WithVisibleRows()` after `WithFillHeight()` disables fill mode and restores the fixed row count.
+
 ## Styling
 
 ```csharp
@@ -178,6 +197,7 @@ Layouts.SelectionList("A", "B", "C")
     .WithSelectedForeground(Color.Green)            // Checked items color
     .WithShowNumbers(true)                          // Show 1. 2. 3. prefixes
     .WithVisibleRows(5)                             // Max visible before scrolling
+    .WithFillHeight()                               // Fill available vertical space
 ```
 
 ## With Typed Items
@@ -390,6 +410,7 @@ public class SettingsPage : ReactivePage<SettingsViewModel>
 | `.WithSelectedForeground(Color)` | Set checked item color |
 | `.WithShowNumbers(bool)` | Show/hide number prefixes |
 | `.WithVisibleRows(int)` | Set max visible rows before scroll |
+| `.WithFillHeight()` | Fill available vertical space (overrides WithVisibleRows) |
 | `.WithOtherOption(string, Action?)` | Add custom input option |
 
 ### SelectionItem Properties

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -219,9 +219,14 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     /// using available.Height / bounds.Height as the visible row count.
     /// This overrides any previously set WithVisibleRows value.
     /// </summary>
-    public SelectionListNode<T> WithFillHeight()
+    /// <param name="fill">
+    /// When <c>true</c> (the default), the list fills its parent's available height.
+    /// When <c>false</c>, fill mode is disabled and the current <see cref="WithVisibleRows"/>
+    /// count is used.
+    /// </param>
+    public SelectionListNode<T> WithFillHeight(bool fill = true)
     {
-        _fillHeight = true;
+        _fillHeight = fill;
         return this;
     }
 
@@ -473,16 +478,14 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     public Size Measure(Size available)
     {
         var totalLines = TotalLineCount;
-        int height;
+
+        // In fill mode, the visible-row count is dictated by the space the parent
+        // allocates. Render() re-syncs this from bounds.Height (the authoritative
+        // value) so EnsureVisible()'s scroll math stays correct between renders.
         if (_fillHeight)
-        {
             _visibleRows = Math.Max(1, available.Height);
-            height = Math.Min(totalLines, _visibleRows);
-        }
-        else
-        {
-            height = Math.Min(totalLines, _visibleRows);
-        }
+
+        var height = Math.Min(totalLines, _visibleRows);
 
         // Calculate width based on content
         var maxItemWidth = _items.Count > 0
@@ -540,6 +543,13 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
 
         // Create a sub-context for this node's bounds so all coordinates are relative
         var subContext = context.CreateSubContext(bounds);
+
+        // In fill mode, bounds.Height is the authoritative visible-row count. Sync it
+        // here so EnsureVisible()'s scroll math is correct even if Render() runs without
+        // a preceding Measure() (e.g. as a Fill child, which VerticalLayout.Render does
+        // not re-measure).
+        if (_fillHeight)
+            _visibleRows = Math.Max(1, bounds.Height);
 
         var visibleLines = Math.Min(_visibleRows, bounds.Height);
         var needsScrollbar = TotalLineCount > visibleLines;

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -53,6 +53,7 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     private Color? _foreground;
     private Color? _selectedForeground;
     private bool _showNumbers = true;
+    private bool _fillHeight;
 
     /// <summary>
     /// Creates a new SelectionListNode with the specified items and plain text display.
@@ -122,7 +123,7 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     public SizeConstraint WidthConstraint => SizeConstraint.FillRemaining();
 
     /// <inheritdoc />
-    public SizeConstraint HeightConstraint => SizeConstraint.AutoSize();
+    public SizeConstraint HeightConstraint => _fillHeight ? SizeConstraint.FillRemaining() : SizeConstraint.AutoSize();
 
     /// <inheritdoc />
     public bool CanFocus => true;
@@ -209,6 +210,18 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     public SelectionListNode<T> WithVisibleRows(int rows)
     {
         _visibleRows = Math.Max(1, rows);
+        _fillHeight = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables fill-height mode: the list expands to fill the available vertical space,
+    /// using available.Height / bounds.Height as the visible row count.
+    /// This overrides any previously set WithVisibleRows value.
+    /// </summary>
+    public SelectionListNode<T> WithFillHeight()
+    {
+        _fillHeight = true;
         return this;
     }
 
@@ -460,7 +473,16 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     public Size Measure(Size available)
     {
         var totalLines = TotalLineCount;
-        var height = Math.Min(totalLines, _visibleRows);
+        int height;
+        if (_fillHeight)
+        {
+            _visibleRows = Math.Max(1, available.Height);
+            height = Math.Min(totalLines, _visibleRows);
+        }
+        else
+        {
+            height = Math.Min(totalLines, _visibleRows);
+        }
 
         // Calculate width based on content
         var maxItemWidth = _items.Count > 0

--- a/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
@@ -738,5 +738,88 @@ public class SelectionListNodeTests
         Assert.Equal("Header\nBody", item.Content.ToPlainText());
     }
 
+
+    [Fact]
+    public void SelectionListNode_WithFillHeight_ReturnsThis()
+    {
+        var items = new[] { "A", "B", "C" };
+        using var list = new SelectionListNode<string>(items, s => s);
+
+        var result = list.WithFillHeight();
+
+        Assert.Same(list, result);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithFillHeight_HeightConstraintIsFill()
+    {
+        using var list = Layouts.SelectionList("A", "B");
+
+        // Default: AutoSize
+        Assert.IsType<SizeConstraint.Auto>(list.HeightConstraint);
+
+        list.WithFillHeight();
+
+        Assert.IsType<SizeConstraint.Fill>(list.HeightConstraint);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithFillHeight_MeasureUsesAvailableHeight()
+    {
+        var items = Enumerable.Range(1, 50).Select(i => "Item " + i).ToArray();
+        using var list = new SelectionListNode<string>(items, s => s).WithFillHeight();
+
+        var measured = list.Measure(new Size(80, 30));
+
+        Assert.Equal(30, measured.Height);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithFillHeight_MeasureClampsToContentCount()
+    {
+        var items = new[] { "A", "B", "C" };
+        using var list = new SelectionListNode<string>(items, s => s).WithFillHeight();
+
+        var measured = list.Measure(new Size(80, 50));
+
+        Assert.Equal(3, measured.Height);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithFillHeight_SmallAvailableHeight_ClampsToOne()
+    {
+        var items = Enumerable.Range(1, 50).Select(i => "Item " + i).ToArray();
+        using var list = new SelectionListNode<string>(items, s => s).WithFillHeight();
+
+        var measured = list.Measure(new Size(80, 0));
+
+        Assert.Equal(1, measured.Height);
+    }
+
+    [Fact]
+    public void SelectionListNode_DefaultBehavior_CapsAtVisibleRows()
+    {
+        var items = Enumerable.Range(1, 50).Select(i => "Item " + i).ToArray();
+        using var list = new SelectionListNode<string>(items, s => s);
+
+        var measured = list.Measure(new Size(80, 50));
+
+        Assert.Equal(10, measured.Height);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithVisibleRows_DisablesFillHeight()
+    {
+        var items = Enumerable.Range(1, 50).Select(i => "Item " + i).ToArray();
+        using var list = new SelectionListNode<string>(items, s => s)
+            .WithFillHeight()
+            .WithVisibleRows(5);
+
+        Assert.IsType<SizeConstraint.Auto>(list.HeightConstraint);
+
+        var measured = list.Measure(new Size(80, 30));
+        Assert.Equal(5, measured.Height);
+    }
+
     #endregion
 }

--- a/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
@@ -4,6 +4,7 @@
 using R3;
 using Termina.Components.Streaming;
 using Termina.Layout;
+using Termina.Rendering;
 using Termina.Terminal;
 using Streaming = Termina.Components.Streaming;
 
@@ -819,6 +820,38 @@ public class SelectionListNodeTests
 
         var measured = list.Measure(new Size(80, 30));
         Assert.Equal(5, measured.Height);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithFillHeight_RenderSyncsVisibleRowsForScrolling()
+    {
+        // 50 items in a fill-height list rendered straight into a 5-row viewport with
+        // no preceding Measure() -- this is how VerticalLayout.Render treats a Fill
+        // child. Render() must sync the visible-row count from bounds.Height so that
+        // EnsureVisible()'s scroll math uses 5, not the default _visibleRows of 10.
+        var items = Enumerable.Range(1, 50).Select(i => "Item " + i).ToArray();
+        using var list = new SelectionListNode<string>(items, s => s).WithFillHeight();
+
+        var terminal = new VirtualTerminal(30, 5);
+        var context = new RegionRenderContext(terminal, 0, 0, 30, 5);
+
+        list.Render(context, new Rect(0, 0, 30, 5));
+
+        // Navigate well past the bottom of the 5-row viewport.
+        var downKey = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+        for (var i = 0; i < 10; i++)
+            list.HandleInput(downKey);
+
+        list.Render(context, new Rect(0, 0, 30, 5));
+
+        var rendered = string.Join("\n", Enumerable.Range(0, 5).Select(terminal.GetLine));
+
+        // The highlight is on "Item 11" (index 10). With visible rows synced to 5 the
+        // list scrolls to keep it on screen (offset 6 -> items 7..11). If _visibleRows
+        // were stuck at 10, EnsureVisible() would scroll only to offset 1 and "Item 11"
+        // would fall off the bottom of the viewport.
+        Assert.Contains("Item 11", rendered);
+        Assert.Contains("Item 7", rendered);
     }
 
     #endregion


### PR DESCRIPTION
## Summary\n\n was capped at a static `_visibleRows` of 10 with no way to expand to fill available vertical space. Adding `WithFillHeight()` as an opt-in that switches `HeightConstraint` to `FillRemaining` and uses `available.Height` at measure time as the visible row count.\n\n## Changes\n\n- Add `_fillHeight` field and `WithFillHeight()` fluent builder\n- `HeightConstraint` returns `FillRemaining()` in fill mode, `AutoSize()` otherwise\n- `Measure()` updates `_visibleRows` from `available.Height` to keep scroll math (`EnsureVisible`) and scrollbar correct\n- `WithVisibleRows()` resets `_fillHeight` to false so it properly overrides\n- 7 new tests covering fill mode, clamping, and override semantics\n\n## Testing\n\nAll 47 tests pass (40 existing + 7 new), 0 failures.\n\nFixes #207