### PR TITLE
Release 0.9.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,20 +10,20 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.8.0</VersionPrefix>
+    <VersionPrefix>0.9.0</VersionPrefix>
     <PackageReleaseNotes>**New Features**:
-- **CopyableTextNode with terminal clipboard support** ([#179](https://github.com/Aaronontheweb/termina/pull/179))
-  - New `CopyableTextNode` component for selectable, copyable text with keyboard-driven selection
-  - Configurable copy key bindings via `CopyKeyBinding`
-  - Terminal clipboard integration using OSC 52 escape sequences with automatic tmux transport fallback
-  - `IClipboardService` / `IClipboardTransport` interfaces for extensible clipboard backends
-  - `TerminalClipboardService` registered automatically via `AddTermina()` in DI
+- **SelectionListNode pre-selection via `WithHighlightedIndex()`** ([#213](https://github.com/Aaronontheweb/termina/pull/213))
+  - New fluent method `WithHighlightedIndex(int index)` allows callers to pre-select a highlighted item in `SelectionListNode` by index at construction time
 
-- **Toast notification system** ([#179](https://github.com/Aaronontheweb/termina/pull/179))
-  - New `ToastOverlayNode` for non-blocking in-app notifications
-  - `IToastService` / `ToastService` for programmatic toast dispatch
-  - Configurable `ToastPosition` (TopRight, TopLeft, BottomRight, BottomLeft) and `ToastOptions`
-  - `CopyFeedbackMode` controls copy success feedback: toast overlay or inline indicator
+- **SelectionListNode full-height mode via `WithFillHeight()`** ([#210](https://github.com/Aaronontheweb/termina/pull/210))
+  - New fluent method `WithFillHeight()` makes `SelectionListNode` expand to fill all available vertical space
+
+**Bug Fixes**:
+- **Fixed navigation data race that crashed pages on ARM64** ([#212](https://github.com/Aaronontheweb/termina/pull/212))
+- **Fixed garbled output when the terminal does not start in UTF-8** ([#204](https://github.com/Aaronontheweb/termina/issues/204))
+
+**Security**:
+- **Fixed CVE-2026-40894: pinned OpenTelemetry.Api to 1.15.3** ([#209](https://github.com/Aaronontheweb/termina/pull/209))
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,27 @@
-#### 0.8.1 May 17th 2026 ####
+#### 0.9.0 May 18th 2026 ####
+
+**New Features**:
+- **SelectionListNode pre-selection via `WithHighlightedIndex()`** ([#213](https://github.com/Aaronontheweb/termina/pull/213))
+  - New fluent method `WithHighlightedIndex(int index)` allows callers to pre-select a highlighted item in `SelectionListNode` by index at construction time
+  - Useful for dialogs that should open with a sensible default already highlighted
+
+- **SelectionListNode full-height mode via `WithFillHeight()`** ([#210](https://github.com/Aaronontheweb/termina/pull/210))
+  - New fluent method `WithFillHeight()` makes `SelectionListNode` expand to fill all available vertical space
+  - Enables list-first layouts where the selection list is the primary content of the page
 
 **Bug Fixes**:
+- **Fixed navigation data race that crashed pages on ARM64** ([#212](https://github.com/Aaronontheweb/termina/pull/212))
+  - Resolved a race condition in the navigation system that caused page crashes on ARM64 hardware
+  - Affects any multi-core ARM64 deployment (Apple Silicon, AWS Graviton, Raspberry Pi, etc.)
+
 - **Fixed garbled output when the terminal does not start in UTF-8** ([#204](https://github.com/Aaronontheweb/termina/issues/204))
   - `AnsiTerminal` no longer caches `Console.Out`. Setting `Console.OutputEncoding` replaces `Console.Out` with a new `TextWriter`, so a cached reference could be left bound to a stale, non-UTF-8 encoding — rendering Unicode box-drawing characters as `U+FFFD`. The output writer is now resolved on every flush.
   - Consolidated UTF-8 output-encoding setup into a single owner (`ConsoleEnvironment.EnsureUtf8Output`, invoked by the platform console) instead of three separate call sites.
   - Original problem diagnosed by [@logical-intent](https://github.com/logical-intent) in [#204](https://github.com/Aaronontheweb/termina/issues/204) / [#205](https://github.com/Aaronontheweb/termina/pull/205).
+
+**Security**:
+- **Fixed CVE-2026-40894: pinned OpenTelemetry.Api to 1.15.3** ([#209](https://github.com/Aaronontheweb/termina/pull/209))
+  - Pinned `OpenTelemetry.Api` to 1.15.3 to address a security vulnerability in earlier versions
 
 ---
 


### PR DESCRIPTION
## Release 0.9.0 — May 18th 2026

This PR prepares the 0.9.0 release. It updates `RELEASE_NOTES.md` and `Directory.Build.props` with the new version.

### New Features

- **SelectionListNode pre-selection via `WithHighlightedIndex()`** ([#213](https://github.com/Aaronontheweb/termina/pull/213)) — new fluent method to pre-select a highlighted item by index at construction time, useful for dialogs that should open with a sensible default already highlighted

- **SelectionListNode full-height mode via `WithFillHeight()`** ([#210](https://github.com/Aaronontheweb/termina/pull/210)) — new fluent method that makes `SelectionListNode` expand to fill all available vertical space, enabling list-first layouts

### Bug Fixes

- **Fixed navigation data race that crashed pages on ARM64** ([#212](https://github.com/Aaronontheweb/termina/pull/212)) — resolved a race condition in the navigation system affecting ARM64 hardware (Apple Silicon, AWS Graviton, Raspberry Pi, etc.)

- **Fixed garbled output when terminal does not start in UTF-8** ([#208](https://github.com/Aaronontheweb/termina/pull/208), [#204](https://github.com/Aaronontheweb/termina/issues/204)) — `AnsiTerminal` no longer caches `Console.Out`; UTF-8 encoding setup consolidated into `ConsoleEnvironment.EnsureUtf8Output`

### Security

- **Fixed CVE-2026-40894: pinned OpenTelemetry.Api to 1.15.3** ([#209](https://github.com/Aaronontheweb/termina/pull/209)) — addresses a security vulnerability in earlier versions of `OpenTelemetry.Api`

---

After this PR is merged, the `0.9.0` tag will be pushed to trigger the CI/CD release pipeline.