### PR TITLE
Add internal semantic input event model

### DIFF
--- a/src/Termina/Input/Semantic/KeyEventPhase.cs
+++ b/src/Termina/Input/Semantic/KeyEventPhase.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Phase of a semantic key event.
+/// </summary>
+internal enum KeyEventPhase
+{
+    Press,
+    Repeat,
+    Release,
+}

--- a/src/Termina/Input/Semantic/KeyModifiers.cs
+++ b/src/Termina/Input/Semantic/KeyModifiers.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Canonical keyboard modifier flags used by the internal semantic input pipeline.
+/// </summary>
+[Flags]
+internal enum KeyModifiers
+{
+    None = 0,
+    Shift = 1 << 0,
+    Alt = 1 << 1,
+    Control = 1 << 2,
+    Super = 1 << 3,
+    Hyper = 1 << 4,
+    Meta = 1 << 5,
+}
+
+internal static class KeyModifiersExtensions
+{
+    public static KeyModifiers ToTerminaKeyModifiers(this ConsoleModifiers modifiers)
+    {
+        var result = KeyModifiers.None;
+        if (modifiers.HasFlag(ConsoleModifiers.Shift)) result |= KeyModifiers.Shift;
+        if (modifiers.HasFlag(ConsoleModifiers.Alt)) result |= KeyModifiers.Alt;
+        if (modifiers.HasFlag(ConsoleModifiers.Control)) result |= KeyModifiers.Control;
+        return result;
+    }
+
+    public static ConsoleModifiers ToConsoleModifiers(this KeyModifiers modifiers)
+    {
+        var result = (ConsoleModifiers)0;
+        if (modifiers.HasFlag(KeyModifiers.Shift)) result |= ConsoleModifiers.Shift;
+        if (modifiers.HasFlag(KeyModifiers.Alt)) result |= ConsoleModifiers.Alt;
+        if (modifiers.HasFlag(KeyModifiers.Control)) result |= ConsoleModifiers.Control;
+        return result;
+    }
+}

--- a/src/Termina/Input/Semantic/PointerAction.cs
+++ b/src/Termina/Input/Semantic/PointerAction.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Canonical pointer action used by the internal semantic input pipeline.
+/// </summary>
+internal enum PointerAction
+{
+    Press,
+    Release,
+    Drag,
+    Move,
+    Wheel,
+}

