### PR TITLE
Harden alternate-scroll rollout and document runtime modes

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -107,6 +107,7 @@ export default defineConfig({
         { text: 'Routing', link: '/concepts/routing' },
         { text: 'Navigation', link: '/concepts/navigation' },
         { text: 'Input Handling', link: '/concepts/input-handling' },
+        { text: 'Terminal Input Modes', link: '/concepts/terminal-input-modes' },
         { text: 'Dynamic Layouts', link: '/concepts/dynamic-layouts' },
         { text: 'Focus Management', link: '/concepts/focus-management' },
         { text: 'Hosting & DI', link: '/concepts/hosting' }

--- a/docs/components/streaming-text-node.md
+++ b/docs/components/streaming-text-node.md
@@ -618,6 +618,8 @@ The scrollbar occupies 1 column on the right edge, reducing the content area wid
 
 `StreamingTextNode` implements `IScrollable`, which enables automatic mouse wheel scroll support. When a `StreamingTextNode` has focus, mouse wheel events are routed to it automatically — no additional code is needed.
 
+By default, Termina captures wheel input using legacy mouse tracking. Apps that want wheel scrolling without taking over native terminal selection can opt into raw input plus alternate-scroll mode. See [Terminal Input Modes](/concepts/terminal-input-modes).
+
 ```csharp
 // Mouse wheel scrolling works automatically when the node has focus
 var stream = StreamingTextNode.Create()

--- a/docs/concepts/hosting.md
+++ b/docs/concepts/hosting.md
@@ -46,6 +46,27 @@ termina.RegisterRoute<TodoPage, TodoViewModel>("/todos");
 termina.RegisterRoute<DetailPage, DetailViewModel>("/todos/{id:int}");
 ```
 
+### ConfigureRuntime
+
+Configure terminal runtime behavior such as raw input, alternate-scroll, kitty keyboard negotiation, and framework-level `Ctrl+C` handling:
+
+```csharp
+builder.Services.AddTermina("/chat", termina =>
+{
+    termina.ConfigureRuntime(options =>
+    {
+        options.PreferRawInput = true;
+        options.ScrollInputMode = ScrollInputMode.AlternateScroll;
+        options.KittyKeyboardMode = KittyKeyboardMode.ReportAllKeysPlusDisambiguate;
+        options.CtrlCHandlingMode = CtrlCHandlingMode.DoublePressWhenRawInput;
+    });
+
+    termina.RegisterRoute<ChatPage, ChatViewModel>("/chat");
+});
+```
+
+See [Terminal Input Modes](/concepts/terminal-input-modes) for the detailed behavior and rollout guidance.
+
 ### Navigation Behavior
 
 Control page lifecycle during navigation:

--- a/docs/concepts/input-handling.md
+++ b/docs/concepts/input-handling.md
@@ -332,7 +332,7 @@ Input.OfType<ResizeEvent>()
 
 ## Mouse Wheel Scrolling
 
-Mouse wheel events are detected via SGR mouse escape sequences and emitted as `MouseScrollEvent`:
+By default, mouse wheel events are detected via SGR mouse escape sequences and emitted as `MouseScrollEvent`:
 
 ```csharp
 Input.OfType<MouseScrollEvent>()
@@ -350,6 +350,18 @@ Input.OfType<MouseScrollEvent>()
 ::: tip Automatic Routing
 If the focused component implements `IScrollable` (like `StreamingTextNode`), mouse scroll events are routed directly to it — each tick scrolls 3 lines. The event only reaches `ViewModel.Input` if no `IScrollable` component has focus.
 :::
+
+### Alternate-Scroll Mode
+
+Apps that want to preserve native terminal selection can opt into raw input plus alternate-scroll mode via `ConfigureRuntime()`.
+
+In that configuration:
+
+- wheel ticks arrive through the terminal's alternate-scroll path
+- arrow keys remain keyboard input
+- kitty keyboard reporting can further improve disambiguation on supported terminals
+
+See [Terminal Input Modes](/concepts/terminal-input-modes) for the supported configuration and fallback behavior.
 
 ## Paste Events
 

--- a/docs/concepts/terminal-input-modes.md
+++ b/docs/concepts/terminal-input-modes.md
@@ -1,0 +1,144 @@
+# Terminal Input Modes
+
+Termina supports two runtime input strategies:
+
+- legacy mouse tracking, which is the compatibility-first default
+- raw input plus alternate-scroll, which is the higher-fidelity mode for apps like Netclaw
+
+This page explains when to use each mode, how to configure them, and what to expect in tmux and kitty-capable terminals.
+
+## Recommended Defaults
+
+The framework default remains `LegacyMouseTracking`.
+
+That means:
+
+- Termina enables bracketed paste automatically
+- Termina enables SGR mouse tracking for wheel events
+- apps get `MouseScrollEvent` support without enabling raw input
+- native terminal text selection is captured while mouse mode is active
+
+This is the safest default because it works on the normal `Console.ReadKey()` path and does not depend on raw-byte parsing.
+
+## When To Use Alternate Scroll
+
+Use `AlternateScroll` when your app needs all of the following:
+
+- mouse wheel scrolling
+- native terminal selection and copy behavior
+- clear separation between wheel ticks and arrow keys
+
+This mode works by combining:
+
+- raw input transport
+- xterm alternate-scroll (`CSI ?1007h`)
+- optionally kitty keyboard reporting for richer key disambiguation
+
+It is a good fit for chat-style interfaces, logs, and scroll-heavy panes where the user still wants the terminal to own click-drag selection.
+
+## Configure Runtime Options
+
+Use `ConfigureRuntime()` from `AddTermina()`:
+
+```csharp
+using Termina.Hosting;
+
+builder.Services.AddTermina("/chat", termina =>
+{
+    termina.ConfigureRuntime(options =>
+    {
+        options.PreferRawInput = true;
+        options.ScrollInputMode = ScrollInputMode.AlternateScroll;
+        options.KittyKeyboardMode = KittyKeyboardMode.ReportAllKeysPlusDisambiguate;
+        options.CtrlCHandlingMode = CtrlCHandlingMode.DoublePressWhenRawInput;
+    });
+
+    termina.RegisterRoute<ChatPage, ChatViewModel>("/chat");
+});
+```
+
+## Option Reference
+
+### `PreferRawInput`
+
+When `true`, Termina prefers the raw-byte platform console implementation when one is available.
+
+Raw input is required for:
+
+- alternate-scroll wheel disambiguation
+- kitty `report_all_keys`
+- structured byte-level parsing of CSI-u input on Unix and Windows Terminal
+
+If raw input is requested on Unix and stdin is not a TTY, Termina falls back cleanly instead of throwing during startup.
+
+### `ScrollInputMode`
+
+`LegacyMouseTracking`
+
+- default
+- most compatible
+- captures wheel via SGR mouse events
+- can interfere with native terminal selection while active
+
+`AlternateScroll`
+
+- opt-in
+- only activated when raw input is actually active
+- preserves native selection and clipboard integration
+- falls back to legacy mouse tracking when raw input is unavailable
+
+### `KittyKeyboardMode`
+
+Termina can negotiate kitty keyboard protocol flags during app startup:
+
+- `Off`
+- `DisambiguateOnly` (`1`)
+- `ReportAllKeys` (`8`)
+- `ReportAllKeysPlusDisambiguate` (`9`)
+- `ReportAllKeysWithEventTypes` (`11`)
+
+Use `ReportAllKeys` or `ReportAllKeysPlusDisambiguate` when you want the parser to treat real arrows and wheel ticks as structurally distinct byte streams under alternate-scroll.
+
+### `CtrlCHandlingMode`
+
+`DoublePressWhenRawInput` is the default.
+
+That means Termina only intercepts `Ctrl+C` globally when raw input is active. Normal console-mode apps keep their prior behavior.
+
+## tmux Notes
+
+If the app runs inside tmux, Termina forwards bracketed-paste and kitty setup sequences to the outer terminal using tmux passthrough.
+
+Enable this in tmux:
+
+```tmux
+set -g allow-passthrough on
+```
+
+Without that setting, tmux silently drops the forwarded setup sequences.
+
+## Terminal Support Expectations
+
+Best results for raw input + alternate-scroll + kitty keyboard:
+
+- Ghostty
+- kitty
+- WezTerm
+- foot
+- iTerm2 3.5+
+- Windows Terminal with raw input enabled
+
+Older or unsupported terminals still work, but Termina may fall back to legacy mouse tracking or reduced key fidelity.
+
+## Safe Rollout Pattern
+
+For existing apps, keep defaults.
+
+For apps like Netclaw, opt in explicitly and test:
+
+1. direct terminal session
+2. tmux session
+3. supported kitty-capable terminal
+4. unsupported terminal fallback
+
+That lets you ship the better mode where it matters without changing behavior for every existing Termina app.

--- a/src/Termina/Hosting/TerminaBuilder.cs
+++ b/src/Termina/Hosting/TerminaBuilder.cs
@@ -13,6 +13,7 @@ public sealed class TerminaBuilder
 {
     private readonly IServiceCollection _services;
     internal readonly List<ReactivePageRegistrationDescriptor> PageDescriptors = new();
+    internal TerminaRuntimeOptions RuntimeOptions { get; } = new();
 
     internal TerminaBuilder(IServiceCollection services)
     {
@@ -89,6 +90,16 @@ public sealed class TerminaBuilder
             sp => pageFactory(sp),
             sp => viewModelFactory(sp)));
 
+        return this;
+    }
+
+    /// <summary>
+    /// Configure runtime terminal/input behavior for the hosted Termina application.
+    /// </summary>
+    public TerminaBuilder ConfigureRuntime(Action<TerminaRuntimeOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        configure(RuntimeOptions);
         return this;
     }
 }

--- a/src/Termina/Hosting/TerminaRuntimeOptions.cs
+++ b/src/Termina/Hosting/TerminaRuntimeOptions.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Hosting;
+
+/// <summary>
+/// Runtime options that control how Termina negotiates terminal input behavior.
+/// </summary>
+public sealed class TerminaRuntimeOptions
+{
+    /// <summary>
+    /// Prefer raw-byte input over the fallback <see cref="Console.ReadKey(bool)"/> pipeline when available.
+    /// This is required for alternate-scroll wheel disambiguation and full kitty keyboard reporting.
+    /// </summary>
+    public bool PreferRawInput { get; set; }
+
+    /// <summary>
+    /// Selects which terminal scroll mode Termina enables during app startup.
+    /// </summary>
+    public ScrollInputMode ScrollInputMode { get; set; } = ScrollInputMode.LegacyMouseTracking;
+
+    /// <summary>
+    /// Selects which kitty keyboard enhancement flags Termina negotiates, if any.
+    /// </summary>
+    public KittyKeyboardMode KittyKeyboardMode { get; set; } = KittyKeyboardMode.DisambiguateOnly;
+
+    /// <summary>
+    /// Selects whether Termina intercepts Ctrl+C globally.
+    /// </summary>
+    public CtrlCHandlingMode CtrlCHandlingMode { get; set; } = CtrlCHandlingMode.DoublePressWhenRawInput;
+}
+
+/// <summary>
+/// Configures how Termina receives scroll-wheel input.
+/// </summary>
+public enum ScrollInputMode
+{
+    /// <summary>
+    /// Use SGR mouse tracking. This is the most compatible default but captures click-drag selection.
+    /// </summary>
+    LegacyMouseTracking,
+
+    /// <summary>
+    /// Use xterm alternate-scroll mode. This preserves native terminal selection but requires raw input.
+    /// </summary>
+    AlternateScroll,
+}
+
+/// <summary>
+/// Kitty keyboard protocol flag presets.
+/// </summary>
+public enum KittyKeyboardMode
+{
+    /// <summary>
+    /// Do not negotiate kitty keyboard enhancements.
+    /// </summary>
+    Off = 0,
+
+    /// <summary>
+    /// Flag 1: disambiguate escape codes.
+    /// </summary>
+    DisambiguateOnly = 1,
+
+    /// <summary>
+    /// Flag 8: report all keys.
+    /// </summary>
+    ReportAllKeys = 8,
+
+    /// <summary>
+    /// Flags 8 | 1: report all keys and disambiguate escape codes.
+    /// </summary>
+    ReportAllKeysPlusDisambiguate = 9,
+
+    /// <summary>
+    /// Flags 8 | 2 | 1: report all keys, event types, and disambiguate escape codes.
+    /// </summary>
+    ReportAllKeysWithEventTypes = 11,
+}
+
+/// <summary>
+/// Configures whether Termina intercepts Ctrl+C at the framework level.
+/// </summary>
+public enum CtrlCHandlingMode
+{
+    /// <summary>
+    /// Never intercept Ctrl+C; let the platform and app own it.
+    /// </summary>
+    Disabled,
+
+    /// <summary>
+    /// Only require double-press Ctrl+C when raw input is active.
+    /// </summary>
+    DoublePressWhenRawInput,
+
+    /// <summary>
+    /// Require double-press Ctrl+C in all modes.
+    /// </summary>
+    DoublePressAlways,
+}

--- a/src/Termina/Hosting/TerminaServiceCollectionExtensions.cs
+++ b/src/Termina/Hosting/TerminaServiceCollectionExtensions.cs
@@ -63,7 +63,7 @@ public static class TerminaServiceCollectionExtensions
         services.AddSingleton<TerminaApplication>(sp =>
         {
             var terminal = sp.GetRequiredService<IAnsiTerminal>();
-            var app = new TerminaApplication(terminal, sp);
+            var app = new TerminaApplication(terminal, builder.RuntimeOptions, sp);
 
             // Register all pages from the builder
             foreach (var descriptor in builder.PageDescriptors)

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -72,7 +72,7 @@ internal sealed class EscapeSequenceParser
     /// bare-CSI-arrow shape to <see cref="KeyPressed"/> (treating any matching SS3 as the wheel
     /// path instead — handled in <see cref="State.InSs3Sequence"/>).
     /// </remarks>
-    public bool KittyKeyboardActive { get; set; }
+    public bool KittyReportAllKeysVisible { get; set; }
 
     /// <summary>
     /// Creates a parser using the system clock.
@@ -222,7 +222,7 @@ internal sealed class EscapeSequenceParser
                 //     CSI form is unambiguously a real key.
                 if (seq.Length == 2 && IsArrowOrFunctionalFinal(key.KeyChar))
                 {
-                    if (KittyKeyboardActive)
+                    if (KittyReportAllKeysVisible)
                     {
                         var ck = FunctionalFinalToKey(key.KeyChar);
                         if (ck != ConsoleKey.None)
@@ -280,7 +280,7 @@ internal sealed class EscapeSequenceParser
                 // arrive via the kitty CSI-u / second-form path instead, so any remaining
                 // SS3 OA/OB at this point must be the ?1007h wheel emission under DECCKM on.
                 // (SS3 OC/OD never come from the wheel — there is no horizontal wheel.)
-                if (KittyKeyboardActive && (key.KeyChar == 'A' || key.KeyChar == 'B'))
+                if (KittyReportAllKeysVisible && (key.KeyChar == 'A' || key.KeyChar == 'B'))
                 {
                     var delta = key.KeyChar == 'A' ? +1 : -1;
                     TerminaTrace.Input.Debug(this, "ESP: SS3 O{0} (kitty active) → MouseScrollEvent({1})", key.KeyChar, delta);

--- a/src/Termina/Input/PlatformInputSource.cs
+++ b/src/Termina/Input/PlatformInputSource.cs
@@ -33,12 +33,13 @@ public sealed class PlatformInputSource : IInputSource
     /// Create a new platform input source.
     /// </summary>
     /// <param name="console">The platform console to use for input.</param>
-    public PlatformInputSource(IPlatformConsole console)
+    /// <param name="configuration">Transport-level parser configuration.</param>
+    public PlatformInputSource(IPlatformConsole console, PlatformInputConfiguration configuration)
     {
         _console = console ?? throw new ArgumentNullException(nameof(console));
         _parser = new EscapeSequenceParser
         {
-            KittyKeyboardActive = _console.Capabilities.KittyKeyboardActive,
+            KittyReportAllKeysVisible = configuration.KittyReportAllKeysVisible,
         };
     }
 

--- a/src/Termina/Platform/FallbackConsole.cs
+++ b/src/Termina/Platform/FallbackConsole.cs
@@ -64,9 +64,8 @@ public sealed class FallbackConsole : IPlatformConsole
         while (!cancellationToken.IsCancellationRequested)
         {
             // Check for keyboard input
-            if (Console.KeyAvailable)
+            if (TryReadKey(out var key))
             {
-                var key = Console.ReadKey(intercept: true);
                 return new ConsoleKeyEvent(key);
             }
 
@@ -89,6 +88,29 @@ public sealed class FallbackConsole : IPlatformConsole
         }
 
         return null;
+    }
+
+    private static bool TryReadKey(out ConsoleKeyInfo key)
+    {
+        key = default;
+
+        try
+        {
+            if (!Console.KeyAvailable)
+                return false;
+
+            key = Console.ReadKey(intercept: true);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // No interactive console available (redirected input / test host).
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
     }
 
     /// <inheritdoc />

--- a/src/Termina/Platform/IPlatformConsole.cs
+++ b/src/Termina/Platform/IPlatformConsole.cs
@@ -91,12 +91,11 @@ public interface IPlatformConsole : IDisposable
     bool SupportsEventDrivenInput { get; }
 
     /// <summary>
-    /// Capabilities the platform console negotiated with the host terminal during initialization.
+    /// Capabilities of the platform console's input transport after initialization.
     /// </summary>
     /// <remarks>
-    /// Default returns a zero-value <see cref="TerminalCapabilities"/> (no negotiation). Consoles
-    /// that push kitty / mouse / focus / etc. enhancements override this to reflect the active
-    /// state, which input plumbing reads to configure parsing accordingly.
+    /// Default returns a zero-value <see cref="TerminalCapabilities"/>. Consoles that provide
+    /// raw-byte input override this so input plumbing can configure parsing and fallbacks.
     /// </remarks>
     TerminalCapabilities Capabilities => default;
 }

--- a/src/Termina/Platform/KittyKeyboardEnhancement.cs
+++ b/src/Termina/Platform/KittyKeyboardEnhancement.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Termina.Diagnostics;
+using Termina.Terminal;
 
 namespace Termina.Platform;
 
@@ -10,7 +11,7 @@ namespace Termina.Platform;
 /// (<c>CSI &gt; N u</c> / <c>CSI &lt; u</c>) on the terminal's per-screen stack.
 /// </summary>
 /// <remarks>
-/// Driven by the <c>TERMINA_KITTY_KEYBOARD</c> environment variable. Common value is <c>8</c>
+/// The owning application selects the exact kitty flags to negotiate. Common value is <c>8</c>
 /// (<c>report_all_keys</c>), which forces all keyboard input through <c>CSI ... u</c> /
 /// <c>CSI 1;mods X</c> — unambiguously separating real arrow keys from <c>?1007h</c> wheel
 /// events that continue to arrive as legacy <c>CSI A/B</c> or <c>SS3 OA/OB</c>.
@@ -24,20 +25,22 @@ namespace Termina.Platform;
 internal static class KittyKeyboardEnhancement
 {
     /// <summary>
-    /// Reads <c>TERMINA_KITTY_KEYBOARD</c> and, if it is a positive integer, writes
-    /// <c>CSI &gt; flags u</c> to push the kitty enhancement onto the terminal's per-screen stack.
+    /// Pushes the specified kitty keyboard protocol flags onto the terminal's per-screen stack.
     /// </summary>
     /// <param name="traceSource">Object used for trace-source attribution in logs.</param>
-    /// <returns>True if the enhancement was pushed; false if the env var was unset/invalid or the write failed.</returns>
-    public static bool TryEnter(object traceSource)
+    /// <param name="flags">The kitty keyboard protocol flags to push.</param>
+    /// <param name="tmuxPassthrough">If true, also forwards the sequence to the outer terminal via tmux DCS passthrough.</param>
+    /// <returns>True if the enhancement was pushed; false if <paramref name="flags"/> is non-positive or the write failed.</returns>
+    public static bool TryEnter(object traceSource, int flags, bool tmuxPassthrough)
     {
-        var raw = Environment.GetEnvironmentVariable("TERMINA_KITTY_KEYBOARD");
-        if (string.IsNullOrEmpty(raw)) return false;
-        if (!int.TryParse(raw, out var flags) || flags <= 0) return false;
+        if (flags <= 0) return false;
 
         try
         {
-            Console.Out.Write($"\x1b[>{flags}u");
+            var sequence = $"\x1b[>{flags}u";
+            Console.Out.Write(sequence);
+            if (tmuxPassthrough)
+                Console.Out.Write(AnsiCodes.TmuxPassthrough(sequence));
             Console.Out.Flush();
             TerminaTrace.Platform.Info(traceSource, "Pushed kitty keyboard flags={0}", flags);
             return true;
@@ -53,11 +56,13 @@ internal static class KittyKeyboardEnhancement
     /// Pops the kitty enhancement from the terminal's per-screen stack by writing
     /// <c>CSI &lt; u</c>. Safe to call on shutdown / restore paths; swallows failures.
     /// </summary>
-    public static void TryLeave()
+    public static void TryLeave(bool tmuxPassthrough)
     {
         try
         {
-            Console.Out.Write("\x1b[<u");
+            Console.Out.Write(AnsiCodes.DisableKittyKeyboard);
+            if (tmuxPassthrough)
+                Console.Out.Write(AnsiCodes.TmuxPassthrough(AnsiCodes.DisableKittyKeyboard));
             Console.Out.Flush();
         }
         catch

--- a/src/Termina/Platform/PlatformConsoleFactory.cs
+++ b/src/Termina/Platform/PlatformConsoleFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.InteropServices;
 using Termina.Diagnostics;
+using Termina.Hosting;
 
 namespace Termina.Platform;
 
@@ -26,8 +27,10 @@ public static class PlatformConsoleFactory
     /// <item><description>Other: Falls back to polling-based implementation</description></item>
     /// </list>
     /// </remarks>
-    public static IPlatformConsole Create()
+    public static IPlatformConsole Create(TerminaRuntimeOptions runtimeOptions)
     {
+        ArgumentNullException.ThrowIfNull(runtimeOptions);
+
         TerminaTrace.Platform.Debug(TraceSource, "PlatformConsoleFactory.Create() called");
         TerminaTrace.Platform.Debug(TraceSource, "OS: {0}, Framework: {1}",
             RuntimeInformation.OSDescription, RuntimeInformation.FrameworkDescription);
@@ -42,7 +45,7 @@ public static class PlatformConsoleFactory
 
             if (isConsoleAvailable)
             {
-                var rawVt = IsRawInputOptedIn();
+                var rawVt = ShouldUseRawInput(runtimeOptions);
                 TerminaTrace.Platform.Info(TraceSource,
                     "Creating WindowsConsole (native P/Invoke, rawVtMode={0})", rawVt);
                 return new WindowsConsole(rawVtMode: rawVt);
@@ -59,10 +62,16 @@ public static class PlatformConsoleFactory
             // UnixConsole is opt-in until Phase 4 of the raw-stdin plan flips the default.
             // Set TERMINA_RAW_INPUT=1 to enable raw-byte stdin reads — required for ?1007h
             // wheel-scroll disambiguation from real arrow keys.
-            if (IsRawInputOptedIn())
+            if (ShouldUseRawInput(runtimeOptions))
             {
-                TerminaTrace.Platform.Info(TraceSource, "Creating UnixConsole (TERMINA_RAW_INPUT)");
-                return new UnixConsole();
+                if (UnixConsole.IsInteractiveStdin())
+                {
+                    TerminaTrace.Platform.Info(TraceSource, "Creating UnixConsole (raw input enabled)");
+                    return new UnixConsole();
+                }
+
+                TerminaTrace.Platform.Warning(TraceSource,
+                    "Raw input requested but stdin is not a TTY; falling back to FallbackConsole.");
             }
         }
 
@@ -75,8 +84,11 @@ public static class PlatformConsoleFactory
     /// <c>TERMINA_RAW_INPUT</c> (canonical) or the legacy <c>TERMINA_UNIX_RAW_INPUT</c> alias.
     /// Setting either variable to <c>1</c> or <c>true</c> (case-insensitive) opts in.
     /// </summary>
-    private static bool IsRawInputOptedIn()
+    private static bool ShouldUseRawInput(TerminaRuntimeOptions runtimeOptions)
     {
+        if (runtimeOptions.PreferRawInput)
+            return true;
+
         var canonical = Environment.GetEnvironmentVariable("TERMINA_RAW_INPUT");
         if (IsTruthy(canonical)) return true;
 

--- a/src/Termina/Platform/PlatformInputConfiguration.cs
+++ b/src/Termina/Platform/PlatformInputConfiguration.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Platform;
+
+/// <summary>
+/// Snapshot of platform input transport properties that influence parser configuration.
+/// </summary>
+public readonly record struct PlatformInputConfiguration(bool RawInputActive, bool KittyReportAllKeysVisible);

--- a/src/Termina/Platform/TerminalCapabilities.cs
+++ b/src/Termina/Platform/TerminalCapabilities.cs
@@ -4,19 +4,10 @@
 namespace Termina.Platform;
 
 /// <summary>
-/// Snapshot of negotiated terminal capabilities the platform console pushed during initialization.
+/// Snapshot of transport-level input capabilities the platform console exposes after initialization.
 /// </summary>
-/// <remarks>
-/// Surfaced via <see cref="IPlatformConsole.Capabilities"/> and consumed by input plumbing
-/// (e.g. <see cref="Input.PlatformInputSource"/> uses it to wire
-/// <see cref="Input.EscapeSequenceParser.KittyKeyboardActive"/>). New capability bits should
-/// be additive — a zero-value <see cref="TerminalCapabilities"/> represents a console that
-/// performed no negotiation.
-/// </remarks>
-/// <param name="KittyKeyboardActive">
-/// True when the platform console has pushed the kitty keyboard protocol enhancement
-/// (<c>CSI &gt; N u</c>). Causes real keyboard events to arrive as canonical kitty
-/// CSI-u / second-form sequences, making them byte-level distinct from <c>?1007h</c>
-/// wheel events that continue to arrive as legacy <c>CSI A/B</c> or <c>SS3 OA/OB</c>.
+/// <param name="RawInputActive">
+/// True when the console is delivering raw bytes to the parser rather than relying on
+/// <see cref="Console.ReadKey(bool)"/> or other cooked input handling.
 /// </param>
-public readonly record struct TerminalCapabilities(bool KittyKeyboardActive);
+public readonly record struct TerminalCapabilities(bool RawInputActive);

--- a/src/Termina/Platform/UnixConsole.cs
+++ b/src/Termina/Platform/UnixConsole.cs
@@ -85,10 +85,26 @@ public sealed class UnixConsole : IPlatformConsole
     private ConsoleCancelEventHandler? _cancelKeyPressHandler;
     private PosixSignalRegistration? _sigwinchRegistration;
 
-    private bool _kittyKeyboardActive;
-
     /// <inheritdoc />
-    public TerminalCapabilities Capabilities => new(KittyKeyboardActive: _kittyKeyboardActive);
+    public TerminalCapabilities Capabilities => new(RawInputActive: true);
+
+    /// <summary>
+    /// Returns true when stdin is an interactive TTY.
+    /// </summary>
+    public static bool IsInteractiveStdin()
+    {
+        if (Console.IsInputRedirected)
+            return false;
+
+        try
+        {
+            return isatty(StdInFd) == 1;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     /// <inheritdoc />
     public bool SupportsEventDrivenInput => true;
@@ -103,7 +119,6 @@ public sealed class UnixConsole : IPlatformConsole
 
         ConsoleEnvironment.EnsureUtf8Output();
         EnterRawMode();
-        TryEnterKittyKeyboard();
 
         try { _lastWidth = Console.WindowWidth; _lastHeight = Console.WindowHeight; }
         catch (IOException) { _lastWidth = 80; _lastHeight = 24; }
@@ -238,24 +253,11 @@ public sealed class UnixConsole : IPlatformConsole
     {
         if (_restored || !_rawModeEntered) return;
         _restored = true;
-        TryLeaveKittyKeyboard();
         var h = GCHandle.Alloc(_savedTermios, GCHandleType.Pinned);
         try { _ = tcsetattr(StdInFd, Tcsanow, h.AddrOfPinnedObject()); }
         catch { /* ignore */ }
         finally { h.Free(); }
         TerminaTrace.Platform.Debug(this, "UnixConsole termios restored");
-    }
-
-    private void TryEnterKittyKeyboard()
-    {
-        _kittyKeyboardActive = KittyKeyboardEnhancement.TryEnter(this);
-    }
-
-    private void TryLeaveKittyKeyboard()
-    {
-        if (!_kittyKeyboardActive) return;
-        KittyKeyboardEnhancement.TryLeave();
-        _kittyKeyboardActive = false;
     }
 
     private void ReaderLoop()
@@ -360,4 +362,7 @@ public sealed class UnixConsole : IPlatformConsole
 
     [DllImport(Libc, SetLastError = true)]
     private static extern nint read(int fd, IntPtr buf, nuint count);
+
+    [DllImport(Libc, SetLastError = true)]
+    private static extern int isatty(int fd);
 }

--- a/src/Termina/Platform/WindowsConsole.cs
+++ b/src/Termina/Platform/WindowsConsole.cs
@@ -217,8 +217,6 @@ public sealed class WindowsConsole : IPlatformConsole
 
     private CancellationTokenSource? _stopCts;
     private Thread? _readerThread;
-    private bool _kittyKeyboardActive;
-
     /// <summary>
     /// Create a Windows console. <paramref name="rawVtMode"/> opts into the raw-byte input path
     /// that matches the Unix pipeline (required for <c>?1007h</c> wheel events and the kitty
@@ -250,7 +248,7 @@ public sealed class WindowsConsole : IPlatformConsole
     public Observable<ConsoleResizeEvent> Resized => _resized;
 
     /// <inheritdoc />
-    public TerminalCapabilities Capabilities => new(KittyKeyboardActive: _kittyKeyboardActive);
+    public TerminalCapabilities Capabilities => new(RawInputActive: _rawVtMode);
 
     /// <inheritdoc />
     public void Initialize()
@@ -417,8 +415,6 @@ public sealed class WindowsConsole : IPlatformConsole
 
         if (_rawVtMode)
         {
-            _kittyKeyboardActive = KittyKeyboardEnhancement.TryEnter(this);
-
             _stopCts = new CancellationTokenSource();
             _readerThread = new Thread(RawByteReaderLoop)
             {
@@ -459,12 +455,6 @@ public sealed class WindowsConsole : IPlatformConsole
             }
             catch { /* ignore */ }
             try { _readerThread?.Join(TimeSpan.FromMilliseconds(250)); } catch { /* ignore */ }
-
-            if (_kittyKeyboardActive)
-            {
-                KittyKeyboardEnhancement.TryLeave();
-                _kittyKeyboardActive = false;
-            }
 
             if (!_restoredInputCp)
             {

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -41,6 +41,7 @@ public sealed class TerminaApplication
 {
     private readonly IAnsiTerminal _terminal;
     private readonly DiffingTerminal? _diffingTerminal;
+    private readonly TerminaRuntimeOptions _runtimeOptions;
     private readonly IServiceProvider? _serviceProvider;
     private readonly Channel<object> _eventChannel;
     private readonly Subject<IInputEvent> _inputSubject = new();
@@ -62,13 +63,39 @@ public sealed class TerminaApplication
     private CancellationTokenSource? _shutdownCts;
     private DateTime? _firstCtrlCAt;
     private static readonly TimeSpan CtrlCDoublePressWindow = TimeSpan.FromSeconds(2);
+    private bool _rawInputActive;
+    private bool _kittyKeyboardPushed;
+    private bool _wheelScrollEnabledByApp;
+
+    /// <summary>
+    /// Creates a new Termina application.
+    /// </summary>
+    /// <param name="terminal">The ANSI terminal for rendering.</param>
+    public TerminaApplication(IAnsiTerminal terminal)
+        : this(terminal, runtimeOptions: null, serviceProvider: null)
+    {
+    }
 
     /// <summary>
     /// Creates a new Termina application.
     /// </summary>
     /// <param name="terminal">The ANSI terminal for rendering.</param>
     /// <param name="serviceProvider">Optional service provider for resolving ViewModels and input sources.</param>
-    public TerminaApplication(IAnsiTerminal terminal, IServiceProvider? serviceProvider = null)
+    public TerminaApplication(IAnsiTerminal terminal, IServiceProvider? serviceProvider)
+        : this(terminal, runtimeOptions: null, serviceProvider: serviceProvider)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new Termina application.
+    /// </summary>
+    /// <param name="terminal">The ANSI terminal for rendering.</param>
+    /// <param name="runtimeOptions">Runtime terminal/input options.</param>
+    /// <param name="serviceProvider">Optional service provider for resolving ViewModels and input sources.</param>
+    public TerminaApplication(
+        IAnsiTerminal terminal,
+        TerminaRuntimeOptions? runtimeOptions = null,
+        IServiceProvider? serviceProvider = null)
     {
         ObservableSystem.RegisterUnhandledExceptionHandler(ex =>
         {
@@ -94,6 +121,7 @@ public sealed class TerminaApplication
             _terminal = _diffingTerminal;
         }
 
+        _runtimeOptions = runtimeOptions ?? new TerminaRuntimeOptions();
         _serviceProvider = serviceProvider;
         _eventChannel = Channel.CreateUnbounded<object>();
         _toastService = serviceProvider?.GetService<IToastService>();
@@ -384,9 +412,16 @@ public sealed class TerminaApplication
         if (_inputSources.Count == 0)
         {
             // Use platform-specific console for event-driven input (no polling on Windows)
-            platformConsole = PlatformConsoleFactory.Create();
+            platformConsole = PlatformConsoleFactory.Create(_runtimeOptions);
             platformConsole.Initialize();
-            _inputSources.Add(new PlatformInputSource(platformConsole));
+            _rawInputActive = platformConsole.Capabilities.RawInputActive;
+
+            var kittyFlags = GetKittyKeyboardFlags();
+            var kittyReportAllKeysVisible = _rawInputActive && (kittyFlags & 8) != 0;
+
+            _inputSources.Add(new PlatformInputSource(
+                platformConsole,
+                new PlatformInputConfiguration(_rawInputActive, kittyReportAllKeysVisible)));
             TerminaTrace.Input.Debug(this, "Added PlatformInputSource");
         }
 
@@ -413,32 +448,35 @@ public sealed class TerminaApplication
             _terminal.Flush();
             TerminaTrace.Render.Debug(this, "Entered alternate screen, cursor hidden, flushed");
 
-            // Enable bracketed paste mode and wheel-only scrolling. We use the terminal's
-            // alternate-scroll mode (CSI ?1007h) rather than SGR mouse tracking so that
-            // mouse-wheel events arrive as cursor up/down keypresses while the host terminal
-            // continues to own click-drag selection, triple-click word selection, and OS
-            // clipboard integration. Apps that need full mouse capture (clicks, drags) can
-            // still call IAnsiTerminal.EnableMouse() explicitly.
+            var inTmux = Environment.GetEnvironmentVariable("TMUX") is not null;
             Console.Write(AnsiCodes.EnableBracketedPaste);
-
-            // Enable kitty keyboard protocol (flag 1 = disambiguate escape codes) so that
-            // Ctrl+Enter, Shift+Enter, etc. produce distinct CSI u escape sequences.
-            // Without this, Ctrl+Enter is indistinguishable from bare Enter on Linux terminals.
-            // See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
-            Console.Write(AnsiCodes.EnableKittyKeyboard);
 
             // When running inside tmux, the inner-pane ESC[?2004h above is intercepted by tmux
             // and never reaches the outer terminal. The outer terminal therefore does not know
             // to wrap Ctrl+Shift+V pastes with ESC[200~...ESC[201~. Use a DCS passthrough to
             // also enable bracketed paste in the outer terminal.
             // Requires: set -g allow-passthrough on  in ~/.tmux.conf (tmux 3.3+).
-            if (Environment.GetEnvironmentVariable("TMUX") is not null)
+            if (inTmux)
             {
                 Console.Write(AnsiCodes.TmuxPassthrough(AnsiCodes.EnableBracketedPaste));
-                Console.Write(AnsiCodes.TmuxPassthrough(AnsiCodes.EnableKittyKeyboard));
             }
 
-            _terminal.EnableWheelScroll();
+            var kittyFlags = GetKittyKeyboardFlags();
+            _kittyKeyboardPushed = KittyKeyboardEnhancement.TryEnter(this, kittyFlags, inTmux);
+
+            if (_runtimeOptions.ScrollInputMode == ScrollInputMode.AlternateScroll && _rawInputActive)
+            {
+                // Alternate-scroll preserves native selection/clipboard behavior but only works
+                // correctly when the input parser sees raw byte sequences.
+                _terminal.EnableWheelScroll();
+                _wheelScrollEnabledByApp = true;
+            }
+            else
+            {
+                _terminal.EnableMouse();
+                _wheelScrollEnabledByApp = false;
+            }
+
             _terminal.Flush();
 
             // Initial render
@@ -461,20 +499,26 @@ public sealed class TerminaApplication
         }
         finally
         {
+            var inTmux = Environment.GetEnvironmentVariable("TMUX") is not null;
+
             // Disable bracketed paste and kitty keyboard protocol before restoring terminal
-            Console.Write(AnsiCodes.DisableKittyKeyboard);
-            Console.Write(AnsiCodes.DisableBracketedPaste);
-            if (Environment.GetEnvironmentVariable("TMUX") is not null)
+            if (_kittyKeyboardPushed)
             {
-                Console.Write(AnsiCodes.TmuxPassthrough(AnsiCodes.DisableKittyKeyboard));
+                KittyKeyboardEnhancement.TryLeave(inTmux);
+                _kittyKeyboardPushed = false;
+            }
+
+            Console.Write(AnsiCodes.DisableBracketedPaste);
+            if (inTmux)
+            {
                 Console.Write(AnsiCodes.TmuxPassthrough(AnsiCodes.DisableBracketedPaste));
             }
 
-            // Restore terminal state fully to avoid artifacts.
-            // DisableWheelScroll() emits CSI ?1007l; DisableMouse() is a no-op unless an
-            // app explicitly opted into full mouse capture.
-            _terminal.DisableWheelScroll();
-            _terminal.DisableMouse();
+            if (_wheelScrollEnabledByApp)
+                _terminal.DisableWheelScroll();
+            else
+                _terminal.DisableMouse();
+
             _terminal.SetCursorVisible(true);
             _terminal.ResetColors();
             _terminal.ExitAlternateScreen();
@@ -514,15 +558,10 @@ public sealed class TerminaApplication
         TerminaTrace.Input.Trace(this, "ProcessEvent: {0}", evt.GetType().Name);
 
         // Framework-level Ctrl+C handling: first press shows a hint, second press
-        // within CtrlCDoublePressWindow shuts the app down. This sits above page /
-        // focus handling so users can always get out, even from a focus-trapping
-        // input control. Under cfmakeraw (UnixConsole) Ctrl+C arrives as a normal
-        // KeyPressed event because ISIG is cleared. On Windows in raw-VT mode
-        // (WindowsConsole opt-in via TERMINA_RAW_INPUT) ENABLE_PROCESSED_INPUT is
-        // cleared for the same reason and Ctrl+C arrives in-band as well. In
-        // Windows record mode the .NET Console.ReadKey path also surfaces Ctrl+C
-        // as a KeyPressed(Key=C, Control), so this handler runs uniformly.
-        if (evt is KeyPressed ctrlC
+        // within CtrlCDoublePressWindow shuts the app down. We scope this to raw-input
+        // mode by default so regular Console.ReadKey apps keep their existing behavior.
+        if (ShouldInterceptCtrlC()
+            && evt is KeyPressed ctrlC
             && ctrlC.KeyInfo.Key == ConsoleKey.C
             && ctrlC.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
         {
@@ -541,6 +580,13 @@ public sealed class TerminaApplication
                 new ToastOptions(Duration: CtrlCDoublePressWindow, Position: ToastPosition.BottomCenter));
             RequestRedraw();
             return;
+        }
+
+        if (evt is KeyPressed keyPressedEvent
+            && !(keyPressedEvent.KeyInfo.Key == ConsoleKey.C
+                 && keyPressedEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control)))
+        {
+            _firstCtrlCAt = null;
         }
 
         // Handle system events
@@ -656,6 +702,16 @@ public sealed class TerminaApplication
         }
         return null;
     }
+
+    private int GetKittyKeyboardFlags() => (int)_runtimeOptions.KittyKeyboardMode;
+
+    private bool ShouldInterceptCtrlC() => _runtimeOptions.CtrlCHandlingMode switch
+    {
+        CtrlCHandlingMode.Disabled => false,
+        CtrlCHandlingMode.DoublePressWhenRawInput => _rawInputActive,
+        CtrlCHandlingMode.DoublePressAlways => true,
+        _ => false,
+    };
 
     /// <summary>
     /// Renders the current page directly to the terminal.

--- a/src/Termina/Terminal/AnsiCodes.cs
+++ b/src/Termina/Terminal/AnsiCodes.cs
@@ -232,13 +232,10 @@ public static class AnsiCodes
     // Supported by: kitty, WezTerm, Ghostty, Alacritty, foot, and others.
 
     /// <summary>
-    /// Push kitty keyboard protocol flags onto the terminal's flag stack.
+    /// Build a kitty keyboard protocol flag-push sequence.
     /// Format: CSI &gt; flags u
-    /// Flag 1 = "disambiguate escape codes" — makes Ctrl+Enter, Shift+Enter, etc.
-    /// send distinct CSI u sequences (e.g. <c>ESC[13;5u</c> for Ctrl+Enter).
-    /// See <see href="https://sw.kovidgoyal.net/kitty/keyboard-protocol/"/> for the full specification.
     /// </summary>
-    public const string EnableKittyKeyboard = $"{Csi}>1u";
+    public static string EnableKittyKeyboard(int flags) => $"{Csi}>{flags}u";
 
     /// <summary>
     /// Pop the kitty keyboard protocol flag stack, restoring the terminal's

--- a/tests/Termina.Tests/Hosting/TerminaRuntimeOptionsTests.cs
+++ b/tests/Termina.Tests/Hosting/TerminaRuntimeOptionsTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Terminal;
+
+namespace Termina.Tests.Hosting;
+
+public class TerminaRuntimeOptionsTests
+{
+    [Fact]
+    public async Task RunAsync_DefaultsToLegacyMouseTracking()
+    {
+        var terminal = new VirtualTerminal();
+        var app = CreateApp(terminal);
+        app.RegisterRoute<TestPage, TestViewModel>("/");
+        app.NavigateTo("/");
+
+        using var cts = new CancellationTokenSource();
+        var runTask = app.RunAsync(cts.Token);
+        await WaitForConditionAsync(() => terminal.MouseEnabled);
+
+        Assert.True(terminal.MouseEnabled);
+        Assert.False(terminal.WheelScrollEnabled);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact]
+    public async Task RunAsync_AlternateScrollWithoutRawInput_FallsBackToLegacyMouseTracking()
+    {
+        var terminal = new VirtualTerminal();
+        var options = new TerminaRuntimeOptions
+        {
+            ScrollInputMode = ScrollInputMode.AlternateScroll,
+        };
+
+        var app = CreateApp(terminal, options);
+        app.RegisterRoute<TestPage, TestViewModel>("/");
+        app.NavigateTo("/");
+
+        using var cts = new CancellationTokenSource();
+        var runTask = app.RunAsync(cts.Token);
+        await WaitForConditionAsync(() => terminal.MouseEnabled);
+
+        Assert.True(terminal.MouseEnabled);
+        Assert.False(terminal.WheelScrollEnabled);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact]
+    public void ProcessEvent_DefaultCtrlCHandling_IgnoresCtrlCWhenRawInputInactive()
+    {
+        var app = CreateApp(new VirtualTerminal(), new TerminaRuntimeOptions());
+
+        InvokeProcessEvent(app, new KeyPressed(new ConsoleKeyInfo('\x03', ConsoleKey.C, false, false, true)));
+
+        Assert.Null(GetFirstCtrlCAt(app));
+    }
+
+    [Fact]
+    public void ProcessEvent_DefaultCtrlCHandling_InterceptsCtrlCWhenRawInputActive()
+    {
+        var app = CreateApp(new VirtualTerminal(), new TerminaRuntimeOptions());
+        SetRawInputActive(app, true);
+
+        InvokeProcessEvent(app, new KeyPressed(new ConsoleKeyInfo('\x03', ConsoleKey.C, false, false, true)));
+
+        Assert.NotNull(GetFirstCtrlCAt(app));
+    }
+
+    [Fact]
+    public void EscapeSequenceParser_OnlyUsesKittyAlternateRoutingWhenReportAllKeysVisible()
+    {
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = false };
+        var events = FeedString(parser, "\x1b[A");
+
+        var scroll = Assert.Single(events);
+        Assert.IsType<MouseScrollEvent>(scroll);
+
+        parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
+        events = FeedString(parser, "\x1b[A");
+
+        var key = Assert.Single(events);
+        Assert.IsType<KeyPressed>(key);
+    }
+
+    private static TerminaApplication CreateApp(VirtualTerminal terminal, TerminaRuntimeOptions? options = null)
+    {
+        var services = new TestServiceProvider();
+        return new TerminaApplication(terminal, options, services);
+    }
+
+    private static void InvokeProcessEvent(TerminaApplication app, object evt)
+    {
+        var method = typeof(TerminaApplication).GetMethod(
+            "ProcessEvent",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.NotNull(method);
+        method!.Invoke(app, [evt]);
+    }
+
+    private static DateTime? GetFirstCtrlCAt(TerminaApplication app)
+    {
+        var field = typeof(TerminaApplication).GetField(
+            "_firstCtrlCAt",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.NotNull(field);
+        return (DateTime?)field!.GetValue(app);
+    }
+
+    private static void SetRawInputActive(TerminaApplication app, bool value)
+    {
+        var field = typeof(TerminaApplication).GetField(
+            "_rawInputActive",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.NotNull(field);
+        field!.SetValue(app, value);
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> condition)
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            if (condition()) return;
+            await Task.Delay(10);
+        }
+
+        Assert.Fail("Condition was not met within the expected time.");
+    }
+
+    private static List<IInputEvent> FeedString(EscapeSequenceParser parser, string s)
+    {
+        var all = new List<IInputEvent>();
+        foreach (var c in s)
+        {
+            var info = c == '\x1b'
+                ? new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)
+                : new ConsoleKeyInfo(c, ConsoleKey.None, false, false, false);
+            all.AddRange(parser.Process(info));
+        }
+
+        return all;
+    }
+
+    private sealed class TestServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IEnumerable<IInputSource>))
+                return Array.Empty<IInputSource>();
+
+            return null;
+        }
+    }
+
+    private sealed class TestPage : ReactivePage<TestViewModel>
+    {
+        public override ILayoutNode BuildLayout() => new TextNode("test");
+    }
+
+    private sealed class TestViewModel : ReactiveViewModel
+    {
+    }
+}

--- a/tests/Termina.Tests/Input/EscapeSequenceParserKittyTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserKittyTests.cs
@@ -9,7 +9,7 @@ namespace Termina.Tests.Input;
 /// Tests for the kitty-keyboard-protocol additions to <see cref="EscapeSequenceParser"/>:
 /// CSI second-form arrow / function keys (<c>CSI 1;&lt;mods&gt; [ABCDFHPQRS]</c>), event-type
 /// subfield handling, kitty PUA functional keycodes in CSI-u form, modifier-alone swallowing,
-/// and the <see cref="EscapeSequenceParser.KittyKeyboardActive"/> mode-flag interaction with
+    /// and the <see cref="EscapeSequenceParser.KittyReportAllKeysVisible"/> mode-flag interaction with
 /// bare <c>CSI A/B</c> / <c>SS3 OA/B</c> wheel routing.
 /// </summary>
 public class EscapeSequenceParserKittyTests
@@ -25,12 +25,12 @@ public class EscapeSequenceParserKittyTests
         return all;
     }
 
-    // --- Bare CSI arrow routing depends on KittyKeyboardActive ---
+    // --- Bare CSI arrow routing depends on KittyReportAllKeysVisible ---
 
     [Fact]
     public void BareCsiUp_WhenKittyInactive_EmitsMouseScrollUp()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = false };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = false };
         var events = FeedString(parser, "\x1b[A");
         Assert.Single(events);
         var scroll = Assert.IsType<MouseScrollEvent>(events[0]);
@@ -40,7 +40,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void BareCsiUp_WhenKittyActive_EmitsKeyPressedUpArrow()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[A");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -50,7 +50,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void BareCsiDown_WhenKittyActive_EmitsKeyPressedDownArrow()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[B");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -68,7 +68,7 @@ public class EscapeSequenceParserKittyTests
     [InlineData('S', ConsoleKey.F4)]
     public void BareCsi_KittyActive_AllFunctionalFinals(char final, ConsoleKey expected)
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, $"\x1b[{final}");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -80,7 +80,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void Ss3OA_WhenKittyInactive_EmitsKeyPressedUpArrow()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = false };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = false };
         var events = FeedString(parser, "\x1bOA");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -90,7 +90,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void Ss3OA_WhenKittyActive_EmitsMouseScrollUp()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1bOA");
         Assert.Single(events);
         var scroll = Assert.IsType<MouseScrollEvent>(events[0]);
@@ -100,7 +100,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void Ss3OB_WhenKittyActive_EmitsMouseScrollDown()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1bOB");
         Assert.Single(events);
         var scroll = Assert.IsType<MouseScrollEvent>(events[0]);
@@ -111,7 +111,7 @@ public class EscapeSequenceParserKittyTests
     public void Ss3OC_WhenKittyActive_StillEmitsRightArrow()
     {
         // Wheel has no horizontal axis — SS3 OC/OD remain real arrows even with kitty active.
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1bOC");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -123,7 +123,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void SecondForm_ShiftUp_EmitsUpArrowWithShift()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[1;2A");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -135,7 +135,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void SecondForm_CtrlDown_EmitsDownArrowWithControl()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[1;5B");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -147,7 +147,7 @@ public class EscapeSequenceParserKittyTests
     public void SecondForm_AltShiftCtrl_AllModifiersCombined()
     {
         // 1 + shift(1) + alt(2) + ctrl(4) = 8
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[1;8A");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -161,7 +161,7 @@ public class EscapeSequenceParserKittyTests
     public void SecondForm_ReleaseEvent_IsSwallowed()
     {
         // CSI 1;<mods>:3 X  — event type 3 = release
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[1;1:3A");
         Assert.Empty(events);
     }
@@ -169,7 +169,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void SecondForm_RepeatEvent_IsSwallowed()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[1;1:2A");
         Assert.Empty(events);
     }
@@ -177,7 +177,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void SecondForm_ExplicitPressEvent_IsEmitted()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[1;1:1A");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -189,7 +189,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void CsiU_PuaUpArrow_NoMods_EmitsUpArrow()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[57352u");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -199,7 +199,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void CsiU_PuaUpArrow_WithShift_EmitsUpArrowShift()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[57352;2u");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -210,7 +210,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void CsiU_PuaF5_EmitsF5()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[57368u"); // 57364 + 4 = F5
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -221,7 +221,7 @@ public class EscapeSequenceParserKittyTests
     public void CsiU_PuaModifierAlone_LeftShift_IsSwallowed()
     {
         // Kitty emits 57441 for the Left Shift key when report_all_keys is on.
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[57441u");
         Assert.Empty(events);
     }
@@ -229,7 +229,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void CsiU_PuaModifierAlone_RightControl_IsSwallowed()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[57448u");
         Assert.Empty(events);
     }
@@ -239,7 +239,7 @@ public class EscapeSequenceParserKittyTests
     {
         // 57441 release with event type 3 — exercises both the modifier-alone and
         // release-event swallowing paths.
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[57441;1:3u");
         Assert.Empty(events);
     }
@@ -248,7 +248,7 @@ public class EscapeSequenceParserKittyTests
     public void CsiU_AsciiKey_ReleaseEvent_IsSwallowed()
     {
         // CSI 97;1:3 u → 'a' release. Should NOT emit.
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[97;1:3u");
         Assert.Empty(events);
     }
@@ -257,7 +257,7 @@ public class EscapeSequenceParserKittyTests
     public void CsiU_AsciiKey_WithTextSubfield_IsParsed()
     {
         // CSI 97;2;65 u → 'A' (shift+a, associated text 65='A').
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = true };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = true };
         var events = FeedString(parser, "\x1b[97;2;65u");
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
@@ -270,7 +270,7 @@ public class EscapeSequenceParserKittyTests
     [Fact]
     public void ExistingBehavior_BareCsiB_KittyInactive_StillEmitsScrollDown()
     {
-        var parser = new EscapeSequenceParser { KittyKeyboardActive = false };
+        var parser = new EscapeSequenceParser { KittyReportAllKeysVisible = false };
         var events = FeedString(parser, "\x1b[B");
         var scroll = Assert.IsType<MouseScrollEvent>(events[0]);
         Assert.Equal(-1, scroll.Delta);


### PR DESCRIPTION
## Summary
- restore legacy mouse tracking as the framework default and only enable alternate-scroll when an app explicitly opts in and raw input is active
- move kitty keyboard negotiation into `TerminaApplication`, tighten parser behavior around `report_all_keys`, and add safer raw-input fallback behavior on Unix and non-interactive consoles
- add regression tests plus website docs for runtime input modes, raw input, alternate-scroll, kitty flags, and tmux passthrough

## Validation
- `dotnet build Termina.slnx`
- `dotnet test Termina.slnx`