### PR TITLE
Add ReactivePage.InvalidateLayout() for runtime layout rebuilds

### DIFF
--- a/src/Termina/Layout/DynamicLayoutNode.cs
+++ b/src/Termina/Layout/DynamicLayoutNode.cs
@@ -100,6 +100,13 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
     internal override IEnumerable<ILayoutNode> GetChildNodes() => [_currentChild];
 
     /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        _childInvalidationSubscription?.Dispose();
+        _childInvalidationSubscription = null;
+    }
+
+    /// <inheritdoc />
     public override Size Measure(Size available)
     {
         EvaluateFactory();

--- a/src/Termina/Layout/GridNode.cs
+++ b/src/Termina/Layout/GridNode.cs
@@ -103,6 +103,15 @@ public sealed class GridNode : LayoutNode, IFocusable, IInvalidatingNode
     /// <inheritdoc />
     public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
+    /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        foreach (var sub in _cellSubscriptions)
+            sub.Dispose();
+
+        _cellSubscriptions.Clear();
+    }
+
     /// <summary>
     /// Observable that emits when the focused cell changes.
     /// </summary>

--- a/src/Termina/Layout/KeyedDynamicLayoutNode.cs
+++ b/src/Termina/Layout/KeyedDynamicLayoutNode.cs
@@ -116,6 +116,13 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     internal override IEnumerable<ILayoutNode> GetChildNodes() => [_currentChild];
 
     /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        _childInvalidationSubscription?.Dispose();
+        _childInvalidationSubscription = null;
+    }
+
+    /// <inheritdoc />
     public override Size Measure(Size available)
     {
         EvaluateFactory();

--- a/src/Termina/Layout/LayoutNode.cs
+++ b/src/Termina/Layout/LayoutNode.cs
@@ -73,6 +73,14 @@ public abstract class LayoutNode : ILayoutNode
     internal virtual IEnumerable<ILayoutNode> GetChildNodes() => [];
 
     /// <summary>
+    /// Disconnect subscriptions from this node to its children without
+    /// disposing or mutating the children themselves.
+    /// </summary>
+    internal virtual void DisconnectChildInvalidationSubscriptions()
+    {
+    }
+
+    /// <summary>
     /// Set width to a fixed value.
     /// </summary>
     public LayoutNode Width(int value)
@@ -216,6 +224,17 @@ public abstract class ContainerNode : LayoutNode, IContainerNode, IInvalidatingN
             child.Dispose();
         }
         base.Dispose();
+    }
+
+    /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        foreach (var subscription in _childInvalidationSubscriptions)
+        {
+            subscription.Dispose();
+        }
+
+        _childInvalidationSubscriptions.Clear();
     }
 
     /// <summary>

--- a/src/Termina/Layout/PanelNode.cs
+++ b/src/Termina/Layout/PanelNode.cs
@@ -130,6 +130,13 @@ public sealed class PanelNode : LayoutNode, IInvalidatingNode
     internal override IEnumerable<ILayoutNode> GetChildNodes() => [_content];
 
     /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        _contentInvalidationSubscription?.Dispose();
+        _contentInvalidationSubscription = null;
+    }
+
+    /// <inheritdoc />
     public override Size Measure(Size available)
     {
         // Border takes 2 chars horizontally (left + right) and 2 rows vertically (top + bottom)
@@ -276,4 +283,3 @@ public sealed class PanelNode : LayoutNode, IInvalidatingNode
         char BottomLeft, char BottomRight,
         char Horizontal, char Vertical);
 }
-

--- a/src/Termina/Layout/ReactiveLayoutNode.cs
+++ b/src/Termina/Layout/ReactiveLayoutNode.cs
@@ -71,6 +71,13 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
     internal override IEnumerable<ILayoutNode> GetChildNodes() => [_currentChild];
 
     /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        _childInvalidationSubscription?.Dispose();
+        _childInvalidationSubscription = null;
+    }
+
+    /// <inheritdoc />
     public override Size Measure(Size available)
     {
         var childSize = _currentChild.Measure(available);
@@ -221,6 +228,13 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
 
     /// <inheritdoc />
     internal override IEnumerable<ILayoutNode> GetChildNodes() => [_currentChild];
+
+    /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        _childInvalidationSubscription?.Dispose();
+        _childInvalidationSubscription = null;
+    }
 
     /// <inheritdoc />
     public override Size Measure(Size available)

--- a/src/Termina/Layout/ScrollableContainerNode.cs
+++ b/src/Termina/Layout/ScrollableContainerNode.cs
@@ -255,6 +255,13 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     internal override IEnumerable<ILayoutNode> GetChildNodes() => [_content];
 
     /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        _contentSubscription?.Dispose();
+        _contentSubscription = null;
+    }
+
+    /// <inheritdoc />
     public override Size Measure(Size available)
     {
         // Calculate available width accounting for scrollbar

--- a/src/Termina/Layout/WizardNode.cs
+++ b/src/Termina/Layout/WizardNode.cs
@@ -619,6 +619,13 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
     }
 
     /// <inheritdoc />
