### PR TITLE
Fix TextInputNode placeholder not respecting configured background color

### DIFF
--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -101,6 +101,13 @@ public sealed class TextInputNode : TextInputBaseNode
 
         var inputContext = context.CreateSubContext(bounds);
 
+        if (Background.HasValue)
+        {
+            inputContext.SetBackground(Background.Value);
+            inputContext.Fill(0, 0, bounds.Width, bounds.Height, ' ');
+            inputContext.ResetColors();
+        }
+
         var prefix = CommittedDisplayPrefix;
         var prefixWidth = prefix.Length;
         var activeText = _text;
@@ -116,6 +123,8 @@ public sealed class TextInputNode : TextInputBaseNode
         if (fullDisplayText.Length == 0 && !string.IsNullOrEmpty(Placeholder))
         {
             inputContext.SetForeground(PlaceholderColor);
+            if (Background.HasValue)
+                inputContext.SetBackground(Background.Value);
             var placeholder = Placeholder.Length > bounds.Width
                 ? Placeholder[..bounds.Width]
                 : Placeholder;

--- a/tests/Termina.Tests/Layout/TextInputNodeRenderTests.cs
+++ b/tests/Termina.Tests/Layout/TextInputNodeRenderTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Rendering tests for <see cref="TextInputNode"/> that inspect the produced cell colors
+/// via <see cref="VirtualTerminal"/>.
+/// </summary>
+public class TextInputNodeRenderTests
+{
+    private const int Width = 20;
+
+    private static (VirtualTerminal Terminal, RegionRenderContext Context) NewSurface()
+    {
+        var terminal = new VirtualTerminal(Width, 1);
+        var context = new RegionRenderContext(terminal, 0, 0, Width, 1);
+        return (terminal, context);
+    }
+
+    [Fact]
+    public void Render_PlaceholderWithBackground_AppliesConfiguredBackground()
+    {
+        // Regression: the placeholder used to render against the terminal default background
+        // even when a Background was configured, leaving a visual seam in styled input panels.
+        var bg = Color.FromRgb(0x33, 0x38, 0x42);
+        using var node = new TextInputNode()
+            .WithBackground(bg)
+            .WithPlaceholder("type here");
+
+        var (terminal, context) = NewSurface();
+        node.Render(context, new Rect(0, 0, Width, 1));
+
+        // Placeholder glyph cell — x >= 1 so we never collide with the cursor cell at (0,0).
+        Assert.Equal(bg, terminal.GetBackground(3, 0));
+
+        // Trailing empty cell beyond the placeholder text also carries the configured bg
+        // (the up-front Fill covers the whole input region, not just the glyph cells).
+        Assert.Equal(bg, terminal.GetBackground(15, 0));
+    }
+
+    [Fact]
+    public void Render_PlaceholderWithoutBackground_LeavesCellsDefault()
+    {
+        // No-regression: without a configured Background, cells stay the terminal default.
+        using var node = new TextInputNode().WithPlaceholder("type here");
+
+        var (terminal, context) = NewSurface();
+        node.Render(context, new Rect(0, 0, Width, 1));
+
+        Assert.Equal(Color.Default, terminal.GetBackground(3, 0));
+        Assert.Equal(Color.Default, terminal.GetBackground(15, 0));
+    }
+}


### PR DESCRIPTION
## Problem

When a `Background` color is configured on `TextInputNode` (e.g. for a styled command panel), the placeholder text renders with the terminal's default background instead of the configured one. This creates a visual inconsistency — the input area has the correct background when text is present, but shows the wrong background when only the placeholder is displayed.

## Fix

Two changes in `TextInputNode.Render`:

1. **Fill the input area with the configured background** before rendering any content (text, cursor, placeholder). This ensures the entire input bounds have the correct background.
2. **Set background before writing placeholder text** so the placeholder glyphs display against the configured background.

## Testing

Verified in the Zerix CLI project where `TextInputNode` is used with `Background = AppTheme.CommandPanelBackground` (`#333842`). The placeholder now correctly renders with the panel background color instead of the terminal default.
