### PR TITLE
Harden NotifyChanged against post-Dispose race

### DIFF
--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -369,11 +369,12 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
                 return;
 
             RebuildBuffer();
-            // Fire under the lock: _disposed is guaranteed false here, so _invalidated
-            // is still alive. Subscribers should be lightweight (queue a render) — if a
-            // subscriber re-enters one of this node's public methods on the same thread,
-            // the lock is reentrant and behaves correctly.
-            _invalidated.OnNext(Unit.Default);
+            // Route through NotifyChanged so the animation path inherits the same
+            // disposal-race hardening (and so any future cross-cutting hooks at
+            // NotifyChanged also see animation invalidations). NotifyChanged's
+            // disposed re-check is redundant here (we just checked it 3 lines up
+            // while holding the lock) but is cheap.
+            NotifyChanged();
         }
     }
 
@@ -540,7 +541,23 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
 
     private void NotifyChanged()
     {
-        _invalidated.OnNext(Unit.Default);
+        // Fast bail when the node has been disposed. Public mutators release _contentLock
+        // before calling NotifyChanged, so Dispose() can race with us — between the
+        // _disposed-write inside Dispose's lock and our OnNext below, Dispose can also
+        // run _invalidated.OnCompleted()/Dispose() (which happen outside the lock).
+        // Without this guard, R3.Subject<T>.OnNext throws ObjectDisposedException on a
+        // disposed Subject (verified empirically). The try/catch handles the narrow
+        // window where _disposed reads as false but the Subject is disposed before
+        // OnNext returns — also harmless because a disposed node has no live observers.
+        if (_disposed) return;
+        try
+        {
+            _invalidated.OnNext(Unit.Default);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Lost the disposal race — expected.
+        }
     }
 
     /// <summary>

--- a/tests/Termina.Tests/Layout/StreamingTextNodeThreadSafetyTests.cs
+++ b/tests/Termina.Tests/Layout/StreamingTextNodeThreadSafetyTests.cs
@@ -287,6 +287,79 @@ public class StreamingTextNodeThreadSafetyTests
     }
 
     /// <summary>
+    /// Public mutators must not throw when called after <see cref="StreamingTextNode.Dispose"/>.
+    /// Pre-fix, every mutator ended with <c>NotifyChanged()</c> → <c>_invalidated.OnNext(...)</c>
+    /// with no disposed check, which threw <see cref="ObjectDisposedException"/> from R3's
+    /// <c>Subject&lt;T&gt;.OnNext</c> on the disposed Subject. The race window: a mutator on
+    /// thread A releases <c>_contentLock</c> before calling NotifyChanged; thread B's
+    /// <c>Dispose()</c> can run the OnCompleted/Dispose on <c>_invalidated</c> in that gap.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(PublicMutatorActions))]
+    public void PublicMutator_AfterDispose_DoesNotThrow(string name, Action<StreamingTextNode> mutate)
+    {
+        _ = name; // theory parameter for clearer test names
+        var node = StreamingTextNode.Create();
+        node.Dispose();
+
+        var ex = Record.Exception(() => mutate(node));
+        Assert.Null(ex);
+    }
+
+    public static IEnumerable<object[]> PublicMutatorActions()
+    {
+        yield return ["Append(string)", new Action<StreamingTextNode>(n => n.Append("x"))];
+        yield return ["Append(string, color)", new Action<StreamingTextNode>(n => n.Append("x", Color.Red))];
+        yield return ["Append(StyledSegment)", new Action<StreamingTextNode>(n => n.Append(new StyledSegment("x", TextStyle.Default)))];
+        yield return ["AppendLine(string)", new Action<StreamingTextNode>(n => n.AppendLine("x"))];
+        yield return ["AppendLine(string, color)", new Action<StreamingTextNode>(n => n.AppendLine("x", Color.Red))];
+        yield return ["AppendTracked", new Action<StreamingTextNode>(n => n.AppendTracked(new SegmentId(42), new StaticTextSegment("x", TextStyle.Default)))];
+        yield return ["Remove", new Action<StreamingTextNode>(n => n.Remove(new SegmentId(42)))];
+        yield return ["Replace", new Action<StreamingTextNode>(n => n.Replace(new SegmentId(42), new StaticTextSegment("y", TextStyle.Default)))];
+        yield return ["Clear", new Action<StreamingTextNode>(n => n.Clear())];
+        yield return ["ScrollUp", new Action<StreamingTextNode>(n => n.ScrollUp())];
+        yield return ["ScrollDown", new Action<StreamingTextNode>(n => n.ScrollDown())];
+        yield return ["ScrollToBottom", new Action<StreamingTextNode>(n => n.ScrollToBottom())];
+    }
+
+    /// <summary>
+    /// Stress test: <c>StreamingTextNode.Append</c> hammered on a background thread
+    /// while the main thread disposes the node. The fix in <c>NotifyChanged</c> must
+    /// prevent <see cref="ObjectDisposedException"/> from leaking out of the in-flight
+    /// mutator after Dispose() has completed <c>_invalidated.Dispose()</c>.
+    /// </summary>
+    [Fact]
+    public async Task Append_ConcurrentWithDispose_DoesNotThrow()
+    {
+        var node = StreamingTextNode.Create();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        Exception? appenderException = null;
+
+        var appender = Task.Run(() =>
+        {
+            try
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    node.Append("x");
+                }
+            }
+            catch (Exception ex)
+            {
+                appenderException = ex;
+            }
+        });
+
+        // Give the appender a head start, then dispose mid-flight to exercise the race.
+        await Task.Delay(50);
+        node.Dispose();
+        await appender;
+
+        Assert.Null(appenderException);
+    }
+
+    /// <summary>
     /// Test-only <see cref="IAnimatedTextSegment"/> whose invalidation is driven by
     /// the test (not a timer), so race tests can fire on a background thread with
     /// no scheduler dependency.