+    internal override void DisconnectChildInvalidationSubscriptions()
+    {
+        _contentInvalidationSubscription?.Dispose();
+        _contentInvalidationSubscription = null;
+    }
+
+    /// <inheritdoc />
     public override void OnActivate()
     {
         _isActive = true;

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -238,13 +238,9 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     /// may hold references to nodes used inside <see cref="BuildLayout"/>
     /// (e.g., a streaming text component initialized in <see cref="OnBound"/>
     /// and reused as panel content); disposing would destroy that state.
-    /// Known limitation: orphaned wrapper containers (panels, vertical/
-    /// horizontal layouts created inline in <see cref="BuildLayout"/>) keep
-    /// their <c>IInvalidatingNode</c> subscriptions to any user-held child
-    /// nodes until the page is disposed; repeated invalidation will
-    /// accumulate dead containers. Prefer reactive bindings inside
-    /// <see cref="BuildLayout"/> over frequent <see cref="InvalidateLayout"/>
-    /// calls when this matters.
+    /// Framework-owned invalidation subscriptions on abandoned wrapper nodes
+    /// are disconnected during the swap so those wrappers do not keep driving
+    /// redraws or stay retained through reused child nodes.
     /// </para>
     /// <para>
     /// <b>User subscriptions targeting BuildLayout-created nodes:</b>
@@ -296,28 +292,39 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
         _isRebuilding = true;
         try
         {
+            var oldRoot = _layoutRoot;
+
             // Build new tree FIRST so a throwing BuildLayout leaves the page
             // with its existing layout intact (no clear/null commit yet).
             var newRoot = BuildLayout()
                 ?? throw new InvalidOperationException(
                     $"BuildLayout() returned null for page {GetType().FullName}.");
 
-            // Activate the new tree before swapping. The IInvalidatingNode
-            // subscription is wired after the swap so synchronous Invalidated
-            // emissions during activation don't trigger a redraw against a
-            // tree the framework hasn't observed yet (we publish one explicit
-            // RequestRedraw at the end instead).
-            if (newRoot is LayoutNode newNode)
-                newNode.OnActivate();
+            var newNodes = CollectLayoutNodes(newRoot);
+
+            // Tear down the old framework wiring before we touch the previous
+            // tree so any invalidation raised during deactivation doesn't
+            // schedule redraws against the outgoing layout.
+            _layoutSubscriptions.Clear();
+
+            // Deactivate the old tree before activating the new one. If the
+            // page reuses child node instances across rebuilds, this ensures
+            // those nodes finish in the active state after the new tree is
+            // activated rather than being shut back down by the old tree.
+            if (oldRoot is LayoutNode oldNode)
+                oldNode.OnDeactivate();
+
+            // Disconnect invalidation subscriptions on old nodes that won't
+            // survive the rebuild. This keeps abandoned wrappers from being
+            // retained through reused children once the swap completes.
+            DisconnectAbandonedNodes(oldRoot, newNodes);
 
             // Atomic swap: from here on, _layoutRoot points at the new tree
             // and the old tree is fully replaced.
-            var oldRoot = _layoutRoot;
             _layoutRoot = newRoot;
 
-            // Tear down the old framework wiring, then re-wire on the new
-            // tree. User-held _subscriptions stay untouched.
-            _layoutSubscriptions.Clear();
+            // Wire framework invalidation on the new tree before activation so
+            // synchronous Invalidated emissions during OnActivate are observed.
             if (newRoot is IInvalidatingNode invalidating)
             {
                 invalidating.Invalidated
@@ -325,11 +332,8 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
                     .DisposeWith(_layoutSubscriptions);
             }
 
-            // Deactivate the old tree AFTER the swap so a brief read of
-            // IBindablePage.LayoutRoot during the transition sees a valid
-            // (active) tree, never null.
-            if (oldRoot is LayoutNode oldNode)
-                oldNode.OnDeactivate();
+            if (newRoot is LayoutNode newNode)
+                newNode.OnActivate();
 
             // Focus handling: preserve user focus if the focused node still
             // exists in the new tree (common case when BuildLayout reuses
@@ -406,6 +410,36 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
         {
             ApplyFocusPolicy(_layoutRoot);
         }
+    }
+
+    private static HashSet<ILayoutNode> CollectLayoutNodes(ILayoutNode root)
+    {
+        var visited = new HashSet<ILayoutNode>();
+        var stack = new Stack<ILayoutNode>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            if (!visited.Add(current) || current is not LayoutNode layoutNode)
+                continue;
+
+            foreach (var child in layoutNode.GetChildNodes())
+                stack.Push(child);
+        }
+
+        return visited;
+    }
+
+    private static void DisconnectAbandonedNodes(ILayoutNode? root, HashSet<ILayoutNode> retainedNodes)
+    {
+        if (root is not LayoutNode layoutNode || retainedNodes.Contains(root))
+            return;
+
+        layoutNode.DisconnectChildInvalidationSubscriptions();
+
+        foreach (var child in layoutNode.GetChildNodes())
+            DisconnectAbandonedNodes(child, retainedNodes);
     }
 
     /// <summary>

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -48,6 +48,12 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     private readonly PageKeyBindings _keyBindings = new();
     private ILayoutNode? _layoutRoot;
 
+    // Lifecycle state — guards InvalidateLayout against bad call patterns
+    // (before activation, after disposal, re-entrant from BuildLayout).
+    private bool _isActivated;
+    private bool _isDisposed;
+    private bool _isRebuilding;
+
     /// <summary>
     /// Determines how focus is automatically assigned when this page is navigated to.
     /// Set in the page constructor or <see cref="OnBound"/> method.
@@ -194,11 +200,21 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     /// </summary>
     public virtual void OnNavigatedTo()
     {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+        // Idempotent: if the framework calls OnNavigatedTo twice without an
+        // intervening OnNavigatingFrom (or a user override calls base after
+        // already-activated state), skip the wiring so we don't double-subscribe
+        // or double-activate.
+        if (_isActivated)
+            return;
+
         BuildAndActivateLayout();
+        _isActivated = true;
     }
 
     /// <summary>
-    /// Discards the cached layout root so the next render rebuilds via
+    /// Discards the cached layout root and rebuilds it via
     /// <see cref="BuildLayout"/>. Use this when external state captured at
     /// <see cref="BuildLayout"/>-time has changed (e.g., terminal dimensions
     /// baked into a <c>HeightAuto</c> constraint, theme values frozen into
@@ -206,50 +222,167 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     /// </summary>
     /// <remarks>
     /// <para>
-    /// User subscriptions in <see cref="Subscriptions"/> and registered
-    /// <see cref="KeyBindings"/> are preserved. Framework-internal wiring
-    /// against the current layout (invalidation→redraw) is torn down and
-    /// re-created against the new tree.
+    /// <b>Preserved across invalidate:</b> user subscriptions in
+    /// <see cref="Subscriptions"/>, registered <see cref="KeyBindings"/>, and
+    /// the user's keyboard focus (when the focused node still exists in the
+    /// new tree). <see cref="FocusPolicy"/> is NOT re-applied unless the
+    /// previous focus target is gone (orphaned by the rebuild).
     /// </para>
     /// <para>