--- a/src/Termina/Input/Semantic/PublicInputEventAdapter.cs
+++ b/src/Termina/Input/Semantic/PublicInputEventAdapter.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Adapts internal semantic input events back to Termina's current public input event surface.
+/// This preserves existing application and component behavior while the internal pipeline evolves.
+/// </summary>
+internal static class PublicInputEventAdapter
+{
+    public static IReadOnlyList<IInputEvent> Adapt(TerminaInputEvent evt) => evt switch
+    {
+        KeyStroke keyStroke => AdaptKeyStroke(keyStroke),
+        TextEntered textEntered => AdaptTextEntered(textEntered),
+        PointerInput pointerInput => AdaptPointerInput(pointerInput),
+        PasteInput pasteInput => [new PasteEvent(pasteInput.Text)],
+        TerminalResizeInput resizeInput => [new ResizeEvent(resizeInput.Width, resizeInput.Height)],
+        TerminalReplyInput => [],
+        _ => [],
+    };
+
+    private static IReadOnlyList<IInputEvent> AdaptKeyStroke(KeyStroke keyStroke)
+    {
+        if (keyStroke.Phase != KeyEventPhase.Press)
+            return [];
+
+        var consoleKey = keyStroke.Key.ToConsoleKey();
+        var keyChar = KeyCharFromAssociatedText(keyStroke.Text, keyStroke.Key);
+
+        if (consoleKey == ConsoleKey.None && keyChar == '\0')
+            return [];
+
+        return [new KeyPressed(new ConsoleKeyInfo(
+            keyChar,
+            consoleKey,
+            keyStroke.Modifiers.HasFlag(KeyModifiers.Shift),
+            keyStroke.Modifiers.HasFlag(KeyModifiers.Alt),
+            keyStroke.Modifiers.HasFlag(KeyModifiers.Control)))];
+    }
+
+    private static IReadOnlyList<IInputEvent> AdaptTextEntered(TextEntered textEntered)
+    {
+        if (string.IsNullOrEmpty(textEntered.Text))
+            return [];
+
+        var events = new List<IInputEvent>(textEntered.Text.Length);
+        foreach (var c in textEntered.Text)
+        {
+            events.Add(new KeyPressed(new ConsoleKeyInfo(
+                c,
+                CharToConsoleKey(c),
+                shift: c is >= 'A' and <= 'Z',
+                alt: false,
+                control: false)));
+        }
+
+        return events;
+    }
+
+    private static IReadOnlyList<IInputEvent> AdaptPointerInput(PointerInput pointerInput)
+    {
+        if (pointerInput.Action == PointerAction.Wheel)
+        {
+            return pointerInput.Button switch
+            {
+                MouseButton.WheelUp => [new MouseScrollEvent(+1)],
+                MouseButton.WheelDown => [new MouseScrollEvent(-1)],
+                _ => [],
+            };
+        }
+
+        return [new MouseEvent(
+            pointerInput.X,
+            pointerInput.Y,
+            pointerInput.Button,
+            pointerInput.Action.ToMouseEventType(),
+            pointerInput.Modifiers.ToConsoleModifiers())];
+    }
+
+    private static char KeyCharFromAssociatedText(string? text, TerminaKey key) =>
+        string.IsNullOrEmpty(text) ? DefaultKeyChar(key) : text[0];
+
+    private static char DefaultKeyChar(TerminaKey key) => key switch
+    {
+        TerminaKey.Escape => '\x1b',
+        TerminaKey.Enter => '\r',
+        TerminaKey.Tab => '\t',
+        TerminaKey.Backspace => '\b',
+        TerminaKey.Space => ' ',
+        _ => '\0',
+    };
+
+    private static ConsoleKey ToConsoleKey(this TerminaKey key) => key switch
+    {
+        TerminaKey.None => ConsoleKey.None,
+        TerminaKey.Escape => ConsoleKey.Escape,
+        TerminaKey.Enter => ConsoleKey.Enter,
+        TerminaKey.Tab => ConsoleKey.Tab,
+        TerminaKey.Backspace => ConsoleKey.Backspace,
+        TerminaKey.Space => ConsoleKey.Spacebar,
+        TerminaKey.Insert => ConsoleKey.Insert,
+        TerminaKey.Delete => ConsoleKey.Delete,
+        TerminaKey.Home => ConsoleKey.Home,
+        TerminaKey.End => ConsoleKey.End,
+        TerminaKey.PageUp => ConsoleKey.PageUp,
+        TerminaKey.PageDown => ConsoleKey.PageDown,
+        TerminaKey.UpArrow => ConsoleKey.UpArrow,
+        TerminaKey.DownArrow => ConsoleKey.DownArrow,
+        TerminaKey.LeftArrow => ConsoleKey.LeftArrow,
+        TerminaKey.RightArrow => ConsoleKey.RightArrow,
+        >= TerminaKey.A and <= TerminaKey.Z => ConsoleKey.A + (key - TerminaKey.A),
+        >= TerminaKey.D0 and <= TerminaKey.D9 => ConsoleKey.D0 + (key - TerminaKey.D0),
+        >= TerminaKey.F1 and <= TerminaKey.F24 => ConsoleKey.F1 + (key - TerminaKey.F1),
+        _ => ConsoleKey.None,
+    };
+
+    private static ConsoleKey CharToConsoleKey(char c) => c switch
+    {
+        >= 'a' and <= 'z' => ConsoleKey.A + (c - 'a'),
+        >= 'A' and <= 'Z' => ConsoleKey.A + (c - 'A'),
+        >= '0' and <= '9' => ConsoleKey.D0 + (c - '0'),
+        ' ' => ConsoleKey.Spacebar,
+        _ => ConsoleKey.None,
+    };
+
+    private static MouseEventType ToMouseEventType(this PointerAction action) => action switch
+    {
+        PointerAction.Press => MouseEventType.Press,
+        PointerAction.Release => MouseEventType.Release,
+        PointerAction.Drag => MouseEventType.Drag,
+        PointerAction.Move => MouseEventType.Move,
+        PointerAction.Wheel => MouseEventType.Scroll,
+        _ => MouseEventType.Move,
+    };
+}

