### PR TITLE
Fix navigation data race that crashes pages on ARM64

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -141,7 +141,7 @@ jobs:
             runtime: linux-x64
           - os: windows-latest
             runtime: win-x64
-          - os: macos-latest
+          - os: macos-26
             runtime: osx-arm64
 
     steps:

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-26]
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: "Checkout"

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -257,8 +257,10 @@ public sealed class TerminaApplication
                 receiver.SetRouteParameters(parameters);
             }
 
-            // Wire up ViewModel with navigation, shutdown, redraw, and input
-            _currentViewModel.WireUp(NavigateTo, (t, v) => NavigateTo(t, v), Shutdown, RequestRedraw, Input);
+            // Wire up ViewModel with navigation, shutdown, redraw, and input.
+            // Navigation is routed through the event channel (RequestNavigation)
+            // so it is processed on the render loop thread, not the caller's.
+            _currentViewModel.WireUp(RequestNavigation, RequestNavigation, Shutdown, RequestRedraw, Input);
 
             // Bind page to ViewModel and wire up focus and navigation
             BindPageToViewModel(_currentPage, _currentViewModel);
@@ -312,7 +314,9 @@ public sealed class TerminaApplication
     {
         if (page is IBindablePage bindablePage)
         {
-            bindablePage.WireUpNavigation(NavigateTo, (t, v) => NavigateTo(t, v), Shutdown);
+            // Route through the event channel so navigation is processed on the
+            // render loop thread (see RequestNavigation).
+            bindablePage.WireUpNavigation(RequestNavigation, RequestNavigation, Shutdown);
         }
     }
 
@@ -344,6 +348,24 @@ public sealed class TerminaApplication
     {
         // Push a redraw event to the event channel - this will trigger re-render
         _eventChannel.Writer.TryWrite(RedrawRequested.Instance);
+    }
+
+    // Navigation requested by a ViewModel or page runs on whatever thread the
+    // caller is on (e.g. an async continuation on the thread pool). Posting a
+    // NavigationRequested event to the channel defers NavigateToInternal to the
+    // render loop thread, so page swaps are serialized against rendering. A
+    // direct cross-thread NavigateTo would publish a not-yet-bound _currentPage
+    // to the render thread — a data race that crashes under ARM64's weak memory
+    // model (the render loop calls BuildLayout() before OnBound() has run).
+    private void RequestNavigation(string path)
+    {
+        _eventChannel.Writer.TryWrite(new NavigationRequested(path));
+    }
+
+    private void RequestNavigation(string routeTemplate, object? routeValues)
+    {
+        _eventChannel.Writer.TryWrite(
+            new NavigationRequested(RouteMatcher.BuildPath(routeTemplate, routeValues)));
     }
 
     /// <summary>