-    /// The old layout root is deactivated but NOT disposed — callers may
-    /// hold references to nodes used inside <see cref="BuildLayout"/> (e.g.,
-    /// a streaming text component initialized in <see cref="OnBound"/> and
-    /// reused as panel content); disposing would destroy that state. The
-    /// orphaned wrapper nodes built only inside <see cref="BuildLayout"/>
-    /// (panels, vertical/horizontal layouts) are garbage-collected.
+    /// <b>Build-then-swap exception safety:</b> the new tree is built and
+    /// activated before the old one is replaced. If <see cref="BuildLayout"/>
+    /// throws, the page keeps its existing layout — no half-state.
+    /// </para>
+    /// <para>
+    /// <b>The old layout root is deactivated but NOT disposed</b> — callers
+    /// may hold references to nodes used inside <see cref="BuildLayout"/>
+    /// (e.g., a streaming text component initialized in <see cref="OnBound"/>
+    /// and reused as panel content); disposing would destroy that state.
+    /// Known limitation: orphaned wrapper containers (panels, vertical/
+    /// horizontal layouts created inline in <see cref="BuildLayout"/>) keep
+    /// their <c>IInvalidatingNode</c> subscriptions to any user-held child
+    /// nodes until the page is disposed; repeated invalidation will
+    /// accumulate dead containers. Prefer reactive bindings inside
+    /// <see cref="BuildLayout"/> over frequent <see cref="InvalidateLayout"/>
+    /// calls when this matters.
+    /// </para>
+    /// <para>
+    /// <b>User subscriptions targeting BuildLayout-created nodes:</b>
+    /// subscriptions registered against nodes created inline in
+    /// <see cref="BuildLayout"/> will continue firing into the orphaned
+    /// old nodes after invalidate, NOT the new nodes. Either subscribe
+    /// against page-field nodes (initialized in <see cref="OnBound"/>) that
+    /// you reuse in <see cref="BuildLayout"/>, or re-subscribe at the start
+    /// of each <see cref="BuildLayout"/> call.
+    /// </para>
+    /// <para>
+    /// <b>Contract:</b> Throws <see cref="ObjectDisposedException"/> after
+    /// <see cref="Dispose"/>. Throws <see cref="InvalidOperationException"/>
+    /// if called re-entrantly (e.g., from inside <see cref="BuildLayout"/>
+    /// or a node lifecycle callback) or if <see cref="BuildLayout"/> returns
+    /// <see langword="null"/>. Silently no-ops if the page is not currently
+    /// active (between <see cref="OnNavigatingFrom"/> and the next
+    /// <see cref="OnNavigatedTo"/>, or before the first navigation) — in
+    /// that case the next navigation will rebuild fresh anyway.
+    /// </para>
+    /// <para>
+    /// <b>Thread affinity:</b> must be called on the same dispatcher
+    /// thread that drives navigation/rendering.
     /// </para>
     /// </remarks>
+    /// <exception cref="ObjectDisposedException">The page has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Called re-entrantly during another <see cref="InvalidateLayout"/> or
+    /// <see cref="BuildLayout"/> on the same page, or
+    /// <see cref="BuildLayout"/> returned <see langword="null"/>.
+    /// </exception>
     protected void InvalidateLayout()
     {
-        // Drop the layout-tied subscriptions so the new tree's invalidation
-        // events flow into a fresh subscription. User subscriptions are
-        // untouched.
-        _layoutSubscriptions.Clear();
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
 
-        // Pause the old tree before replacing it. We do NOT Dispose() because
-        // user-held node references would be destroyed (see remarks).
-        if (_layoutRoot is LayoutNode oldNode)
+        if (_isRebuilding)
         {
-            oldNode.OnDeactivate();
+            throw new InvalidOperationException(
+                "InvalidateLayout cannot be called re-entrantly from BuildLayout " +
+                "or a layout node lifecycle callback.");
         }
 
-        _layoutRoot = null;
+        // No-op when inactive: the next OnNavigatedTo will build fresh anyway,
+        // so doing the work now would just resurrect an inactive page and
+        // cause double-subscribe + double-activate on the next navigation.
+        if (!_isActivated)
+            return;
 
-        BuildAndActivateLayout();
+        _isRebuilding = true;
+        try
+        {
+            // Build new tree FIRST so a throwing BuildLayout leaves the page
+            // with its existing layout intact (no clear/null commit yet).
+            var newRoot = BuildLayout()
+                ?? throw new InvalidOperationException(
+                    $"BuildLayout() returned null for page {GetType().FullName}.");
+
+            // Activate the new tree before swapping. The IInvalidatingNode
+            // subscription is wired after the swap so synchronous Invalidated
+            // emissions during activation don't trigger a redraw against a
+            // tree the framework hasn't observed yet (we publish one explicit
+            // RequestRedraw at the end instead).
+            if (newRoot is LayoutNode newNode)
+                newNode.OnActivate();
+
+            // Atomic swap: from here on, _layoutRoot points at the new tree
+            // and the old tree is fully replaced.
+            var oldRoot = _layoutRoot;
+            _layoutRoot = newRoot;
+
+            // Tear down the old framework wiring, then re-wire on the new
+            // tree. User-held _subscriptions stay untouched.
+            _layoutSubscriptions.Clear();
+            if (newRoot is IInvalidatingNode invalidating)
+            {
+                invalidating.Invalidated
+                    .Subscribe(_ => ViewModel.RequestRedraw())
+                    .DisposeWith(_layoutSubscriptions);
+            }
+
+            // Deactivate the old tree AFTER the swap so a brief read of
+            // IBindablePage.LayoutRoot during the transition sees a valid
+            // (active) tree, never null.
+            if (oldRoot is LayoutNode oldNode)
+                oldNode.OnDeactivate();
+
+            // Focus handling: preserve user focus if the focused node still
+            // exists in the new tree (common case when BuildLayout reuses
+            // page-field nodes). Otherwise the focused node is orphaned —
+            // clear focus and fall back to the policy default on the new
+            // tree so the user has somewhere to land.
+            if (Focus is not null && Focus.CurrentFocus is { } currentFocus)
+            {
+                var newFocusables = Focus.CollectFocusables(newRoot);
+                var stillPresent = false;
+                foreach (var f in newFocusables)
+                {
+                    if (ReferenceEquals(f, currentFocus))
+                    {
+                        stillPresent = true;
+                        break;
+                    }
+                }
+
+                if (!stillPresent)
+                {
+                    Focus.ClearFocus();
+                    if (FocusPolicy != FocusPolicy.Manual)
+                        ApplyFocusPolicy(newRoot);
+                }
+            }
+
+            // Request a redraw so the new tree actually renders. Without
+            // this, callers who invalidate in response to an event that
+            // doesn't otherwise touch a ReactiveProperty would see no visual
+            // change until the next unrelated reactive emission.
+            ViewModel.RequestRedraw();
+        }
+        finally
+        {
+            _isRebuilding = false;
+        }
     }
 
     /// <summary>
     /// Build (if needed) and activate the layout tree, wiring framework-level