--- a/src/Termina/Input/Semantic/TerminaInputEvent.cs
+++ b/src/Termina/Input/Semantic/TerminaInputEvent.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Internal canonical input event produced by terminal protocol decoders before adapting
+/// back to Termina's public input event surface.
+/// </summary>
+internal abstract record TerminaInputEvent;
+
+/// <summary>
+/// Semantic key event independent of a specific terminal byte sequence or
+/// <see cref="ConsoleKeyInfo"/> transport shape.
+/// </summary>
+internal sealed record KeyStroke(
+    TerminaKey Key,
+    KeyModifiers Modifiers = KeyModifiers.None,
+    KeyEventPhase Phase = KeyEventPhase.Press,
+    string? Text = null) : TerminaInputEvent;
+
+/// <summary>
+/// Text input that should be handled as text rather than as a physical key.
+/// </summary>
+internal sealed record TextEntered(string Text) : TerminaInputEvent;
+
+/// <summary>
+/// Semantic pointer input for mouse-compatible terminal protocols.
+/// </summary>
+internal sealed record PointerInput(
+    PointerAction Action,
+    int X,
+    int Y,
+    MouseButton Button,
+    KeyModifiers Modifiers = KeyModifiers.None) : TerminaInputEvent;
+
+/// <summary>
+/// Bracketed paste payload as a single semantic event.
+/// </summary>
+internal sealed record PasteInput(string Text) : TerminaInputEvent;
+
+/// <summary>
+/// Terminal viewport resize as a semantic input event.
+/// </summary>
+internal sealed record TerminalResizeInput(int Width, int Height) : TerminaInputEvent;
+
+/// <summary>
+/// Terminal-originated response such as cursor position, device attributes, or focus reports.
+/// This is intentionally inert in the current compatibility adapter so future decoders can
+/// identify terminal replies without leaking them as user input.
+/// </summary>
+internal sealed record TerminalReplyInput(string Sequence) : TerminaInputEvent;

--- a/src/Termina/Input/Semantic/TerminaKey.cs
+++ b/src/Termina/Input/Semantic/TerminaKey.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Canonical key identity used by the internal semantic input pipeline.
+/// </summary>
+internal enum TerminaKey
+{
+    None = 0,
+
+    Escape,
+    Enter,
+    Tab,
+    Backspace,
+    Space,
+
+    Insert,
+    Delete,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+
+    UpArrow,
+    DownArrow,
+    LeftArrow,
+    RightArrow,
+
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z,
+
+    D0,
+    D1,
+    D2,
+    D3,
+    D4,
+    D5,
+    D6,
+    D7,
+    D8,
+    D9,
+
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    F11,
+    F12,
+    F13,
+    F14,
+    F15,
+    F16,
+    F17,
+    F18,
+    F19,
+    F20,
+    F21,
+    F22,
+    F23,
+    F24,
+}

