### PR TITLE
SelectionListNode: add WithHighlightedIndex() for pre-selection

### DIFF
--- a/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/SelectionListGalleryPage.cs
@@ -19,6 +19,7 @@ namespace Termina.Demo.Gallery.Pages;
 /// - Both single and multi-select modes
 /// - Rich multi-line content with styling
 /// - WithFillHeight() expanding a long list to fill its column (Issue #207 fix)
+/// - WithHighlightedIndex() pre-selecting an item, scrolled into view (Issue #203 fix)
 /// </summary>
 public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewModel>
 {
@@ -100,13 +101,16 @@ public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewMod
             .WithVisibleRows(8);
 
         // Fill-height list with 100 items - expands to fill the column instead of
-        // being capped at the 10-row default (Issue #207).
+        // being capped at the 10-row default (Issue #207). WithHighlightedIndex
+        // pre-selects item #50, so the list opens scrolled to it rather than at
+        // the top (Issue #203).
         _numberedList = Layouts.SelectionList(
             Enumerable.Range(1, 100).Select(i => $"Item number {i}"))
             .WithMode(SelectionMode.Single)
             .WithShowNumbers(true)
             .WithHighlightColors(Color.Black, Color.Cyan)
-            .WithFillHeight();
+            .WithFillHeight()
+            .WithHighlightedIndex(49);
 
         return Layouts.Vertical()
             .WithChild(BuildHeader())
@@ -174,7 +178,7 @@ public class SelectionListGalleryPage : ReactivePage<SelectionListGalleryViewMod
                         .Bold()
                         .Height(1))
                 .WithChild(
-                    new TextNode("100 items, WithFillHeight() fills the column")
+                    new TextNode("100 items via WithFillHeight(), opens pre-selected at #50")
                         .WithForeground(Color.DarkGray)
                         .Height(2))
                 .WithChild(_numberedList));

--- a/docs/components/selection-list-node.md
+++ b/docs/components/selection-list-node.md
@@ -196,6 +196,19 @@ A few details worth knowing:
 - To truly fill a container, the container must allocate the full height. A `Fill`-constrained parent (e.g. a `VerticalLayout` slot or a `Fill()` panel) does this; an auto-sized parent shrinks to the list's content.
 - `WithFillHeight(false)` disables fill mode, as does calling `WithVisibleRows()` afterward — both restore the fixed row count.
 