-    /// subscriptions. Called from <see cref="OnNavigatedTo"/> and from
-    /// <see cref="InvalidateLayout"/>.
+    /// subscriptions. Called from <see cref="OnNavigatedTo"/> only;
+    /// <see cref="InvalidateLayout"/> takes its own build-then-swap path for
+    /// exception safety.
     /// </summary>
     private void BuildAndActivateLayout()
     {
         // Build layout once on first navigation, reactivate on subsequent visits.
         if (_layoutRoot == null)
         {
-            _layoutRoot = BuildLayout();
+            _layoutRoot = BuildLayout()
+                ?? throw new InvalidOperationException(
+                    $"BuildLayout() returned null for page {GetType().FullName}.");
         }
 
         // Subscribe to layout invalidation events to trigger redraws. Lives in
@@ -336,6 +469,10 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
             node.OnDeactivate();
         }
 
+        // InvalidateLayout becomes a no-op until the next OnNavigatedTo —
+        // there's no point rebuilding a tree that isn't being rendered.
+        _isActivated = false;
+
         // Note: _layoutRoot is NOT disposed or nulled - it's preserved for reactivation
     }
 
@@ -345,7 +482,16 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     /// </summary>
     public virtual void Dispose()
     {
-        // Final cleanup when page is truly destroyed (not just navigated away)
+        if (_isDisposed)
+            return;
+
+        // Final cleanup when page is truly destroyed (not just navigated away).
+        // Set _isDisposed before the disposal cascade so any late callback that
+        // re-enters InvalidateLayout or OnNavigatedTo throws cleanly instead
+        // of resurrecting a dead page.
+        _isDisposed = true;
+        _isActivated = false;
+
         _subscriptions.Dispose();
         _layoutSubscriptions.Dispose();
         _layoutRoot?.Dispose();

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -40,6 +40,11 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     where TViewModel : ReactiveViewModel
 {
     private readonly CompositeDisposable _subscriptions = new();
+    // Framework-internal subscriptions tied to the current _layoutRoot (e.g.,
+    // IInvalidatingNode.Invalidated → RequestRedraw). Kept separate from
+    // _subscriptions so InvalidateLayout() can tear them down and re-wire
+    // without touching user code's page-level subscriptions.
+    private readonly CompositeDisposable _layoutSubscriptions = new();
     private readonly PageKeyBindings _keyBindings = new();
     private ILayoutNode? _layoutRoot;
 
@@ -189,20 +194,72 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     /// </summary>
     public virtual void OnNavigatedTo()
     {
-        // Build layout once on first navigation, reactivate on subsequent visits
+        BuildAndActivateLayout();
+    }
+
+    /// <summary>
+    /// Discards the cached layout root so the next render rebuilds via
+    /// <see cref="BuildLayout"/>. Use this when external state captured at
+    /// <see cref="BuildLayout"/>-time has changed (e.g., terminal dimensions
+    /// baked into a <c>HeightAuto</c> constraint, theme values frozen into
+    /// node colors) and you need the layout tree to re-evaluate those values.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// User subscriptions in <see cref="Subscriptions"/> and registered
+    /// <see cref="KeyBindings"/> are preserved. Framework-internal wiring
+    /// against the current layout (invalidation→redraw) is torn down and
+    /// re-created against the new tree.
+    /// </para>
+    /// <para>
+    /// The old layout root is deactivated but NOT disposed — callers may
+    /// hold references to nodes used inside <see cref="BuildLayout"/> (e.g.,
+    /// a streaming text component initialized in <see cref="OnBound"/> and
+    /// reused as panel content); disposing would destroy that state. The
+    /// orphaned wrapper nodes built only inside <see cref="BuildLayout"/>
+    /// (panels, vertical/horizontal layouts) are garbage-collected.
+    /// </para>
+    /// </remarks>
+    protected void InvalidateLayout()
+    {
+        // Drop the layout-tied subscriptions so the new tree's invalidation
+        // events flow into a fresh subscription. User subscriptions are
+        // untouched.
+        _layoutSubscriptions.Clear();
+
+        // Pause the old tree before replacing it. We do NOT Dispose() because
+        // user-held node references would be destroyed (see remarks).
+        if (_layoutRoot is LayoutNode oldNode)
+        {
+            oldNode.OnDeactivate();
+        }
+
+        _layoutRoot = null;
+
+        BuildAndActivateLayout();
+    }
+
+    /// <summary>
+    /// Build (if needed) and activate the layout tree, wiring framework-level
+    /// subscriptions. Called from <see cref="OnNavigatedTo"/> and from
+    /// <see cref="InvalidateLayout"/>.
+    /// </summary>
+    private void BuildAndActivateLayout()
+    {
+        // Build layout once on first navigation, reactivate on subsequent visits.
         if (_layoutRoot == null)
         {
             _layoutRoot = BuildLayout();
         }
 
-        // Subscribe to layout invalidation events to trigger redraws.
-        // This must be outside the null check because _subscriptions is cleared
-        // in OnNavigatingFrom() — the subscription must be re-created on each visit.
+        // Subscribe to layout invalidation events to trigger redraws. Lives in
+        // _layoutSubscriptions so InvalidateLayout can replace it without
+        // touching user-held entries in _subscriptions.
         if (_layoutRoot is IInvalidatingNode invalidating)
         {
             invalidating.Invalidated
                 .Subscribe(_ => ViewModel.RequestRedraw())
-                .DisposeWith(_subscriptions);
+                .DisposeWith(_layoutSubscriptions);
         }
 
         // Activate the layout tree (resume subscriptions, timers, etc.)
@@ -268,8 +325,9 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     /// </summary>
     public virtual void OnNavigatingFrom()
     {
-        // Clear page-level subscriptions and key bindings
+        // Clear page-level subscriptions, framework layout subscriptions, and key bindings.
         _subscriptions.Clear();
+        _layoutSubscriptions.Clear();
         _keyBindings.Clear();
 
         // Deactivate layout (pause, don't dispose)
@@ -289,6 +347,7 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
     {
         // Final cleanup when page is truly destroyed (not just navigated away)
         _subscriptions.Dispose();
+        _layoutSubscriptions.Dispose();
         _layoutRoot?.Dispose();
         _layoutRoot = null;
     }

--- a/tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs
+++ b/tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs
@@ -5,6 +5,7 @@ using R3;
 using Termina.Input;
 using Termina.Layout;
 using Termina.Reactive;
+using Termina.Rendering;
 
 namespace Termina.Tests.Reactive;
 
@@ -106,7 +107,218 @@ public class ReactivePageInvalidateLayoutTests
         Assert.Equal(42, page.LastObservedValue);
     }
 
-    private class CountingPage : ReactivePage<EmptyViewModel>
+    // ----- Lifecycle guard tests -----
+
+    [Fact]
+    public void InvalidateLayout_BeforeOnNavigatedTo_IsNoOp()
+    {
+        // Calling InvalidateLayout before the first navigation must not
+        // build / activate / subscribe — otherwise the framework's eventual
+        // OnNavigatedTo would double-subscribe and double-activate.
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+
+        page.CallInvalidateLayout();
+        Assert.Equal(0, page.BuildLayoutCallCount);
+
+        page.OnNavigatedTo();
+        Assert.Equal(1, page.BuildLayoutCallCount);
+    }
+
+    [Fact]
+    public void InvalidateLayout_AfterOnNavigatingFrom_IsNoOp()
+    {
+        // Between OnNavigatingFrom and the next OnNavigatedTo the page is
+        // "cached inactive" — _layoutRoot is preserved but deactivated.
+        // InvalidateLayout here must not resurrect the page.
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+        Assert.Equal(1, page.BuildLayoutCallCount);
+
+        page.OnNavigatingFrom();
+
+        page.CallInvalidateLayout();
+        Assert.Equal(1, page.BuildLayoutCallCount); // no rebuild while inactive
+
+        // Next navigation correctly reactivates the cached layout (no new build).
+        page.OnNavigatedTo();
+        Assert.Equal(1, page.BuildLayoutCallCount);
+    }
+
+    [Fact]
+    public void InvalidateLayout_AfterDispose_Throws()
+    {
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+        page.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => page.CallInvalidateLayout());
+    }
+
+    [Fact]
+    public void OnNavigatedTo_AfterDispose_Throws()
+    {
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+        page.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => page.OnNavigatedTo());
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+
+        page.Dispose();
+        page.Dispose(); // must not throw
+    }
+
+    [Fact]
+    public void InvalidateLayout_ReEntrant_Throws()
+    {
+        // BuildLayout calling InvalidateLayout would otherwise stack-overflow
+        // or leave _layoutRoot pointing at a leaked sub-tree.
+        var page = new ReEntrantPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+
+        page.ReEnterOnNextBuild = true;
+
+        Assert.Throws<InvalidOperationException>(() => page.CallInvalidateLayout());
+    }
+
+    [Fact]
+    public void InvalidateLayout_NullBuildLayout_Throws()
+    {
+        var page = new NullBuildPage();
+        page.BindForTest(new EmptyViewModel());
+
+        // First navigation: BuildLayout returns a real node so the page activates.
+        page.ReturnNullNext = false;
+        page.OnNavigatedTo();
+
+        // Now make BuildLayout return null and invalidate — should throw,
+        // leaving the existing layout intact.
+        page.ReturnNullNext = true;
+        var firstRoot = ((Pages.IBindablePage)page).LayoutRoot;
+
+        Assert.Throws<InvalidOperationException>(() => page.CallInvalidateLayout());
+
+        // Layout root unchanged after the failed rebuild — build-then-swap
+        // exception safety.
+        Assert.Same(firstRoot, ((Pages.IBindablePage)page).LayoutRoot);
+    }
+
+    [Fact]
+    public void InvalidateLayout_BuildLayoutThrows_LeavesLayoutIntact()
+    {
+        var page = new ThrowingBuildPage();
+        page.BindForTest(new EmptyViewModel());
+
+        page.ShouldThrowNext = false;
+        page.OnNavigatedTo();
+        var firstRoot = ((Pages.IBindablePage)page).LayoutRoot;
+        Assert.NotNull(firstRoot);
+
+        page.ShouldThrowNext = true;
+        Assert.Throws<InvalidOperationException>(() => page.CallInvalidateLayout());
+
+        // The page is still operational on the old tree.
+        Assert.Same(firstRoot, ((Pages.IBindablePage)page).LayoutRoot);
+
+        // Subsequent successful invalidate works.
+        page.ShouldThrowNext = false;
+        page.CallInvalidateLayout();
+        Assert.NotSame(firstRoot, ((Pages.IBindablePage)page).LayoutRoot);
+    }
+
+    [Fact]
+    public void InvalidateLayout_RequestsRedraw()
+    {
+        var vm = new TrackingViewModel();
+        var page = new CountingPage();
+        page.BindForTest(vm);
+        page.OnNavigatedTo();
+
+        var redrawsBefore = vm.RedrawRequestCount;
+        page.CallInvalidateLayout();
+
+        // The new tree won't necessarily emit Invalidated synchronously, so
+        // InvalidateLayout must explicitly request a redraw — otherwise the
+        // user-visible frame stays stale until the next unrelated reactive
+        // emission.
+        Assert.True(vm.RedrawRequestCount > redrawsBefore,
+            $"Expected RequestRedraw to be called by InvalidateLayout. " +
+            $"Before: {redrawsBefore}, After: {vm.RedrawRequestCount}");
+    }
+
+    // ----- IInvalidatingNode wiring tests -----
+
+    [Fact]
+    public void InvalidateLayout_OldInvalidatingNode_DoesNotDriveRedraws()
+    {
+        // After invalidate, the OLD layout's Invalidated emissions must NOT
+        // trigger RequestRedraw — otherwise _layoutSubscriptions accumulates
+        // dead subscriptions and every event fires N times.
+        var vm = new TrackingViewModel();
+        var page = new InvalidatingNodePage();
+        page.BindForTest(vm);
+        page.OnNavigatedTo();
+
+        var oldNode = page.LastBuilt!;
+        page.CallInvalidateLayout();
+        var redrawsAfterInvalidate = vm.RedrawRequestCount;
+
+        // Fire the old tree's Invalidated — no redraw should follow.
+        oldNode.RaiseInvalidated();
+        Assert.Equal(redrawsAfterInvalidate, vm.RedrawRequestCount);
+    }
+
+    [Fact]
+    public void InvalidateLayout_NewInvalidatingNode_DrivesRedraws()
+    {
+        var vm = new TrackingViewModel();
+        var page = new InvalidatingNodePage();
+        page.BindForTest(vm);
+        page.OnNavigatedTo();
+
+        page.CallInvalidateLayout();
+        var newNode = page.LastBuilt!;
+        var baselineRedraws = vm.RedrawRequestCount;
+
+        // Fire the new tree's Invalidated — exactly one redraw must follow.
+        newNode.RaiseInvalidated();
+        Assert.Equal(baselineRedraws + 1, vm.RedrawRequestCount);
+    }
+
+    [Fact]
+    public void InvalidateLayout_RepeatedCalls_DoNotAccumulateSubscriptions()
+    {
+        // Multiple invalidations in a row must not pile up subscriptions on
+        // the live tree (each invalidate replaces all _layoutSubscriptions).
+        var vm = new TrackingViewModel();
+        var page = new InvalidatingNodePage();
+        page.BindForTest(vm);
+        page.OnNavigatedTo();
+
+        page.CallInvalidateLayout();
+        page.CallInvalidateLayout();
+        page.CallInvalidateLayout();
+
+        var liveNode = page.LastBuilt!;
+        var baseline = vm.RedrawRequestCount;
+        liveNode.RaiseInvalidated();
+
+        Assert.Equal(baseline + 1, vm.RedrawRequestCount);
+    }
+
+    private sealed class CountingPage : ReactivePage<EmptyViewModel>
     {
         public int BuildLayoutCallCount { get; private set; }
 
@@ -116,7 +328,7 @@ public class ReactivePageInvalidateLayoutTests
             return new TextNode("test");
         }
 
-        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void BindForTest(ReactiveViewModel vm) => Bind((EmptyViewModel)vm);
         public void CallInvalidateLayout() => InvalidateLayout();
         public void AddUserSubscription(IDisposable d) => Subscriptions.Add(d);
         public new PageKeyBindings KeyBindings => base.KeyBindings;
@@ -137,7 +349,100 @@ public class ReactivePageInvalidateLayoutTests
         public void CallInvalidateLayout() => InvalidateLayout();
     }
 