--- a/tests/Termina.Tests/Input/PublicInputEventAdapterTests.cs
+++ b/tests/Termina.Tests/Input/PublicInputEventAdapterTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class PublicInputEventAdapterTests
+{
+    [Fact]
+    public void KeyStrokePress_AdaptsToKeyPressed()
+    {
+        var events = PublicInputEventAdapter.Adapt(new KeyStroke(
+            TerminaKey.PageUp,
+            KeyModifiers.Control | KeyModifiers.Shift));
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.PageUp, pressed.KeyInfo.Key);
+        Assert.Equal('\0', pressed.KeyInfo.KeyChar);
+        Assert.True(pressed.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+        Assert.True(pressed.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
+    }
+
+    [Fact]
+    public void KeyStrokeNonPress_DoesNotEmitPublicKeyEvent()
+    {
+        var repeatEvents = PublicInputEventAdapter.Adapt(new KeyStroke(TerminaKey.Enter, Phase: KeyEventPhase.Repeat));
+        var releaseEvents = PublicInputEventAdapter.Adapt(new KeyStroke(TerminaKey.Enter, Phase: KeyEventPhase.Release));
+
+        Assert.Empty(repeatEvents);
+        Assert.Empty(releaseEvents);
+    }
+
+    [Fact]
+    public void KeyStroke_WithAssociatedText_UsesFirstTextCharacterAsKeyChar()
+    {
+        var events = PublicInputEventAdapter.Adapt(new KeyStroke(
+            TerminaKey.Enter,
+            KeyModifiers.Control,
+            Text: "\r"));
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.Enter, pressed.KeyInfo.Key);
+        Assert.Equal('\r', pressed.KeyInfo.KeyChar);
+        Assert.True(pressed.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Fact]
+    public void KeyStroke_ControlKeysUseConsoleCompatibleDefaultKeyChars()
+    {
+        var cases = new[]
+        {
+            (Key: TerminaKey.Escape, ConsoleKey: ConsoleKey.Escape, KeyChar: '\x1b'),
+            (Key: TerminaKey.Enter, ConsoleKey: ConsoleKey.Enter, KeyChar: '\r'),
+            (Key: TerminaKey.Tab, ConsoleKey: ConsoleKey.Tab, KeyChar: '\t'),
+            (Key: TerminaKey.Backspace, ConsoleKey: ConsoleKey.Backspace, KeyChar: '\b'),
+            (Key: TerminaKey.Space, ConsoleKey: ConsoleKey.Spacebar, KeyChar: ' '),
+        };
+
+        foreach (var testCase in cases)
+        {
+            var events = PublicInputEventAdapter.Adapt(new KeyStroke(testCase.Key));
+
+            var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+            Assert.Equal(testCase.ConsoleKey, pressed.KeyInfo.Key);
+            Assert.Equal(testCase.KeyChar, pressed.KeyInfo.KeyChar);
+        }
+    }
+
+    [Fact]
+    public void KeyStroke_CanRepresentModifierBearingPrintableKey()
+    {
+        var events = PublicInputEventAdapter.Adapt(new KeyStroke(
+            TerminaKey.A,
+            KeyModifiers.Control,
+            Text: "\x01"));
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.A, pressed.KeyInfo.Key);
+        Assert.Equal('\x01', pressed.KeyInfo.KeyChar);
+        Assert.True(pressed.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Fact]
+    public void KeyStroke_AdaptsDigitKeyIdentity()
+    {
+        var events = PublicInputEventAdapter.Adapt(new KeyStroke(TerminaKey.D7, Text: "7"));
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.D7, pressed.KeyInfo.Key);
+        Assert.Equal('7', pressed.KeyInfo.KeyChar);
+    }
+
+    [Fact]
+    public void TextEntered_AdaptsEachCharacterToKeyPressed()
+    {
+        var events = PublicInputEventAdapter.Adapt(new TextEntered("Az1!"));
+
+        Assert.Equal(4, events.Count);
+        AssertKey(events[0], ConsoleKey.A, 'A', ConsoleModifiers.Shift);
+        AssertKey(events[1], ConsoleKey.Z, 'z', default);
+        AssertKey(events[2], ConsoleKey.D1, '1', default);
+        AssertKey(events[3], ConsoleKey.None, '!', default);
+    }
+
+    [Theory]
+    [InlineData(MouseButton.WheelUp, +1)]
+    [InlineData(MouseButton.WheelDown, -1)]
+    public void PointerWheel_AdaptsToMouseScrollEvent(MouseButton button, int expectedDelta)
+    {
+        var events = PublicInputEventAdapter.Adapt(new PointerInput(
+            PointerAction.Wheel,
+            X: 3,
+            Y: 4,
+            button));
+
+        var scroll = Assert.IsType<MouseScrollEvent>(Assert.Single(events));
+        Assert.Equal(expectedDelta, scroll.Delta);
+    }
+
+    [Fact]
+    public void PointerPress_AdaptsToMouseEvent()
+    {
+        var events = PublicInputEventAdapter.Adapt(new PointerInput(
+            PointerAction.Press,
+            X: 3,
+            Y: 4,
+            MouseButton.Left,
+            KeyModifiers.Alt));
+
+        var mouse = Assert.IsType<MouseEvent>(Assert.Single(events));
+        Assert.Equal(3, mouse.X);
+        Assert.Equal(4, mouse.Y);
+        Assert.Equal(MouseButton.Left, mouse.Button);
+        Assert.Equal(MouseEventType.Press, mouse.EventType);
+        Assert.Equal(ConsoleModifiers.Alt, mouse.Modifiers);
+    }
+
+    [Fact]
+    public void PasteInput_AdaptsToPasteEvent()
+    {
+        var events = PublicInputEventAdapter.Adapt(new PasteInput("line 1\nline 2"));
+
+        var paste = Assert.IsType<PasteEvent>(Assert.Single(events));
+        Assert.Equal("line 1\nline 2", paste.Content);
+    }
+
+    [Fact]
+    public void TerminalResizeInput_AdaptsToResizeEvent()
+    {
+        var events = PublicInputEventAdapter.Adapt(new TerminalResizeInput(120, 40));
+
+        var resize = Assert.IsType<ResizeEvent>(Assert.Single(events));
+        Assert.Equal(120, resize.Width);
+        Assert.Equal(40, resize.Height);
+    }
+
+    [Fact]
+    public void TerminalReplyInput_DoesNotEmitPublicEvent()
+    {
+        var events = PublicInputEventAdapter.Adapt(new TerminalReplyInput("[12;40R"));
+
+        Assert.Empty(events);
+    }
+
+    private static void AssertKey(
+        IInputEvent evt,
+        ConsoleKey key,
+        char keyChar,
+        ConsoleModifiers modifiers)
+    {
+        var pressed = Assert.IsType<KeyPressed>(evt);
+        Assert.Equal(key, pressed.KeyInfo.Key);
+        Assert.Equal(keyChar, pressed.KeyInfo.KeyChar);
+        Assert.Equal(modifiers, pressed.KeyInfo.Modifiers);
+    }
+}

