### PR TITLE
Prototype terminal conformance harness and workflow

### DIFF
--- a/.github/workflows/terminal_conformance.yml
+++ b/.github/workflows/terminal_conformance.yml
@@ -1,0 +1,97 @@
+name: terminal_conformance
+
+on:
+  push:
+    branches:
+      - feature/terminal-conformance-matrix
+  pull_request:
+    paths:
+      - '.github/workflows/terminal_conformance.yml'
+      - 'demos/Termina.Demo.Conformance/**'
+      - 'tests/conformance/**'
+      - 'src/Termina/**'
+
+jobs:
+  linux-baseline:
+    name: Linux-Baseline-Capture
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v5.2.0
+        with:
+          global-json-file: ./global.json
+
+      - name: Build conformance demo
+        run: dotnet build demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj -c Release
+
+      - name: Run baseline PTY capture
+        run: bash tests/conformance/linux/run-baseline-capture.sh "$RUNNER_TEMP/conformance-baseline"
+
+      - name: Upload baseline artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conformance-baseline
+          path: ${{ runner.temp }}/conformance-baseline
+
+  linux-kitty:
+    name: Linux-Kitty-Selection
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v5.2.0
+        with:
+          global-json-file: ./global.json
+
+      - name: Install Linux terminal harness deps
+        run: sudo apt-get update && sudo apt-get install -y kitty xdotool xsel xvfb jq python3
+
+      - name: Build conformance demo
+        run: dotnet build demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj -c Release
+
+      - name: Run kitty conformance harness
+        run: bash tests/conformance/linux/run-kitty-selection.sh "$RUNNER_TEMP/conformance-kitty"
+
+      - name: Upload kitty artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conformance-kitty
+          path: ${{ runner.temp }}/conformance-kitty
+
+  linux-tmux:
+    name: Linux-Tmux-Conformance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v5.2.0
+        with:
+          global-json-file: ./global.json
+
+      - name: Install tmux harness deps
+        run: sudo apt-get update && sudo apt-get install -y tmux python3
+
+      - name: Build conformance demo
+        run: dotnet build demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj -c Release
+
+      - name: Run tmux conformance harness
+        run: bash tests/conformance/linux/run-tmux-capture.sh "$RUNNER_TEMP/conformance-tmux"
+
+      - name: Upload tmux artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conformance-tmux
+          path: ${{ runner.temp }}/conformance-tmux

--- a/Termina.slnx
+++ b/Termina.slnx
@@ -18,6 +18,7 @@
     <Project Path="demos/Termina.Demo.Streaming/Termina.Demo.Streaming.csproj" />
     <Project Path="demos/Termina.Demo.Wizard/Termina.Demo.Wizard.csproj" />
     <Project Path="demos/Termina.Demo.KittyScroll/Termina.Demo.KittyScroll.csproj" />
+    <Project Path="demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Termina.Tests/Termina.Tests.csproj" />

--- a/demos/Termina.Demo.Conformance/ConformanceLogPaths.cs
+++ b/demos/Termina.Demo.Conformance/ConformanceLogPaths.cs
@@ -1,0 +1,3 @@
+namespace Termina.Conformance;
+
+public sealed record ConformanceLogPaths(string TracePath, string EventLogPath);

--- a/demos/Termina.Demo.Conformance/ConformanceRecorder.cs
+++ b/demos/Termina.Demo.Conformance/ConformanceRecorder.cs
@@ -1,0 +1,29 @@
+namespace Termina.Conformance;
+
+public sealed class ConformanceRecorder : IDisposable
+{
+    private readonly StreamWriter _writer;
+    private readonly Lock _gate = new();
+
+    public ConformanceRecorder(ConformanceLogPaths paths)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(paths.EventLogPath)!);
+        _writer = new StreamWriter(paths.EventLogPath, append: false) { AutoFlush = true };
+    }
+
+    public void RecordLine(string payload)
+    {
+        lock (_gate)
+        {
+            _writer.WriteLine(payload);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _writer.Dispose();
+        }
+    }
+}