+    private sealed class ReEntrantPage : ReactivePage<EmptyViewModel>
+    {
+        public bool ReEnterOnNextBuild { get; set; }
+
+        public override ILayoutNode BuildLayout()
+        {
+            if (ReEnterOnNextBuild)
+            {
+                ReEnterOnNextBuild = false; // arm only once to avoid runaway recursion if guard breaks
+                InvalidateLayout(); // must throw
+            }
+            return new TextNode("test");
+        }
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+    }
+
+    private sealed class NullBuildPage : ReactivePage<EmptyViewModel>
+    {
+        public bool ReturnNullNext { get; set; }
+
+        public override ILayoutNode BuildLayout()
+        {
+            // Returning null is illegal per the contract; deliberately suppress
+            // the non-nullable warning for the test.
+            return ReturnNullNext ? null! : new TextNode("test");
+        }
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+    }
+
+    private sealed class ThrowingBuildPage : ReactivePage<EmptyViewModel>
+    {
+        public bool ShouldThrowNext { get; set; }
+
+        public override ILayoutNode BuildLayout()
+        {
+            if (ShouldThrowNext)
+                throw new InvalidOperationException("simulated build failure");
+            return new TextNode("test");
+        }
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+    }
+
+    private sealed class InvalidatingNodePage : ReactivePage<TrackingViewModel>
+    {
+        public TestInvalidatingNode? LastBuilt { get; private set; }
+
+        public override ILayoutNode BuildLayout()
+        {
+            LastBuilt = new TestInvalidatingNode();
+            return LastBuilt;
+        }
+
+        public void BindForTest(TrackingViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+    }
+
+    private sealed class TestInvalidatingNode : LayoutNode, IInvalidatingNode
+    {
+        private readonly Subject<Unit> _invalidated = new();
+
+        public Observable<Unit> Invalidated => _invalidated;
+
+        public void RaiseInvalidated() => _invalidated.OnNext(Unit.Default);
+
+        public override Size Measure(Size available) => new(0, 0);
+
+        public override void Render(IRenderContext context, Rect bounds)
+        {
+            // No-op for tests.
+        }
+    }
+
     private class EmptyViewModel : ReactiveViewModel
     {
+    }
+
+    private sealed class TrackingViewModel : EmptyViewModel
+    {
+        public int RedrawRequestCount { get; private set; }
+
+        public TrackingViewModel()
+        {
+            WireUp(
+                navigate: _ => { },
+                navigateWithParams: (_, _) => { },
+                shutdown: () => { },
+                requestRedraw: () => RedrawRequestCount++,
+                input: Observable.Empty<IInputEvent>());
+        }
     }
 }

