### PR TITLE
Prepare release v0.10.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,31 +10,25 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.10.0</VersionPrefix>
-    <PackageReleaseNotes>**New Features**:
-- **`ReactivePage.InvalidateLayout()` for runtime layout rebuilds** ([#220](https://github.com/Aaronontheweb/termina/pull/220))
-  - New `protected void InvalidateLayout()` method on `ReactivePage&lt;TViewModel&gt;` that discards the cached layout tree and rebuilds via `BuildLayout()`
-  - Solves the problem of layout values "baked in" at first navigation time (e.g. `SizeConstraint.Auto` records) being permanently frozen — consumers can now trigger a full rebuild when external state changes (terminal resize, etc.)
-  - Preserves user subscriptions, key bindings, and focus when the target node survives the rebuild
-  - Exception-safe: builds the new tree first, then atomically swaps — if `BuildLayout` throws, the existing layout is left intact
-  - Includes 17 comprehensive lifecycle tests covering disposed-guard, re-entrancy, idempotent dispose, and subscription cleanup
+    <VersionPrefix>0.10.1</VersionPrefix>
+    <PackageReleaseNotes>**Bug Fixes** — `StreamingTextNode` thread-safety and disposal hardening:
 
-- **Alternate-scroll wheel mode with Kitty keyboard protocol disambiguation** ([#215](https://github.com/Aaronontheweb/termina/pull/215))
-  - Replaces SGR mouse tracking with `?1007h` alternate-scroll mode for wheel events, combined with Kitty keyboard protocol (`report_all_keys`) for true key disambiguation
-  - On Ghostty, kitty, WezTerm, foot, and iTerm2 ≥ 3.5: scroll-wheel scrolls `IScrollable` components, arrow keys act as arrows even in always-focused text inputs, and native text selection (click-drag) still works
-  - New opt-in `TERMINA_UNIX_RAW_INPUT=1` environment variable enables raw Unix stdin for the protocol to work
-  - Dual Ctrl+C quit pattern replaces per-demo Ctrl+Q convention
+- **`RebuildBuffer` correctly inserts a newline before block segments after `Clear()`** ([#224](https://github.com/Aaronontheweb/termina/pull/224))
+  - Pre-fix, after `Clear()` reset `HasContentOnCurrentLine`, the first re-added block segment skipped its leading newline during rebuild, causing block content to collide with prior content on the same line.
+  - Moves the block-newline check inline, evaluated *after* prior elements are re-appended so the buffer state reflects the in-progress reconstruction.
 
-- **Harden alternate-scroll rollout and document runtime input modes** ([#217](https://github.com/Aaronontheweb/termina/pull/217))
-  - Restored legacy mouse tracking as the framework default — alternate-scroll is now opt-in via explicit app configuration
-  - Moved Kitty keyboard negotiation into `TerminaApplication` with safer raw-input fallback on non-interactive consoles
-  - Added comprehensive website docs covering runtime input modes, raw input, alternate-scroll, Kitty flags, and tmux passthrough
+- **Animation callbacks now hold `_contentLock`** ([#225](https://github.com/Aaronontheweb/termina/pull/225))
+  - Animation `Invalidated` callbacks from `IAnimatedTextSegment` (e.g. `SpinnerSegment` on the R3 timer thread) previously called `RebuildBuffer` without locking, racing with public mutators (`Append`/`AppendTracked`/`Remove`/`Replace`/`Clear`/`Dispose`) that all hold the lock. Symptoms ranged from `InvalidOperationException` ("Collection was modified") on the `foreach` inside `RebuildBuffer` to torn buffer state and `ObjectDisposedException` if `Dispose()` ran while a callback was queued behind the lock.
+  - Funnels both callback sites through a single `OnAnimationInvalidated()` helper that takes `_contentLock`, checks a new volatile `_disposed` flag, then runs `RebuildBuffer` + notification safely.
+  - `Dispose()` is now idempotent and sets `_disposed = true` first so in-flight callbacks bail before touching `_invalidated`.
 
-**Bug Fixes**:
-- **`ResizeEvent` now forwards to `ViewModel.Input` observable** ([#219](https://github.com/Aaronontheweb/termina/pull/219))
-  - Fixed `TerminaApplication.ProcessEvent` swallowing `ResizeEvent` via early `return;` — the event now correctly falls through to `_inputSubject.OnNext(inputEvent)`
-  - Pages and ViewModels subscribing via `ViewModel.Input.OfType&lt;ResizeEvent&gt;()` now receive resize notifications as intended
-  - Enables consumers to recompute width- or height-sensitive layout on terminal resize
+- **`NotifyChanged` hardened against post-Dispose race** ([#227](https://github.com/Aaronontheweb/termina/pull/227))
+  - Every public mutator released `_contentLock` before calling `NotifyChanged()`, so a racing `Dispose()` could complete `_invalidated.OnCompleted()/Dispose()` in the gap and the mutator's `OnNext` would throw `ObjectDisposedException`. Same shape applied to deliberate use-after-dispose calls.
+  - `NotifyChanged` now reads `_disposed` and try/catches `ObjectDisposedException`. `OnAnimationInvalidated` routes through `NotifyChanged` so the animation path inherits the same hardening.
+
+**Test improvements** ([#226](https://github.com/Aaronontheweb/termina/pull/226)):
+- Restructured the `Replace` thread-safety stress test so the ticker always fires on a live, permanently-tracked spinner (was mostly hitting an already-disposed segment after each `Replace`).
+- Added a reflection-based test that directly exercises the `_disposed` belt-and-suspenders guard inside `OnAnimationInvalidated` (the original `AfterDispose` test was passing for the wrong reason because subscription teardown was hiding the in-flight-callback path).
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,27 @@
+#### 0.10.1 May 24th 2026 ####
+
+**Bug Fixes** — `StreamingTextNode` thread-safety and disposal hardening:
+
+- **`RebuildBuffer` correctly inserts a newline before block segments after `Clear()`** ([#224](https://github.com/Aaronontheweb/termina/pull/224))
+  - Pre-fix, after `Clear()` reset `HasContentOnCurrentLine`, the first re-added block segment skipped its leading newline during rebuild, causing block content to collide with prior content on the same line.
+  - Moves the block-newline check inline, evaluated *after* prior elements are re-appended so the buffer state reflects the in-progress reconstruction.
+
+- **Animation callbacks now hold `_contentLock`** ([#225](https://github.com/Aaronontheweb/termina/pull/225))
+  - Animation `Invalidated` callbacks from `IAnimatedTextSegment` (e.g. `SpinnerSegment` on the R3 timer thread) previously called `RebuildBuffer` without locking, racing with public mutators (`Append`/`AppendTracked`/`Remove`/`Replace`/`Clear`/`Dispose`) that all hold the lock. Symptoms ranged from `InvalidOperationException` ("Collection was modified") on the `foreach` inside `RebuildBuffer` to torn buffer state and `ObjectDisposedException` if `Dispose()` ran while a callback was queued behind the lock.
+  - Funnels both callback sites through a single `OnAnimationInvalidated()` helper that takes `_contentLock`, checks a new volatile `_disposed` flag, then runs `RebuildBuffer` + notification safely.
+  - `Dispose()` is now idempotent and sets `_disposed = true` first so in-flight callbacks bail before touching `_invalidated`.
+
+- **`NotifyChanged` hardened against post-Dispose race** ([#227](https://github.com/Aaronontheweb/termina/pull/227))
+  - Every public mutator released `_contentLock` before calling `NotifyChanged()`, so a racing `Dispose()` could complete `_invalidated.OnCompleted()/Dispose()` in the gap and the mutator's `OnNext` would throw `ObjectDisposedException`. Same shape applied to deliberate use-after-dispose calls.
+  - `NotifyChanged` now reads `_disposed` and try/catches `ObjectDisposedException`. `OnAnimationInvalidated` routes through `NotifyChanged` so the animation path inherits the same hardening.
+
+**Test improvements** ([#226](https://github.com/Aaronontheweb/termina/pull/226)):
+
+- Restructured the `Replace` thread-safety stress test so the ticker always fires on a live, permanently-tracked spinner (was mostly hitting an already-disposed segment after each `Replace`).
+- Added a reflection-based test that directly exercises the `_disposed` belt-and-suspenders guard inside `OnAnimationInvalidated` (the original `AfterDispose` test was passing for the wrong reason because subscription teardown was hiding the in-flight-callback path).
+
+---
+
 #### 0.10.0 May 24th 2026 ####
 
 **New Features**:


### PR DESCRIPTION
## Summary

Patch release. Four PRs since 0.10.0, all hardening `StreamingTextNode` thread-safety:

- #224 — `RebuildBuffer` block-segment newline fix after `Clear()`
- #225 — Animation callbacks now hold `_contentLock`; `Dispose()` idempotent; `_disposed` guard
- #226 — Test-quality fixes (restructured Replace stress test; reflection-based `_disposed` flag test)
- #227 — `NotifyChanged` hardened against post-Dispose race

## Changes

- Bumped `VersionPrefix` to `0.10.1` in `Directory.Build.props`
- Refreshed `PackageReleaseNotes` for the new version
- Prepended 0.10.1 section to `RELEASE_NOTES.md`

Verified `AssemblyInformationalVersion: 0.10.1+<sha>` is stamped into the build output.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings
- [x] Assembly version metadata reflects 0.10.1
- [ ] CI green on PR
- [ ] After merge: tag `0.10.1` (no `v` prefix per repo convention) and publish GitHub release named `Termina 0.10.1`