--- a/demos/Termina.Demo.Conformance/Pages/ConformancePage.cs
+++ b/demos/Termina.Demo.Conformance/Pages/ConformancePage.cs
@@ -1,0 +1,120 @@
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Conformance;
+
+public sealed class ConformancePage : ReactivePage<ConformanceViewModel>
+{
+    private StreamingTextNode _history = null!;
+    private TextInputNode _input = null!;
+    private TextNode _selectionTarget = null!;
+
+    public ConformancePage()
+    {
+        FocusPolicy = FocusPolicy.FirstFocusable;
+    }
+
+    protected override void OnBound()
+    {
+        base.OnBound();
+
+        _history = StreamingTextNode.Create()
+            .WithPrefix("  ", Color.Gray)
+            .WithScrollbar();
+
+        for (var i = 1; i <= 160; i++)
+        {
+            _history.AppendLine($"History line {i,3}: wheel should scroll this pane without breaking text selection.", Color.White);
+        }
+
+        _selectionTarget = new TextNode("Selection sentinel: SELECTABLE SENTINEL 12345")
+            .WithForeground(Color.Yellow)
+            .NoWrap();
+
+        _input = new TextInputNode()
+            .WithPlaceholder("Type here, press Enter to submit. Up/Down should still be keyboard input.")
+            .WithForeground(Color.Cyan);
+    }
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+
+        _input.Submitted
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Subscribe(text =>
+            {
+                ViewModel.RecordSubmitted(text);
+                _history.AppendLine($"submit> {text}", Color.BrightGreen);
+                _input.Clear();
+            })
+            .DisposeWith(Subscriptions);
+
+        ViewModel.Input.OfType<IInputEvent, MouseScrollEvent>()
+            .Subscribe(scroll =>
+            {
+                IScrollable scrollable = _history;
+                if (scroll.Delta > 0)
+                    scrollable.ScrollUp(3);
+                else
+                    scrollable.ScrollDown(3);
+            })
+            .DisposeWith(Subscriptions);
+
+        KeyBindings.Register(ConsoleKey.Q, ConsoleModifiers.Control, Shutdown);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(new TextNode("Termina terminal conformance harness").WithForeground(Color.Yellow).Bold().Height(1))
+            .WithChild(new TextNode("Goals: preserve native selection, keep wheel distinct from arrows, and leave input behavior intact.")
+                .WithForeground(Color.BrightBlack)
+                .Height(1))
+            .WithChild(new EmptyNode().Height(1))
+            .WithChild(_selectionTarget.Height(1))
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("History")
+                    .WithTitleColor(Color.Yellow)
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Yellow)
+                    .WithContent(_history.Fill())
+                    .Fill())
+            .WithChild(
+                Observable.CombineLatest(
+                        ViewModel.LastKeyboardEvent,
+                        ViewModel.ArrowUpCount,
+                        ViewModel.ArrowDownCount,
+                        ViewModel.WheelUpCount,
+                        ViewModel.WheelDownCount,
+                        ViewModel.SubmittedCount,
+                        ViewModel.LastSubmitted,
+                        (last, au, ad, wu, wd, submitted, lastSubmitted) =>
+                            $"LastKey:{last,-16} ArrowUp:{au,3} ArrowDown:{ad,3} WheelUp:{wu,3} WheelDown:{wd,3} Submitted:{submitted,3} LastSubmit:{lastSubmitted}")
+                    .Select<string, ILayoutNode>(line => new TextNode(line).WithForeground(Color.White).NoWrap())
+                    .AsLayout()
+                    .Height(1))
+            .WithChild(
+                Observable.CombineLatest(
+                        ViewModel.TracePath,
+                        ViewModel.EventLogPath,
+                        (tracePath, eventLogPath) => $"Trace: {tracePath}   Events: {eventLogPath}")
+                    .Select<string, ILayoutNode>(line => new TextNode(line).WithForeground(Color.BrightBlack).NoWrap())
+                    .AsLayout()
+                    .Height(1))
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Input")
+                    .WithTitleColor(Color.Cyan)
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Cyan)
+                    .WithContent(_input)
+                    .Height(3));
+    }
+}