--- a/tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs
+++ b/tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+
+namespace Termina.Tests.Reactive;
+
+/// <summary>
+/// Tests for <see cref="ReactivePage{TViewModel}.InvalidateLayout"/>. The
+/// invalidation hook lets consumers force a <see cref="ReactivePage{T}.BuildLayout"/>
+/// rebuild when external state captured at build time has changed (e.g.,
+/// terminal dimensions baked into a <c>HeightAuto</c> constraint that
+/// needs to track resize).
+/// </summary>
+public class ReactivePageInvalidateLayoutTests
+{
+    [Fact]
+    public void InvalidateLayout_TriggersBuildLayoutAgain()
+    {
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+
+        page.OnNavigatedTo();
+        Assert.Equal(1, page.BuildLayoutCallCount);
+
+        page.CallInvalidateLayout();
+
+        Assert.Equal(2, page.BuildLayoutCallCount);
+    }
+
+    [Fact]
+    public void InvalidateLayout_ReplacesLayoutRoot()
+    {
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+
+        var firstRoot = ((Pages.IBindablePage)page).LayoutRoot;
+        Assert.NotNull(firstRoot);
+
+        page.CallInvalidateLayout();
+
+        var secondRoot = ((Pages.IBindablePage)page).LayoutRoot;
+        Assert.NotNull(secondRoot);
+        Assert.NotSame(firstRoot, secondRoot);
+    }
+
+    [Fact]
+    public void InvalidateLayout_PreservesUserSubscriptions()
+    {
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+
+        // Add a user subscription tracking some external signal.
+        var subject = new Subject<int>();
+        var received = new List<int>();
+        page.AddUserSubscription(subject.Subscribe(received.Add));
+
+        subject.OnNext(1);
+        page.CallInvalidateLayout();
+        subject.OnNext(2);
+
+        // Subscriptions added to the protected Subscriptions disposable are
+        // only cleared by the framework on navigation away or disposal; an
+        // InvalidateLayout must not disturb them.
+        Assert.Equal(new[] { 1, 2 }, received);
+    }
+
+    [Fact]
+    public void InvalidateLayout_PreservesKeyBindings()
+    {
+        var page = new CountingPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+
+        page.KeyBindings.Register(ConsoleKey.Escape, () => { });
+        page.KeyBindings.Register(ConsoleKey.Tab, () => { });
+        Assert.Equal(2, page.KeyBindings.Count);
+
+        page.CallInvalidateLayout();
+
+        Assert.Equal(2, page.KeyBindings.Count);
+    }
+
+    [Fact]
+    public void InvalidateLayout_SeesUpdatedExternalStateInBuildLayout()
+    {
+        // Concrete consumer scenario: BuildLayout's output reflects a value
+        // that changes between calls (e.g., terminal width). After
+        // InvalidateLayout, BuildLayout's next invocation must see the
+        // current value, not the captured-at-first-render value.
+        var page = new ExternalStatePage();
+        page.BindForTest(new EmptyViewModel());
+
+        page.ExternalValue = 10;
+        page.OnNavigatedTo();
+        Assert.Equal(10, page.LastObservedValue);
+
+        page.ExternalValue = 42;
+        page.CallInvalidateLayout();
+
+        Assert.Equal(42, page.LastObservedValue);
+    }
+
+    private class CountingPage : ReactivePage<EmptyViewModel>
+    {
+        public int BuildLayoutCallCount { get; private set; }
+
+        public override ILayoutNode BuildLayout()
+        {
+            BuildLayoutCallCount++;
+            return new TextNode("test");
+        }
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+        public void AddUserSubscription(IDisposable d) => Subscriptions.Add(d);
+        public new PageKeyBindings KeyBindings => base.KeyBindings;
+    }
+
+    private sealed class ExternalStatePage : ReactivePage<EmptyViewModel>
+    {
+        public int ExternalValue { get; set; }
+        public int LastObservedValue { get; private set; }
+
+        public override ILayoutNode BuildLayout()
+        {
+            LastObservedValue = ExternalValue;
+            return new TextNode(ExternalValue.ToString());
+        }
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+    }
+
+    private class EmptyViewModel : ReactiveViewModel
+    {
+    }
+}

