### PR TITLE
Fix legacy CSI tilde key decoding

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -22,6 +22,7 @@ namespace Termina.Input;
 ///   <item><description>SGR mouse scroll down: <c>ESC[&lt;65;x;yM</c> → <see cref="MouseScrollEvent"/>(<c>-1</c>)</description></item>
 ///   <item><description>Other SGR mouse events (clicks, releases): silently consumed — prevents spurious <c>ESC</c> keypresses.</description></item>
 ///   <item><description>CSI u (kitty keyboard protocol): <c>ESC[keycode;modifiersu</c> → <see cref="KeyPressed"/> with correct modifiers.</description></item>
+///   <item><description>Legacy CSI tilde keys: <c>ESC[5~</c> / <c>ESC[5;5~</c> → <see cref="KeyPressed"/> (PgUp/PgDn/etc. with modifiers).</description></item>
 ///   <item><description>CSI arrow under xterm alternate-scroll mode: <c>ESC[A</c> / <c>ESC[B</c> → <see cref="MouseScrollEvent"/>.</description></item>
 ///   <item><description>SS3 arrow / function key: <c>ESC O A/B/C/D/H/F/P-S</c> → <see cref="KeyPressed"/> (arrows, Home/End, F1-F4).</description></item>
 ///   <item><description>Alt+Enter: <c>ESC</c> followed by <c>\r</c>/<c>\n</c> → <see cref="KeyPressed"/> with Alt modifier set.</description></item>
@@ -187,6 +188,19 @@ internal sealed class EscapeSequenceParser
                     _pendingEndSeqPos = 0;
                     _state = State.PasteBuffering;
                     TerminaTrace.Input.Debug(this, "ESP: Paste start detected → PasteBuffering");
+                    break;
+                }
+
+                // Legacy xterm/VT function-key form: ESC[<num>~ or ESC[<num>;<mods>~.
+                // Keep this after bracketed paste so ESC[200~ remains the paste sentinel.
+                if (key.KeyChar == '~'
+                    && TryParseLegacyCsiTilde(seq, out var legacyKeyEvent)
+                    && legacyKeyEvent is not null)
+                {
+                    TerminaTrace.Input.Debug(this, "ESP: legacy CSI tilde {0} → {1}", seq, legacyKeyEvent);
+                    results.Add(legacyKeyEvent);
+                    _seqBuffer.Clear();
+                    _state = State.Normal;
                     break;
                 }
 
@@ -362,10 +376,8 @@ internal sealed class EscapeSequenceParser
         if (seq.Length <= pasteStart.Length && pasteStart.StartsWith(seq, StringComparison.Ordinal))
             return true;
 
-        // Complete but unrecognized CSI tilde-terminated sequences (e.g. [5~ for PgUp,
-        // [6~ for PgDn, [3~ for Delete, [1~ for Home, [4~ for End). These are not
-        // handled by our parser — flush them as raw KeyPressed events so applications
-        // can process them rather than keeping the parser stuck in InBracketSequence.
+        // Complete but still-unrecognized CSI tilde-terminated sequences flush as raw
+        // KeyPressed events rather than keeping the parser stuck in InBracketSequence.
         if (seq.Length >= 3 && seq[^1] == '~')
             return false;
 
@@ -411,6 +423,62 @@ internal sealed class EscapeSequenceParser
         'Q' => ConsoleKey.F2,
         'R' => ConsoleKey.F3,
         'S' => ConsoleKey.F4,