--- a/demos/Termina.Demo.Conformance/Pages/ConformanceViewModel.cs
+++ b/demos/Termina.Demo.Conformance/Pages/ConformanceViewModel.cs
@@ -1,0 +1,124 @@
+using R3;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Termina.Conformance;
+
+public sealed class ConformanceViewModel : ReactiveViewModel
+{
+    private readonly ConformanceRecorder _recorder;
+    private readonly ConformanceLogPaths _paths;
+
+    public ReactiveProperty<string> LastKeyboardEvent { get; } = new("(none)");
+    public ReactiveProperty<int> ArrowUpCount { get; } = new(0);
+    public ReactiveProperty<int> ArrowDownCount { get; } = new(0);
+    public ReactiveProperty<int> WheelUpCount { get; } = new(0);
+    public ReactiveProperty<int> WheelDownCount { get; } = new(0);
+    public ReactiveProperty<int> SubmittedCount { get; } = new(0);
+    public ReactiveProperty<string> LastSubmitted { get; } = new("(none)");
+    public ReactiveProperty<string> TracePath { get; }
+    public ReactiveProperty<string> EventLogPath { get; }
+
+    public ConformanceViewModel(ConformanceRecorder recorder, ConformanceLogPaths paths)
+    {
+        _recorder = recorder;
+        _paths = paths;
+        TracePath = new ReactiveProperty<string>(paths.TracePath);
+        EventLogPath = new ReactiveProperty<string>(paths.EventLogPath);
+    }
+
+    public override void OnActivated()
+    {
+        _recorder.RecordLine(
+            JsonLine(
+                ("phase", "startup"),
+                ("tracePath", _paths.TracePath),
+                ("eventLogPath", _paths.EventLogPath),
+                ("envRawInput", Environment.GetEnvironmentVariable("TERMINA_RAW_INPUT") ?? ""),
+                ("envKittyKeyboard", Environment.GetEnvironmentVariable("TERMINA_KITTY_KEYBOARD") ?? ""),
+                ("tmux", (Environment.GetEnvironmentVariable("TMUX") is not null).ToString().ToLowerInvariant()),
+                ("term", Environment.GetEnvironmentVariable("TERM") ?? ""),
+                ("termProgram", Environment.GetEnvironmentVariable("TERM_PROGRAM") ?? "")));
+
+        Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(HandleKey)
+            .DisposeWith(Subscriptions);
+
+        Input.OfType<IInputEvent, MouseScrollEvent>()
+            .Subscribe(scroll =>
+            {
+                if (scroll.Delta > 0)
+                    WheelUpCount.Value++;
+                else
+                    WheelDownCount.Value++;
+
+                _recorder.RecordLine(
+                    JsonLine(
+                        ("phase", "input"),
+                        ("kind", "MouseScrollEvent"),
+                        ("delta", scroll.Delta.ToString())));
+            })
+            .DisposeWith(Subscriptions);
+    }
+
+    public void RecordSubmitted(string text)
+    {
+        SubmittedCount.Value++;
+        LastSubmitted.Value = text;
+        _recorder.RecordLine(
+            JsonLine(
+                ("phase", "submit"),
+                ("text", text),
+                ("count", SubmittedCount.Value.ToString())));
+    }
+
+    private void HandleKey(KeyPressed key)
+    {
+        var info = key.KeyInfo;
+        LastKeyboardEvent.Value = info.Modifiers == 0
+            ? info.Key.ToString()
+            : $"{info.Modifiers}+{info.Key}";
+
+        if (info.Key == ConsoleKey.UpArrow && info.Modifiers == 0)
+            ArrowUpCount.Value++;
+        else if (info.Key == ConsoleKey.DownArrow && info.Modifiers == 0)
+            ArrowDownCount.Value++;
+
+        _recorder.RecordLine(
+            JsonLine(
+                ("phase", "input"),
+                ("kind", "KeyPressed"),
+                ("key", info.Key.ToString()),
+                ("modifiers", info.Modifiers.ToString()),
+                ("keyChar", info.KeyChar == '\0' ? "" : info.KeyChar.ToString())));
+    }
+
+    private static string JsonLine(params (string Key, string Value)[] fields)
+    {
+        return "{" + string.Join(",", fields.Select(field => $"\"{Escape(field.Key)}\":\"{Escape(field.Value)}\"")) + "}";
+    }
+
+    private static string Escape(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
+    }
+
+    public override void Dispose()
+    {
+        LastKeyboardEvent.Dispose();
+        ArrowUpCount.Dispose();
+        ArrowDownCount.Dispose();
+        WheelUpCount.Dispose();
+        WheelDownCount.Dispose();
+        SubmittedCount.Dispose();
+        LastSubmitted.Dispose();
+        TracePath.Dispose();
+        EventLogPath.Dispose();
+        base.Dispose();
+    }
+}