--- a/tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs
+++ b/tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs
@@ -318,6 +318,79 @@ public class ReactivePageInvalidateLayoutTests
         Assert.Equal(baseline + 1, vm.RedrawRequestCount);
     }
 
+    [Fact]
+    public void InvalidateLayout_AbandonedWrapper_DoesNotReceiveReusedChildInvalidation()
+    {
+        var page = new ReusedChildInPanelPage();
+        page.BindForTest(new EmptyViewModel());
+        page.OnNavigatedTo();
+
+        var oldRoot = Assert.IsType<PanelNode>(((Pages.IBindablePage)page).LayoutRoot);
+        var oldRootInvalidations = 0;
+        oldRoot.Invalidated.Subscribe(_ => oldRootInvalidations++);
+
+        page.CallInvalidateLayout();
+
+        var newRoot = Assert.IsType<PanelNode>(((Pages.IBindablePage)page).LayoutRoot);
+        var newRootInvalidations = 0;
+        newRoot.Invalidated.Subscribe(_ => newRootInvalidations++);
+
+        page.SharedChild.RaiseInvalidated();
+
+        Assert.Equal(0, oldRootInvalidations);
+        Assert.Equal(1, newRootInvalidations);
+    }
+
+    [Fact]
+    public void InvalidateLayout_ReusedFocusedNode_RemainsActive()
+    {
+        using var focusManager = new FocusManager();
+
+        var page = new ReusedInputPage();
+        page.BindForTest(new EmptyViewModel());
+        page.WireFocusForTest(focusManager);
+        page.OnNavigatedTo();
+
+        focusManager.SetFocus(page.Input);
+        Assert.True(page.Input.IsAnimating);
+
+        page.CallInvalidateLayout();
+
+        Assert.True(page.Input.IsAnimating);
+        Assert.True(page.Input.HasFocus);
+
+        var handled = focusManager.RouteInput(new ConsoleKeyInfo('x', (ConsoleKey)0, false, false, false));
+
+        Assert.True(handled);
+        Assert.Equal("x", page.Input.Text);
+    }
+
+    [Fact]
+    public void InvalidateLayout_ReplacedFocusedNode_ClearsManualFocus()
+    {
+        using var focusManager = new FocusManager();
+
+        var page = new ReplacingInputPage();
+        page.BindForTest(new EmptyViewModel());
+        page.WireFocusForTest(focusManager);
+        page.OnNavigatedTo();
+
+        var firstInput = page.CurrentInput;
+        focusManager.SetFocus(firstInput);
+
+        page.CallInvalidateLayout();
+
+        var secondInput = page.CurrentInput;
+        Assert.NotSame(firstInput, secondInput);
+        Assert.Null(focusManager.CurrentFocus);
+
+        var handled = focusManager.RouteInput(new ConsoleKeyInfo('x', (ConsoleKey)0, false, false, false));
+
+        Assert.False(handled);
+        Assert.Equal(string.Empty, firstInput.Text);
+        Assert.Equal(string.Empty, secondInput.Text);
+    }
+
     private sealed class CountingPage : ReactivePage<EmptyViewModel>
     {
         public int BuildLayoutCallCount { get; private set; }
@@ -409,6 +482,42 @@ public class ReactivePageInvalidateLayoutTests
 
         public void BindForTest(TrackingViewModel vm) => Bind(vm);
         public void CallInvalidateLayout() => InvalidateLayout();
+    }
+
+    private sealed class ReusedChildInPanelPage : ReactivePage<EmptyViewModel>
+    {
+        public TestInvalidatingNode SharedChild { get; } = new();
+
+        public override ILayoutNode BuildLayout() => new PanelNode().WithContent(SharedChild);
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+    }
+
+    private sealed class ReusedInputPage : ReactivePage<EmptyViewModel>
+    {
+        public TextInputNode Input { get; } = new();
+
+        public override ILayoutNode BuildLayout() => new PanelNode().WithContent(Input);
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+        public void WireFocusForTest(IFocusManager focusManager) => ((Pages.IBindablePage)this).WireUpFocus(focusManager);
+    }
+
+    private sealed class ReplacingInputPage : ReactivePage<EmptyViewModel>
+    {
+        public TextInputNode CurrentInput { get; private set; } = null!;
+
+        public override ILayoutNode BuildLayout()
+        {
+            CurrentInput = new TextInputNode();
+            return CurrentInput;
+        }
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void CallInvalidateLayout() => InvalidateLayout();
+        public void WireFocusForTest(IFocusManager focusManager) => ((Pages.IBindablePage)this).WireUpFocus(focusManager);
     }
 
     private sealed class TestInvalidatingNode : LayoutNode, IInvalidatingNode


