### PR TITLE
fix: flush unrecognized CSI tilde sequences instead of buffering indefinitely

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -362,6 +362,13 @@ internal sealed class EscapeSequenceParser
         if (seq.Length <= pasteStart.Length && pasteStart.StartsWith(seq, StringComparison.Ordinal))
             return true;
 
+        // Complete but unrecognized CSI tilde-terminated sequences (e.g. [5~ for PgUp,
+        // [6~ for PgDn, [3~ for Delete, [1~ for Home, [4~ for End). These are not
+        // handled by our parser — flush them as raw KeyPressed events so applications
+        // can process them rather than keeping the parser stuck in InBracketSequence.
+        if (seq.Length >= 3 && seq[^1] == '~')
+            return false;
+
         // Could be a CSI u sequence "[keycode;modifiersu" — digits, semicolons, colons, up to ~32 chars
         if (seq.Length >= 2 && seq.Length <= 32 && (char.IsDigit(seq[1]) || seq[1] == ';' || seq[1] == ':'))
             return true;

--- a/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
@@ -465,4 +465,80 @@ public class EscapeSequenceParserTests
         var single = Assert.Single(events);
         Assert.Equal('a', ((KeyPressed)single).KeyInfo.KeyChar);
     }
+
+    // --- Unrecognized CSI tilde sequences are flushed, not buffered forever ---
+
+    [Theory]
+    [InlineData("[1~")] // Home
+    [InlineData("[3~")] // Delete
+    [InlineData("[4~")] // End
+    [InlineData("[5~")] // PgUp
+    [InlineData("[6~")] // PgDn
+    public void UnrecognizedCsiTilde_FlushesAsRawKeys_AndUnsticksParser(string seq)
+    {
+        // Regression: these complete-but-unrecognized tilde sequences have a digit second
+        // char, so the CSI-u length check used to return true and leave the parser stuck in
+        // InBracketSequence — silently swallowing all subsequent input.
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, seq));
+
+        // Parser must not remain stuck buffering the bracket sequence.
+        Assert.False(parser.IsBufferingEscape);
+
+        // Flushed as raw KeyPressed events (ESC + each buffered char) rather than consumed.
+        Assert.NotEmpty(events);
+        Assert.All(events, e => Assert.IsType<KeyPressed>(e));
+    }
+
+    [Fact]
+    public void MouseWheel_AfterUnrecognizedCsiTilde_StillParses()
+    {
+        // The reported symptom: a complete-but-unrecognized [5~ (PgUp) left the parser stuck,
+        // so subsequent mouse wheel events were swallowed. After the flush fix, wheel works.
+        var parser = new EscapeSequenceParser();
+
+        parser.Process(EscKey());
+        FeedString(parser, "[5~");
+        Assert.False(parser.IsBufferingEscape);
+
+        var events = FeedSequence(parser, SgrMouseSequence(64, 5, 10));
+        var scroll = Assert.Single(events);
+        Assert.Equal(+1, Assert.IsType<MouseScrollEvent>(scroll).Delta);
+    }
+
+    [Fact]
+    public void ModifiedCsiTilde_FlushesAndUnsticksParser()
+    {
+        // e.g. [5;3~ (PgUp with a modifier) is also unrecognized and must not get stuck.
+        var parser = new EscapeSequenceParser();
+
+        parser.Process(EscKey());
+        FeedString(parser, "[5;3~");
+        Assert.False(parser.IsBufferingEscape);
+
+        // A regular key afterward is processed normally.
+        var events = parser.Process(Key('a', ConsoleKey.A));
+        Assert.Equal('a', ((KeyPressed)Assert.Single(events)).KeyInfo.KeyChar);
+    }
+
+    [Fact]
+    public void BracketedPaste_StillWorks_WithTildeFlushGuard()
+    {
+        // Guards against the tilde-flush returning false for the paste start "[200~" or end
+        // "[201~": paste must still round-trip into a single PasteEvent.
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[200~"));
+        events.AddRange(FeedString(parser, "pasted!"));
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[201~"));
+
+        var pe = Assert.IsType<PasteEvent>(Assert.Single(events));
+        Assert.Equal("pasted!", pe.Content);
+    }
 }


### PR DESCRIPTION
## Problem

`EscapeSequenceParser.CouldLeadToRecognizedSequence` incorrectly returns `true` for complete but unrecognized CSI tilde-terminated sequences like `[5~` (PgUp), `[6~` (PgDn), `[3~` (Delete), `[1~` (Home), `[4~` (End).

The second character (`5`) is a digit, so the CSI-u digit/semicolon/colon check at line 366 returns `true` — the parser stays stuck in `InBracketSequence`, silently swallowing **all subsequent input** (including mouse wheel events).

`CheckEscapeTimeout` only flushes the `AfterEscape` state, not `InBracketSequence`. The parser escapes the stuck state only after 32+ buffered characters are accumulated, since every subsequent byte also matches the digit check.

## Fix

Adds a guard before the CSI-u digit check: if the sequence is a complete CSI form ending with `~` and has length >= 3, it cannot become any recognized pattern — return `false` to flush the sequence as raw `KeyPressed` events so applications can process them.

## Testing

- 1138/1138 existing Termina unit tests pass
- Verified in downstream TUI application: PgUp/PgDn scroll output, mouse wheel scrolls output, Up/Down navigates command history