--- a/tests/Termina.Tests/Input/SemanticInputEventTests.cs
+++ b/tests/Termina.Tests/Input/SemanticInputEventTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class SemanticInputEventTests
+{
+    [Fact]
+    public void KeyStroke_DefaultsToPressWithoutModifiers()
+    {
+        var stroke = new KeyStroke(TerminaKey.Enter);
+
+        Assert.Equal(TerminaKey.Enter, stroke.Key);
+        Assert.Equal(KeyModifiers.None, stroke.Modifiers);
+        Assert.Equal(KeyEventPhase.Press, stroke.Phase);
+        Assert.Null(stroke.Text);
+    }
+
+    [Fact]
+    public void KeyStroke_CanRepresentModifiedReleaseWithAssociatedText()
+    {
+        var stroke = new KeyStroke(
+            TerminaKey.F5,
+            KeyModifiers.Control | KeyModifiers.Shift,
+            KeyEventPhase.Release,
+            Text: "associated text");
+
+        Assert.Equal(TerminaKey.F5, stroke.Key);
+        Assert.True(stroke.Modifiers.HasFlag(KeyModifiers.Control));
+        Assert.True(stroke.Modifiers.HasFlag(KeyModifiers.Shift));
+        Assert.Equal(KeyEventPhase.Release, stroke.Phase);
+        Assert.Equal("associated text", stroke.Text);
+    }
+
+    [Fact]
+    public void TextEntered_CanCarryMultipleCharacters()
+    {
+        var entered = new TextEntered("hello");
+
+        Assert.Equal("hello", entered.Text);
+    }
+
+    [Fact]
+    public void PointerInput_CanRepresentWheelWithCoordinatesAndModifiers()
+    {
+        var pointer = new PointerInput(
+            PointerAction.Wheel,
+            X: 12,
+            Y: 5,
+            MouseButton.WheelDown,
+            KeyModifiers.Alt);
+
+        Assert.Equal(PointerAction.Wheel, pointer.Action);
+        Assert.Equal(12, pointer.X);
+        Assert.Equal(5, pointer.Y);
+        Assert.Equal(MouseButton.WheelDown, pointer.Button);
+        Assert.Equal(KeyModifiers.Alt, pointer.Modifiers);
+    }
+
+    [Fact]
+    public void PasteInput_CarriesPasteTextAsSingleSemanticEvent()
+    {
+        var paste = new PasteInput("line 1\nline 2");
+
+        Assert.Equal("line 1\nline 2", paste.Text);
+    }
+
+    [Fact]
+    public void TerminalResizeInput_CarriesViewportDimensions()
+    {
+        var resize = new TerminalResizeInput(120, 40);
+
+        Assert.Equal(120, resize.Width);
+        Assert.Equal(40, resize.Height);
+    }
+
+    [Fact]
+    public void TerminalReplyInput_CarriesRawReplySequence()
+    {
+        var reply = new TerminalReplyInput("[12;40R");
+
+        Assert.Equal("[12;40R", reply.Sequence);
+    }
+
+    [Fact]
+    public void ConsoleModifiers_RoundTripThroughTerminaSubset()
+    {
+        const ConsoleModifiers console = ConsoleModifiers.Control | ConsoleModifiers.Shift;
+
+        var termina = console.ToTerminaKeyModifiers();
+
+        Assert.True(termina.HasFlag(KeyModifiers.Control));
+        Assert.True(termina.HasFlag(KeyModifiers.Shift));
+        Assert.False(termina.HasFlag(KeyModifiers.Alt));
+        Assert.Equal(console, termina.ToConsoleModifiers());
+    }
+
+    [Fact]
+    public void TerminaOnlyModifiers_AreIgnoredWhenConvertingToConsoleModifiers()
+    {
+        const KeyModifiers modifiers = KeyModifiers.Super | KeyModifiers.Meta | KeyModifiers.Control;
+
+        var console = modifiers.ToConsoleModifiers();
+
+        Assert.Equal(ConsoleModifiers.Control, console);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds internal semantic input event types for keys, text, pointer input, paste, resize, and terminal replies.
- Adds an internal compatibility adapter back to the current public input events.
- Keeps the production input pipeline unchanged; this is a behavior-neutral architecture slice.

## Related Issues
- Part of #240
- Supports #241
- Supports #244

## Tests
- dotnet test tests/Termina.Tests/Termina.Tests.csproj --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test tests/Termina.Tests/Termina.Tests.csproj