--- a/demos/Termina.Demo.Conformance/Program.cs
+++ b/demos/Termina.Demo.Conformance/Program.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Termina.Conformance;
+using Termina.Diagnostics;
+using Termina.Hosting;
+
+var argsSet = args.ToHashSet(StringComparer.OrdinalIgnoreCase);
+var rawMode = argsSet.Contains("--raw-alt-scroll") || argsSet.Contains("--kitty-alt-scroll");
+var kittyMode = argsSet.Contains("--kitty-alt-scroll")
+    ? KittyKeyboardMode.ReportAllKeysPlusDisambiguate
+    : KittyKeyboardMode.Off;
+
+var outputDir = Path.Combine(Path.GetTempPath(), "termina-conformance");
+Directory.CreateDirectory(outputDir);
+
+var tracePath = Path.Combine(outputDir, "trace.log");
+var eventLogPath = Path.Combine(outputDir, "events.jsonl");
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+builder.Services.AddTerminaFileTracing(tracePath, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+builder.Services.AddSingleton(new ConformanceLogPaths(tracePath, eventLogPath));
+builder.Services.AddSingleton<ConformanceRecorder>();
+
+builder.Services.AddTermina("/", termina =>
+{
+    termina.ConfigureRuntime(options =>
+    {
+        options.PreferRawInput = rawMode;
+        options.ScrollInputMode = rawMode ? ScrollInputMode.AlternateScroll : ScrollInputMode.LegacyMouseTracking;
+        options.KittyKeyboardMode = kittyMode;
+        options.CtrlCHandlingMode = CtrlCHandlingMode.DoublePressWhenRawInput;
+    });
+
+    termina.RegisterRoute<ConformancePage, ConformanceViewModel>("/");
+});
+
+await builder.Build().RunAsync();

--- a/demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj
+++ b/demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Termina\Termina.csproj" />
+    <ProjectReference Include="..\..\src\Termina.Generators\Termina.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all"
+                      Publish="false" />
+  </ItemGroup>
+
+</Project>

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -1,0 +1,17 @@
+# Terminal Conformance
+
+This directory holds the first-pass terminal conformance harness for Termina.
+
+Goals:
+
+- verify that alternate-scroll does not regress native text selection
+- verify that wheel input remains distinct from keyboard arrows when raw input + kitty reporting are enabled
+- verify that fallback / baseline terminal behavior still produces the expected setup sequences
+
+The initial automation target is Linux on GitHub-hosted runners:
+
+- plain PTY capture
+- `tmux`
+- `kitty` under `Xvfb`
+
+The suite intentionally does **not** merge into the main validation workflow yet. It is designed to be iterated on in a dedicated branch until the runner behavior is stable.

--- a/tests/conformance/linux/assert-conformance.py
+++ b/tests/conformance/linux/assert-conformance.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_events(path: Path):
+    events = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        events.append(json.loads(line))
+    return events
+
+
+def require(condition: bool, message: str):
+    if not condition:
+        raise AssertionError(message)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--events", required=True)
+    parser.add_argument("--selection")
+    parser.add_argument("--ansi-capture")
+    parser.add_argument("--expect-wheel", action="store_true")
+    parser.add_argument("--expect-arrows", action="store_true")
+    parser.add_argument("--expect-selection")
+    parser.add_argument("--require-alt-scroll-sequence", action="store_true")
+    parser.add_argument("--require-alt-scroll-enable-only", action="store_true")
+    parser.add_argument("--require-no-mouse-tracking", action="store_true")
+    parser.add_argument("--require-legacy-mouse-tracking", action="store_true")
+    parser.add_argument("--require-kitty-sequence")
+    args = parser.parse_args()
+
+    events = load_events(Path(args.events))
+    require(
+        any(evt.get("phase") == "startup" for evt in events), "missing startup event"
+    )
+
+    if args.expect_wheel:
+        require(
+            any(evt.get("kind") == "MouseScrollEvent" for evt in events),
+            "missing MouseScrollEvent",
+        )
+
+    if args.expect_arrows:
+        keys = [evt for evt in events if evt.get("kind") == "KeyPressed"]
+        require(
+            any(evt.get("key") == "UpArrow" for evt in keys), "missing UpArrow event"
+        )
+        require(
+            any(evt.get("key") == "DownArrow" for evt in keys),
+            "missing DownArrow event",
+        )
+
+    if args.expect_selection:
+        selection_text = Path(args.selection).read_text()
+        require(
+            args.expect_selection in selection_text,
+            f"selection did not contain '{args.expect_selection}'",
+        )
+
+    if args.ansi_capture:
+        capture = Path(args.ansi_capture).read_bytes()
+        if args.require_alt_scroll_sequence:
+            require(
+                b"\x1b[?1007h" in capture, "missing alternate-scroll enable sequence"
+            )
+            require(
+                b"\x1b[?1007l" in capture, "missing alternate-scroll disable sequence"
+            )
+            require(b"\x1b[?1h" in capture, "missing DECCKM enable sequence")
+            require(b"\x1b[?1l" in capture, "missing DECCKM disable sequence")
+
+        if args.require_alt_scroll_enable_only:
+            require(
+                b"\x1b[?1007h" in capture, "missing alternate-scroll enable sequence"
+            )
+            require(b"\x1b[?1h" in capture, "missing DECCKM enable sequence")
+
+        if args.require_no_mouse_tracking:
+            require(
+                b"\x1b[?1000h" not in capture,
+                "unexpected mouse tracking enable sequence",
+            )
+            require(
+                b"\x1b[?1006h" not in capture, "unexpected SGR mouse enable sequence"
+            )
+
+        if args.require_legacy_mouse_tracking:
+            require(
+                b"\x1b[?1000h" in capture,
+                "missing normal mouse tracking enable sequence",
+            )
+            require(
+                b"\x1b[?1006h" in capture,
+                "missing SGR mouse enable sequence",
+            )
+            require(
+                b"\x1b[?1007h" not in capture,
+                "unexpected alternate-scroll enable sequence",
+            )
+
+        if args.require_kitty_sequence:
+            expected = f"\x1b[>{args.require_kitty_sequence}u".encode()
+            require(
+                expected in capture,
+                f"missing kitty enable sequence {args.require_kitty_sequence}",
+            )
+            require(b"\x1b[<u" in capture, "missing kitty disable sequence")
+
+    print("conformance assertions passed")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except AssertionError as exc:
+        print(f"ASSERTION FAILED: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/conformance/linux/run-baseline-capture.sh
+++ b/tests/conformance/linux/run-baseline-capture.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ARTIFACT_DIR="${1:-${ROOT_DIR}/conformance-artifacts/baseline}"
+mkdir -p "$ARTIFACT_DIR"
+
+CAPTURE="$ARTIFACT_DIR/ansi-capture.log"
+EVENTS="$ARTIFACT_DIR/events.jsonl"
+
+export TERMINA_RAW_INPUT=0
+unset TERMINA_KITTY_KEYBOARD || true
+unset TMUX || true
+unset TERM_PROGRAM || true
+
+rm -rf /tmp/termina-conformance || true
+
+script -qefc "dotnet run --project demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj -c Release --no-build" "$CAPTURE" >/dev/null &
+SCRIPT_PID=$!
+
+for _ in $(seq 1 30); do
+  [[ -f /tmp/termina-conformance/events.jsonl ]] && break
+  sleep 1
+done
+
+sleep 2
+pkill -f "Termina.Demo.Conformance" || true
+wait "$SCRIPT_PID" || true
+
+cp /tmp/termina-conformance/events.jsonl "$EVENTS"
+
+python3 "$ROOT_DIR/tests/conformance/linux/assert-conformance.py" \
+  --events "$EVENTS" \
+  --ansi-capture "$CAPTURE" \
+  --require-legacy-mouse-tracking

--- a/tests/conformance/linux/run-kitty-selection.sh
+++ b/tests/conformance/linux/run-kitty-selection.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ARTIFACT_DIR="${1:-${ROOT_DIR}/conformance-artifacts/kitty}"
+mkdir -p "$ARTIFACT_DIR"
+
+RUN_ROOT="$(mktemp -d)"
+CONFORMANCE_DIR="$RUN_ROOT/termina-conformance"
+
+KITTY_CONF="$ARTIFACT_DIR/kitty.conf"
+SELECTION_FILE="$ARTIFACT_DIR/selection.txt"
+EVENTS="$ARTIFACT_DIR/events.jsonl"
+CAPTURE="$ARTIFACT_DIR/ansi-capture.log"
+SOCKET_PATH="${ARTIFACT_DIR}/kitty.sock"
+SOCKET="unix:${SOCKET_PATH}"
+DISPLAY_NUM=":104"
+
+cat >"$KITTY_CONF" <<'EOF'
+allow_remote_control socket
+confirm_os_window_close 0
+enable_audio_bell no
+font_size 16.0
+window_padding_width 0
+tab_bar_style hidden
+copy_on_select clipboard
+shell_integration no-rc no-cursor
+EOF
+
+export DISPLAY="$DISPLAY_NUM"
+export TERMINA_RAW_INPUT=1
+export TERMINA_KITTY_KEYBOARD=9
+export TMPDIR="$RUN_ROOT"
+unset TMUX || true
+unset TERM_PROGRAM || true
+
+Xvfb "$DISPLAY_NUM" -screen 0 1400x900x24 >"$ARTIFACT_DIR/xvfb.log" 2>&1 &
+XVFB_PID=$!
+cleanup() {
+  kill "$KITTY_PID" "$XVFB_PID" >/dev/null 2>&1 || true
+  rm -rf "$RUN_ROOT"
+}
+trap cleanup EXIT
+
+kitty --config "$KITTY_CONF" --listen-on "$SOCKET" \
+  env -u TMUX -u TERM_PROGRAM bash --noprofile --norc -lc "script -qefc 'dotnet run --project demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj -c Release --no-build -- --kitty-alt-scroll' '$CAPTURE'" \
+  >"$ARTIFACT_DIR/kitty.log" 2>&1 &
+KITTY_PID=$!
+
+for _ in $(seq 1 30); do
+  kitty @ --to "$SOCKET" ls >"$ARTIFACT_DIR/kitty-ls.json" 2>/dev/null && [[ -s "$ARTIFACT_DIR/kitty-ls.json" ]] && [[ -f "$CONFORMANCE_DIR/events.jsonl" ]] && break
+  sleep 1
+done
+
+WINDOW_ID=$(jq '.[0].platform_window_id // 0' "$ARTIFACT_DIR/kitty-ls.json")
+COLS=$(jq '.[0].tabs[0].windows[0].columns // 0' "$ARTIFACT_DIR/kitty-ls.json")
+LINES=$(jq '.[0].tabs[0].windows[0].lines // 0' "$ARTIFACT_DIR/kitty-ls.json")
+
+if [[ "$WINDOW_ID" -eq 0 || "$COLS" -eq 0 || "$LINES" -eq 0 ]]; then
+  echo "kitty window metadata not ready" >&2
+  exit 1
+fi
+
+for _ in $(seq 1 30); do
+  if xdotool getwindowgeometry --shell "$WINDOW_ID" >"$ARTIFACT_DIR/geometry.env" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ ! -s "$ARTIFACT_DIR/geometry.env" ]]; then
+  echo "kitty window geometry not ready" >&2
+  exit 1
+fi
+
+eval "$(cat "$ARTIFACT_DIR/geometry.env")"
+
+CELL_W=$((WIDTH / COLS))
+CELL_H=$((HEIGHT / LINES))
+START_X=$((CELL_W * 3 + CELL_W / 2))
+START_Y=$((CELL_H * 3 + CELL_H / 2))
+END_X=$((CELL_W * 31))
+END_Y=$START_Y
+
+xdotool key --window "$WINDOW_ID" a b c Left Left Up Down Return
+sleep 1
+
+xdotool mousemove --window "$WINDOW_ID" "$START_X" "$START_Y"
+xdotool mousedown --window "$WINDOW_ID" 1
+xdo_event_delay=0
+xdotool click --window "$WINDOW_ID" 4
+xdotool click --window "$WINDOW_ID" 5
+xdotool mousemove --sync --window "$WINDOW_ID" "$END_X" "$END_Y"
+xdotool mouseup --window "$WINDOW_ID" 1
+sleep 1
+
+kitty @ --to "$SOCKET" get-text --extent selection >"$SELECTION_FILE"
+cp "$CONFORMANCE_DIR/events.jsonl" "$EVENTS"
+
+python3 "$ROOT_DIR/tests/conformance/linux/assert-conformance.py" \
+  --events "$EVENTS" \
+  --selection "$SELECTION_FILE" \
+  --ansi-capture "$CAPTURE" \
+  --expect-arrows \
+  --expect-selection "SELECTABLE" \
+  --require-alt-scroll-enable-only \
+  --require-no-mouse-tracking \
+  --require-kitty-sequence 9