### PR DESCRIPTION
## Summary
Third and final follow-up from the PR #225 self-review. Closes the latent pre-existing race the review flagged — `NotifyChanged()` was not protected against the node being disposed mid-call.

## The race
Every public mutator (`Append`, `AppendLine`, `AppendTracked`, `Remove`, `Replace`, `Clear`, `ScrollUp`/`Down`/`ToBottom`) ends with `NotifyChanged()` → `_invalidated.OnNext(Unit.Default)`. The mutator releases `_contentLock` before calling NotifyChanged. `Dispose()` runs `_invalidated.OnCompleted()` and `_invalidated.Dispose()` **outside** the lock (lines 791-792). So:

1. Thread A: \`Append\` acquires lock, mutates, **releases lock**.
2. Thread B: \`Dispose\` acquires lock, sets \`_disposed=true\`, releases lock.
3. Thread B: \`_invalidated.OnCompleted()\` + \`_invalidated.Dispose()\`.
4. Thread A: \`NotifyChanged\` → \`_invalidated.OnNext(Unit.Default)\` → **ObjectDisposedException** from \`R3.Subject<T>.OnNext\` (empirically verified).

The same shape applies to a deliberate use-after-dispose call.

## Fix
\`\`\`csharp
private void NotifyChanged()
{
    if (_disposed) return;
    try
    {
        _invalidated.OnNext(Unit.Default);
    }
    catch (ObjectDisposedException)
    {
        // Lost the disposal race — expected.
    }
}
\`\`\`

Also routes \`OnAnimationInvalidated\`'s notification through \`NotifyChanged\` (instead of inlining \`_invalidated.OnNext\`) so the animation path inherits the same hardening AND so any future cross-cutting hook at NotifyChanged covers both paths. Resolves the \"animation path bypasses NotifyChanged\" divergence the earlier review surfaced (#7).

## Verification
- **Negative test**: temporarily replaced the guard with bare \`_invalidated.OnNext(Unit.Default)\` and ran the 12-case parameterized suite. **11 of 12 cases failed** with \`ObjectDisposedException\` (the 2 that passed are \`Remove\`/\`Replace\` with a non-existent SegmentId, which return \`false\` before reaching NotifyChanged). Restored guard → all 12 pass.
- **Concurrent stress test**: \`Append\` hammered on a background thread for 250ms wall-clock while the main thread disposes mid-flight — no exception.

## Tests added
- \`PublicMutator_AfterDispose_DoesNotThrow\` (12 parameterized cases, one per public mutator)
- \`Append_ConcurrentWithDispose_DoesNotThrow\` (bounded stress test)

## Test plan
- [x] Negative test confirms guard catches the bug (11/12 cases fail without it)
- [x] Full suite 1138/1138 pass with guard restored
- [x] Streaming thread-safety tests (19) pass in ~1s — no perf regression
- [ ] CI green on PR

## Performance impact
\`NotifyChanged\` adds one volatile bool read on the hot path. The try/catch block adds no runtime cost when no exception is thrown (try is free; catch only allocates on the disposal-race miss). Negligible.