--- a/tests/Termina.Tests/NavigationThreadSafetyTests.cs
+++ b/tests/Termina.Tests/NavigationThreadSafetyTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Threading.Channels;
+using Termina.Layout;
+using Termina.Navigation;
+using Termina.Reactive;
+using Termina.Terminal;
+
+namespace Termina.Tests;
+
+/// <summary>
+/// Navigation initiated by a ViewModel or page must be posted to the event
+/// channel and processed on the render-loop thread — never run synchronously on
+/// the caller's thread. A ViewModel commonly calls <c>Navigate(...)</c> from an
+/// async continuation on the thread pool; running navigation there mutates
+/// <c>_currentPage</c> concurrently with the render loop and publishes a
+/// not-yet-bound page, which the render loop then renders before <c>OnBound()</c>
+/// has run. Under ARM64's weak memory model that surfaces as a
+/// <see cref="NullReferenceException" /> in the page's <c>BuildLayout()</c>
+/// (netclaw#1069 — <c>netclaw init</c> crash on Apple Silicon).
+/// </summary>
+public class NavigationThreadSafetyTests
+{
+    [Fact]
+    public void ViewModelInitiatedNavigation_IsPostedToEventChannel_NotRunSynchronously()
+    {
+        var app = new TerminaApplication(new VirtualTerminal());
+        app.RegisterRoute<NavigatingPage, NavigatingViewModel>("/page-a");
+        app.RegisterRoute<PlainPage, IdleViewModel>("/page-b");
+
+        // Initial navigation runs synchronously (no render loop yet). The page-a
+        // ViewModel requests navigation to /page-b from OnActivated().
+        app.NavigateTo("/page-a");
+
+        // The ViewModel's request must NOT have navigated synchronously.
+        Assert.Equal("/page-a", app.CurrentPath);
+
+        // It must have been posted to the event channel as a NavigationRequested.
+        var navRequest = ReadQueuedNavigation(app);
+        Assert.Equal("/page-b", navRequest.PageKey);
+
+        // Processing the event — what the render-loop thread does — performs the
+        // navigation, fully binding the page before it can be rendered.
+        InvokeProcessEvent(app, navRequest);
+        Assert.Equal("/page-b", app.CurrentPath);
+    }
+
+    [Fact]
+    public void PageInitiatedNavigation_IsPostedToEventChannel_NotRunSynchronously()
+    {
+        var app = new TerminaApplication(new VirtualTerminal());
+        app.RegisterRoute<PageNavigatingPage, IdleViewModel>("/start");
+        app.RegisterRoute<PlainPage, IdleViewModel>("/dest");
+
+        // The page requests navigation to /dest from its OnNavigatedTo() override.
+        app.NavigateTo("/start");
+
+        Assert.Equal("/start", app.CurrentPath);
+
+        var navRequest = ReadQueuedNavigation(app);
+        Assert.Equal("/dest", navRequest.PageKey);
+
+        InvokeProcessEvent(app, navRequest);
+        Assert.Equal("/dest", app.CurrentPath);
+    }
+
+    private static NavigationRequested ReadQueuedNavigation(TerminaApplication app)
+    {
+        var field = typeof(TerminaApplication).GetField(
+            "_eventChannel", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+
+        var channel = (Channel<object>)field!.GetValue(app)!;
+        while (channel.Reader.TryRead(out var evt))
+        {
+            if (evt is NavigationRequested navRequest)
+                return navRequest;
+        }
+
+        Assert.Fail("Expected a NavigationRequested event on the channel.");
+        return null!;
+    }
+
+    private static void InvokeProcessEvent(TerminaApplication app, object evt)
+    {
+        var method = typeof(TerminaApplication).GetMethod(
+            "ProcessEvent", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        method!.Invoke(app, [evt]);
+    }
+
+    private sealed class NavigatingViewModel : ReactiveViewModel
+    {
+        public override void OnActivated()
+        {
+            base.OnActivated();
+            Navigate("/page-b");
+        }
+    }
+
+    private sealed class IdleViewModel : ReactiveViewModel
+    {
+    }
+
+    private sealed class NavigatingPage : ReactivePage<NavigatingViewModel>
+    {
+        public override ILayoutNode BuildLayout() => new TextNode("A");
+    }
+
+    private sealed class PageNavigatingPage : ReactivePage<IdleViewModel>
+    {
+        public override void OnNavigatedTo()
+        {
+            base.OnNavigatedTo();
+            Navigate("/dest");
+        }
+
+        public override ILayoutNode BuildLayout() => new TextNode("start");
+    }
+
+    private sealed class PlainPage : ReactivePage<IdleViewModel>
+    {
+        public override ILayoutNode BuildLayout() => new TextNode("plain");
+    }
+}


### PR DESCRIPTION
## Summary

ViewModel- and page-initiated navigation called `NavigateTo` directly, running
`NavigateToInternal` on whatever thread the caller was on — commonly an async
continuation on the thread pool. That mutated `_currentPage` concurrently with the
render loop and published a **not-yet-bound page**, which the render loop could
render (`BuildLayout()`) before `OnBound()` had run.

x86-64's TSO memory model masks the unsafe publication, so it works by accident on
Linux/Windows. ARM64's weak memory model exposes it as a `NullReferenceException`
in the page's `BuildLayout()` — the root cause of
[netclaw-dev/netclaw#1069](https://github.com/netclaw-dev/netclaw/issues/1069)
(`netclaw init` crashes on Apple Silicon when the wizard hands off to the chat page).

## Fix

- Route VM/page navigation through the event channel via a new `RequestNavigation`
  helper, which posts a `NavigationRequested` event. `NavigateToInternal` — and
  every read/write of `_currentPage` / `_currentViewModel` / `_layoutRoot` — now
  runs only on the render-loop thread. This mirrors the `NavigationRequested`
  plumbing already used for input-driven navigation, so the race is eliminated
  structurally (no locks, no `volatile`, no memory-model reasoning).
- Public `NavigateTo` is unchanged and still used for the initial startup
  navigation (single-threaded, before the render loop exists).
- Add `macos-latest` (Apple Silicon) to the Test matrix for ARM64 baseline coverage.

## Behavior change

VM/page navigation is now processed on the next event-loop iteration rather than
synchronously. Every caller is fire-and-forget, so this is the correct model.

## Tests

- New `NavigationThreadSafetyTests` — 2 deterministic tests asserting VM- and
  page-initiated navigation is posted to the event channel and not run
  synchronously on the caller's thread.
- Full suite: 1004 passed, 0 failed.

## Follow-up

#211 — add a navigation concurrency *stress* test (deterministic tests cannot catch
race regressions; that needs a stress test run on the Apple Silicon leg).

## Test plan

- [x] `dotnet test` — 1004 passed
- [ ] Termina PR CI green on the new `macos-latest` leg
- [ ] After release, bump `Termina` in netclaw `Directory.Packages.props` and confirm the `Native Smoke (macOS)` `init-wizard` leg passes