+        _ => ConsoleKey.None,
+    };
+
+    /// <summary>
+    /// Attempts to parse the legacy xterm/VT tilde-terminated key form:
+    /// <c>[num~</c> or <c>[num;modifiers~</c>.
+    /// </summary>
+    private static bool TryParseLegacyCsiTilde(string seq, out KeyPressed? result)
+    {
+        result = null;
+        if (seq.Length < 3 || seq[0] != '[' || seq[^1] != '~') return false;
+
+        var inner = seq[1..^1];
+        var semicolon = inner.IndexOf(';');
+        var keyPart = semicolon < 0 ? inner : inner[..semicolon];
+        if (!int.TryParse(keyPart, out var keyCode)) return false;
+
+        var consoleKey = LegacyTildeCodeToKey(keyCode);
+        if (consoleKey == ConsoleKey.None) return false;
+
+        var modValue = 1;
+        if (semicolon >= 0)
+        {
+            var modPart = inner[(semicolon + 1)..];
+            if (!int.TryParse(modPart, out modValue) || modValue < 1) return false;
+        }
+
+        var modBits = modValue - 1;
+        var shift = (modBits & 1) != 0;
+        var alt = (modBits & 2) != 0;
+        var ctrl = (modBits & 4) != 0;
+
+        result = new KeyPressed(new ConsoleKeyInfo('\0', consoleKey, shift, alt, ctrl));
+        return true;
+    }
+
+    private static ConsoleKey LegacyTildeCodeToKey(int code) => code switch
+    {
+        1 or 7 => ConsoleKey.Home,
+        2 => ConsoleKey.Insert,
+        3 => ConsoleKey.Delete,
+        4 or 8 => ConsoleKey.End,
+        5 => ConsoleKey.PageUp,
+        6 => ConsoleKey.PageDown,
+        11 => ConsoleKey.F1,
+        12 => ConsoleKey.F2,
+        13 => ConsoleKey.F3,
+        14 => ConsoleKey.F4,
+        15 => ConsoleKey.F5,
+        17 => ConsoleKey.F6,
+        18 => ConsoleKey.F7,
+        19 => ConsoleKey.F8,
+        20 => ConsoleKey.F9,
+        21 => ConsoleKey.F10,
+        23 => ConsoleKey.F11,
+        24 => ConsoleKey.F12,
         _ => ConsoleKey.None,
     };
 

--- a/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
@@ -466,62 +466,104 @@ public class EscapeSequenceParserTests
         Assert.Equal('a', ((KeyPressed)single).KeyInfo.KeyChar);
     }
 
-    // --- Unrecognized CSI tilde sequences are flushed, not buffered forever ---
+    // --- Legacy CSI tilde key sequences ---
 
     [Theory]
-    [InlineData("[1~")] // Home
-    [InlineData("[3~")] // Delete
-    [InlineData("[4~")] // End
-    [InlineData("[5~")] // PgUp
-    [InlineData("[6~")] // PgDn
-    public void UnrecognizedCsiTilde_FlushesAsRawKeys_AndUnsticksParser(string seq)
+    [InlineData("[1~", ConsoleKey.Home)]
+    [InlineData("[2~", ConsoleKey.Insert)]
+    [InlineData("[3~", ConsoleKey.Delete)]
+    [InlineData("[4~", ConsoleKey.End)]
+    [InlineData("[5~", ConsoleKey.PageUp)]
+    [InlineData("[6~", ConsoleKey.PageDown)]
+    [InlineData("[7~", ConsoleKey.Home)]
+    [InlineData("[8~", ConsoleKey.End)]
+    [InlineData("[11~", ConsoleKey.F1)]
+    [InlineData("[12~", ConsoleKey.F2)]
+    [InlineData("[13~", ConsoleKey.F3)]
+    [InlineData("[14~", ConsoleKey.F4)]
+    [InlineData("[15~", ConsoleKey.F5)]
+    [InlineData("[17~", ConsoleKey.F6)]
+    [InlineData("[18~", ConsoleKey.F7)]
+    [InlineData("[19~", ConsoleKey.F8)]
+    [InlineData("[20~", ConsoleKey.F9)]
+    [InlineData("[21~", ConsoleKey.F10)]
+    [InlineData("[23~", ConsoleKey.F11)]
+    [InlineData("[24~", ConsoleKey.F12)]
+    public void LegacyCsiTilde_EmitsSemanticKeyPressed(string seq, ConsoleKey expected)
     {
-        // Regression: these complete-but-unrecognized tilde sequences have a digit second
-        // char, so the CSI-u length check used to return true and leave the parser stuck in
-        // InBracketSequence — silently swallowing all subsequent input.
         var parser = new EscapeSequenceParser();
         var events = new List<IInputEvent>();
 
         events.AddRange(parser.Process(EscKey()));
         events.AddRange(FeedString(parser, seq));
 
-        // Parser must not remain stuck buffering the bracket sequence.
         Assert.False(parser.IsBufferingEscape);
 
-        // Flushed as raw KeyPressed events (ESC + each buffered char) rather than consumed.
+        var press = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(expected, press.KeyInfo.Key);
+        Assert.Equal('\0', press.KeyInfo.KeyChar);
+        Assert.Equal((ConsoleModifiers)0, press.KeyInfo.Modifiers);
+    }
+
+    [Theory]
+    [InlineData("[5;2~", true, false, false)]
+    [InlineData("[5;3~", false, true, false)]
+    [InlineData("[5;5~", false, false, true)]
+    [InlineData("[5;8~", true, true, true)]
+    public void LegacyCsiTilde_WithModifiers_EmitsSemanticKeyPressed(string seq, bool shift, bool alt, bool ctrl)
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, seq));
+
+        Assert.False(parser.IsBufferingEscape);
+
+        var press = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.PageUp, press.KeyInfo.Key);
+        Assert.Equal(shift, press.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
+        Assert.Equal(alt, press.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Alt));
+        Assert.Equal(ctrl, press.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Theory]
+    [InlineData("[9~")]
+    [InlineData("[25;5~")]
+    public void UnknownCsiTilde_FlushesAsRawKeys_AndUnsticksParser(string seq)
+    {
+        // Regression from #232: complete-but-unknown tilde sequences must not leave the parser
+        // stuck in InBracketSequence and swallowing subsequent input.
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, seq));
+
+        Assert.False(parser.IsBufferingEscape);
         Assert.NotEmpty(events);
         Assert.All(events, e => Assert.IsType<KeyPressed>(e));