### PR DESCRIPTION
## Problem

`ReactivePage<TViewModel>.OnNavigatedTo` builds and caches `_layoutRoot` exactly once and never re-runs `BuildLayout()`. Any value captured *inside* `BuildLayout()` and baked into a layout-node field (like `HeightAuto`'s `SizeConstraint.Auto` record) is permanently frozen at first-navigation time. Consumers have no way to trigger a rebuild — terminal resize handlers can't force the layout to re-evaluate height/width-dependent constraints.

## Fix

Add `protected void InvalidateLayout()` to `ReactivePage<TViewModel>`. Discards the cached `_layoutRoot` and rebuilds via `BuildLayout()`, preserving everything the user cares about (`Subscriptions`, `KeyBindings`, and user focus when the target node survives the rebuild).

Refactor: move the framework's `IInvalidatingNode.Invalidated → RequestRedraw` subscription to a dedicated `_layoutSubscriptions` `CompositeDisposable` so `InvalidateLayout` can tear it down without touching user code.

## Consumer usage

```csharp
// In OnBound, post #219:
ViewModel.Input.OfType<IInputEvent, ResizeEvent>()
    .Subscribe(_ => InvalidateLayout())
    .DisposeWith(Subscriptions);
```

## Hardened lifecycle contract (post review)

Initial commit was functional but fragile. Code review surfaced lifecycle / exception-safety / UX gaps that this PR now addresses:

**Lifecycle state (`_isActivated` / `_isDisposed` / `_isRebuilding` flags):**

- **Throws `ObjectDisposedException`** if `InvalidateLayout` or `OnNavigatedTo` is called after `Dispose`. Verified R3 `CompositeDisposable.Clear/Add` silently no-op on a disposed bag, so without the guard a late `InvalidateLayout` would build a fresh tree, `OnActivate` every node (starting timers/animations), then leak the whole tree.
- **Throws `InvalidOperationException`** on re-entrant `InvalidateLayout` (from inside `BuildLayout` or a node lifecycle callback) — prevents unbounded recursion and divergent state.
- **No-ops when inactive** (before first `OnNavigatedTo`, or between `OnNavigatingFrom` and the next `OnNavigatedTo`) — prevents resurrecting an inactive page and the resulting double-subscribe + double-activate on the next navigation.
- **Idempotent `OnNavigatedTo`** — skips wiring path when already active so a user override calling `base.OnNavigatedTo()` twice doesn't pile up duplicate `_layoutSubscriptions`.
- **Idempotent `Dispose`**.

**Exception-safe build-then-swap:**

- Builds the new tree FIRST, then `OnActivate`'s it, then atomically swaps `_layoutRoot`, then deactivates the old. If `BuildLayout` throws, the page keeps its existing layout — no half-state with cleared subscriptions and a null root.
- `BuildLayout` returning `null` throws `InvalidOperationException` with a clear message instead of silently leaving `_layoutRoot` null and rendering blank.

**Focus preservation:**

- No longer unconditionally re-applies `FocusPolicy`. If the user has Tab'd to a focusable AND that node still exists in the new tree (common case when `BuildLayout` reuses page-field nodes), focus is preserved. Only when the focused node is orphaned does the policy default re-apply.

**Redraw trigger:**

- `InvalidateLayout` explicitly calls `ViewModel.RequestRedraw()` at the end so a resize handler that only invalidates produces a visible change.

## What's documented (not enforced)

- **Orphan-container leak**: `ContainerNode.Dispose()` recurses into children, so we can't Dispose the old tree without destroying user-held leaves (e.g., a `StreamingTextNode` page field). The old container's `_childInvalidationSubscriptions` to those leaves stay live until page Dispose. Repeated invalidate accumulates dead containers. Documented in the XML remarks; consumers using heavy reusable nodes should prefer reactive bindings inside `BuildLayout` over frequent invalidate.
- **User `Subscriptions` targeting `BuildLayout`-created nodes**: those subscriptions keep firing into orphaned nodes after invalidate. Documented; consumers should bind to page-field nodes (initialized in `OnBound` and reused) or re-subscribe at the start of each `BuildLayout`.
- **Non-`LayoutNode` `ILayoutNode` wrappers**: not deactivated by the pattern match (pre-existing behavior in `OnNavigatingFrom`/`Dispose`). Documented in remarks.
- **Thread affinity**: `InvalidateLayout` must be called on the same dispatcher thread that drives navigation/rendering.

## Tests

`tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs` — 17 tests total (5 original + 12 new):

| Test | Covers |
|---|---|
| `TriggersBuildLayoutAgain`, `ReplacesLayoutRoot` | Basic rebuild |
| `PreservesUserSubscriptions`, `PreservesKeyBindings` | User state preserved |
| `SeesUpdatedExternalStateInBuildLayout` | Consumer-shaped use case |
| `BeforeOnNavigatedTo_IsNoOp` | Inactive-before-first-nav guard |
| `AfterOnNavigatingFrom_IsNoOp` | Inactive-between-navs guard |
| `AfterDispose_Throws`, `OnNavigatedTo_AfterDispose_Throws` | Disposed guard |
| `Dispose_IsIdempotent` | Idempotent dispose |
| `ReEntrant_Throws` | Re-entrancy guard (page re-enters from `BuildLayout`) |
| `NullBuildLayout_Throws` | Null contract enforcement |
| `BuildLayoutThrows_LeavesLayoutIntact` | Build-then-swap rollback |
| `RequestsRedraw` | Explicit redraw trigger |
| `OldInvalidatingNode_DoesNotDriveRedraws` | Old subscription disposed |
| `NewInvalidatingNode_DrivesRedraws` | New subscription wired |
| `RepeatedCalls_DoNotAccumulateSubscriptions` | No subscription pile-up |

The last three close the gap the original tests had — all originals used `TextNode` which is NOT `IInvalidatingNode`, so the entire subscription-leak surface was untested.

## Test plan

- [x] `dotnet test tests/Termina.Tests` — 1116/1116 pass (17 InvalidateLayout + 1099 existing).
- [x] No behavior change for existing pages that don't call `InvalidateLayout` or override the lifecycle methods.
- [x] No new public surface beyond a single `protected` method (`InvalidateLayout`).