--- a/tests/conformance/linux/run-kitty-selection.sh
+++ b/tests/conformance/linux/run-kitty-selection.sh
@@ -95,6 +95,27 @@ xdotool mouseup --window "$WINDOW_ID" 1
 sleep 1
 
 kitty @ --to "$SOCKET" get-text --extent selection >"$SELECTION_FILE"
+
+# Let the app exit cleanly so the capture includes kitty/alternate-scroll teardown.
+xdotool key --window "$WINDOW_ID" ctrl+q
+
+for _ in $(seq 1 30); do
+  if [[ -f "$CAPTURE" ]] && python3 - "$CAPTURE" <<'PY'
+import sys
+from pathlib import Path
+
+capture = Path(sys.argv[1]).read_bytes()
+sys.exit(0 if b"\x1b[<u" in capture and b"\x1b[?1007l" in capture else 1)
+PY
+  then
+    break
+  fi
+
+  sleep 1
+done
+
+rm -f "$SOCKET_PATH"
+
 cp "$CONFORMANCE_DIR/events.jsonl" "$EVENTS"
 
 python3 "$ROOT_DIR/tests/conformance/linux/assert-conformance.py" \

--- a/tests/conformance/linux/run-tmux-capture.sh
+++ b/tests/conformance/linux/run-tmux-capture.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ARTIFACT_DIR="${1:-${ROOT_DIR}/conformance-artifacts/tmux}"
+mkdir -p "$ARTIFACT_DIR"
+
+RUN_ROOT="$(mktemp -d)"
+CONFORMANCE_DIR="$RUN_ROOT/termina-conformance"
+
+CAPTURE="$ARTIFACT_DIR/pane.txt"
+EVENTS="$ARTIFACT_DIR/events.jsonl"
+SESSION="termina-conformance"
+TMUX_SOCKET="termina-ci"
+
+export TERMINA_RAW_INPUT=1
+export TERMINA_KITTY_KEYBOARD=9
+export TMPDIR="$RUN_ROOT"
+unset TMUX || true
+unset TERM_PROGRAM || true
+
+tmux -L "$TMUX_SOCKET" kill-server >/dev/null 2>&1 || true
+tmux -L "$TMUX_SOCKET" new-session -d -s "$SESSION" "env -u TMUX -u TERM_PROGRAM bash --noprofile --norc -lc 'dotnet run --project demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj -c Release --no-build -- --kitty-alt-scroll'"
+
+sleep 4
+tmux -L "$TMUX_SOCKET" send-keys -t "$SESSION" a b c Left Left Up Down Enter
+sleep 1
+tmux -L "$TMUX_SOCKET" capture-pane -p -t "$SESSION" >"$CAPTURE"
+
+cp "$CONFORMANCE_DIR/events.jsonl" "$EVENTS"
+
+python3 "$ROOT_DIR/tests/conformance/linux/assert-conformance.py" \
+  --events "$EVENTS" \
+  --expect-wheel
+
+tmux -L "$TMUX_SOCKET" kill-session -t "$SESSION" >/dev/null 2>&1 || true
+tmux -L "$TMUX_SOCKET" kill-server >/dev/null 2>&1 || true
+rm -rf "$RUN_ROOT"


### PR DESCRIPTION
## Summary
- add a first-pass terminal conformance demo that records machine-readable input events and trace paths
- add Linux smoke scripts for baseline PTY capture, tmux behavior, and an experimental kitty selection/assertion path
- add a dedicated GitHub Actions workflow so this can iterate independently from the main PR validation pipeline

## Notes
- this PR is intentionally exploratory and is not ready to merge yet
- baseline and tmux legs are locally viable
- the kitty leg is still experimental and needs more runner-driven iteration, especially around window readiness and wheel synthesis