+        var keyChars = events.Select(e => ((KeyPressed)e).KeyInfo.KeyChar).ToArray();
+        Assert.Equal($"\x1b{seq}".ToCharArray(), keyChars);
     }
 
     [Fact]
-    public void MouseWheel_AfterUnrecognizedCsiTilde_StillParses()
+    public void MouseWheel_AfterLegacyCsiTilde_StillParses()
     {
-        // The reported symptom: a complete-but-unrecognized [5~ (PgUp) left the parser stuck,
-        // so subsequent mouse wheel events were swallowed. After the flush fix, wheel works.
+        // The reported #232 symptom: [5~ used to leave the parser stuck, causing later mouse
+        // wheel events to be swallowed. Semantic decoding must keep the parser unstuck too.
         var parser = new EscapeSequenceParser();
 
-        parser.Process(EscKey());
-        FeedString(parser, "[5~");
+        var keyEvents = new List<IInputEvent>();
+        keyEvents.AddRange(parser.Process(EscKey()));
+        keyEvents.AddRange(FeedString(parser, "[5~"));
+
         Assert.False(parser.IsBufferingEscape);
+        Assert.Equal(ConsoleKey.PageUp, Assert.IsType<KeyPressed>(Assert.Single(keyEvents)).KeyInfo.Key);
 
         var events = FeedSequence(parser, SgrMouseSequence(64, 5, 10));
         var scroll = Assert.Single(events);
         Assert.Equal(+1, Assert.IsType<MouseScrollEvent>(scroll).Delta);
-    }
-
-    [Fact]
-    public void ModifiedCsiTilde_FlushesAndUnsticksParser()
-    {
-        // e.g. [5;3~ (PgUp with a modifier) is also unrecognized and must not get stuck.
-        var parser = new EscapeSequenceParser();
-
-        parser.Process(EscKey());
-        FeedString(parser, "[5;3~");
-        Assert.False(parser.IsBufferingEscape);
-
-        // A regular key afterward is processed normally.
-        var events = parser.Process(Key('a', ConsoleKey.A));
-        Assert.Equal('a', ((KeyPressed)Assert.Single(events)).KeyInfo.KeyChar);
     }
 
     [Fact]


### PR DESCRIPTION
Summary: Maps legacy CSI tilde sequences for Home, End, Insert, Delete, PageUp, PageDown, and F1-F12 into semantic ConsoleKey events with modifier support. Keeps unknown tilde sequences raw-flushing so the #232 parser unstick behavior remains intact. Tests: dotnet test tests/Termina.Tests/Termina.Tests.csproj. Closes #235.