+## Pre-selecting an Item
+
+By default the first item (index 0) is highlighted. Use `WithHighlightedIndex()` to start on a different item — useful when re-entering a previously configured view, such as a wizard step the user is editing:
+
+```csharp
+// Re-open an "Enable DMs?" step on the option the user chose last time
+var list = Layouts.SelectionList("Yes", "No")
+    .WithMode(SelectionMode.Single)
+    .WithHighlightedIndex(previousChoice == DmSetting.Enabled ? 0 : 1);
+```
+
+The index is clamped to the valid range, and the call is ignored when the list is empty. The highlighted item is scrolled into view, so call `WithHighlightedIndex()` after `WithVisibleRows()` when both are used so the scroll offset is computed against the intended row count.
+
 ## Styling
 
 ```csharp
@@ -414,6 +427,7 @@ public class SettingsPage : ReactivePage<SettingsViewModel>
 |--------|-------------|
 | `.WithMode(SelectionMode)` | Set Single or Multi select mode |
 | `.WithHighlightColors(fg, bg)` | Set highlight row colors |
+| `.WithHighlightedIndex(int)` | Set the initially highlighted item (clamped) |
 | `.WithForeground(Color)` | Set default text color |
 | `.WithSelectedForeground(Color)` | Set checked item color |
 | `.WithShowNumbers(bool)` | Show/hide number prefixes |

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -178,6 +178,32 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode
     }
 
     /// <summary>
+    /// Sets the initially highlighted item by index. Useful for pre-selecting an item
+    /// when re-entering a previously configured view (e.g. a wizard edit flow).
+    /// </summary>
+    /// <param name="index">
+    /// The item index to highlight. Clamped to the valid range; ignored when the list
+    /// is empty.
+    /// </param>
+    /// <remarks>
+    /// The highlighted item is scrolled into view using the current visible-row count,
+    /// so call this after <see cref="WithVisibleRows"/> when both are used. In
+    /// <see cref="WithFillHeight"/> mode the row count is not known until layout, so the
+    /// scroll offset is computed against the default; the highlight still becomes visible
+    /// once the user navigates, which re-runs the scroll math against the real height.
+    /// </remarks>
+    public SelectionListNode<T> WithHighlightedIndex(int index)
+    {
+        if (_items.Count > 0)
+        {
+            _highlightedIndex = Math.Clamp(index, 0, _items.Count - 1);
+            EnsureVisible();
+        }
+
+        return this;
+    }
+
+    /// <summary>
     /// Sets the default foreground color.
     /// </summary>
     public SelectionListNode<T> WithForeground(Color color)

--- a/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
+++ b/tests/Termina.Tests/Layout/SelectionListNodeTests.cs
@@ -854,5 +854,78 @@ public class SelectionListNodeTests
         Assert.Contains("Item 7", rendered);
     }
 
+    [Fact]
+    public void SelectionListNode_WithHighlightedIndex_ReturnsThis()
+    {
+        var items = new[] { "A", "B", "C" };
+        using var list = new SelectionListNode<string>(items, s => s);
+
+        var result = list.WithHighlightedIndex(1);
+
+        Assert.Same(list, result);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithHighlightedIndex_SetsHighlightedItem()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithHighlightedIndex(2);
+
+        Assert.Equal("C", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithHighlightedIndex_ClampsAboveRange()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithHighlightedIndex(99);
+
+        Assert.Equal("C", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithHighlightedIndex_ClampsNegativeToFirst()
+    {
+        using var list = Layouts.SelectionList("A", "B", "C")
+            .WithHighlightedIndex(-5);
+
+        Assert.Equal("A", list.HighlightedItem?.DisplayText);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithHighlightedIndex_EmptyList_DoesNotThrow()
+    {
+        using var list = new SelectionListNode<string>(Array.Empty<string>(), s => s);
+
+        var result = list.WithHighlightedIndex(3);
+
+        Assert.Same(list, result);
+        Assert.Null(list.HighlightedItem);
+    }
+
+    [Fact]
+    public void SelectionListNode_WithHighlightedIndex_ScrollsHighlightIntoView()
+    {
+        // Pre-highlight an item well below the viewport. WithHighlightedIndex calls
+        // EnsureVisible(), so the initial render should already be scrolled to it
+        // rather than starting at the top.
+        var items = Enumerable.Range(1, 50).Select(i => "Item " + i).ToArray();
+        using var list = new SelectionListNode<string>(items, s => s)
+            .WithVisibleRows(5)
+            .WithHighlightedIndex(40);
+
+        var terminal = new VirtualTerminal(30, 5);
+        var context = new RegionRenderContext(terminal, 0, 0, 30, 5);
+        list.Render(context, new Rect(0, 0, 30, 5));
+
+        var rendered = string.Join("\n", Enumerable.Range(0, 5).Select(terminal.GetLine));
+
+        // Highlight is on index 40 ("Item 41"); with 5 visible rows the list scrolls
+        // to offset 36, showing items 37..41 -- "Item 37" at the top proves it is not
+        // still parked at the default top-of-list position.
+        Assert.Contains("Item 41", rendered);
+        Assert.Contains("Item 37", rendered);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary

`SelectionListNode<T>` always started with item index 0 highlighted and exposed no public API to change it. This blocks pre-selection when re-entering a previously configured view (e.g. a wizard edit flow where the user's prior choice should be re-highlighted).

Adds `WithHighlightedIndex(int)` — a fluent builder consistent with `WithMode`, `WithHighlightColors`, etc.

## Changes

- Add `WithHighlightedIndex(int)` fluent builder
  - Clamps the index to the valid range
  - Ignores the call when the list is empty — the issue's proposed `Math.Clamp(index, 0, _items.Count - 1)` throws `ArgumentException` (`min > max`) on an empty list; guarding avoids that
  - Calls `EnsureVisible()` so a pre-selected off-screen item is scrolled into view on the first render
- 6 new tests: fluent return, sets highlight, clamps above range, clamps negative, empty-list guard, scroll-into-view
- Docs: new "Pre-selecting an Item" section + API reference table entry

## Testing

All 1018 tests pass (1012 existing + 6 new), 0 failures.

Fixes #203