### PR TITLE
Fix RebuildBuffer block segment newline bug

### DIFF
--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -372,8 +372,15 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
                     _buffer.Append(s.Segment);
                     break;
                 case TrackedElement t:
-                    // Handle block segments in rebuild
-                    EnsureBlockNewLine(t.Segment);
+                    // Block segments always start on a new line if current line has content.
+                    // We check after appending the previous element (not before), because
+                    // after Clear() the buffer is empty and EnsureBlockNewLine would skip
+                    // the newline incorrectly.
+                    if (t.Segment is BlockSegment && _buffer.HasContentOnCurrentLine)
+                    {
+                        _buffer.AppendLine(string.Empty);
+                    }
+
                     var inner = UnwrapBlock(t.Segment);
                     _buffer.Append(inner.GetCurrentSegment());
                     break;


### PR DESCRIPTION
## Problem

`RebuildBuffer()` clears the buffer then calls `EnsureBlockNewLine()` to check if a block segment needs a preceding newline. But since the buffer was just cleared, `HasContentOnCurrentLine` returns false and no newline gets inserted — so both 'Static line' and the spinner end up on the same buffer line, causing `GetAllStyledLines()[1]` to crash.

## Fix

Moved the block-segment newline check inline in `RebuildBuffer()` and check buffer state after the previous element has been appended, not before.