### PR TITLE
Add terminal input pipeline facade

### DIFF
--- a/src/Termina/Input/PlatformInputSource.cs
+++ b/src/Termina/Input/PlatformInputSource.cs
@@ -19,14 +19,14 @@ namespace Termina.Input;
 /// </para>
 /// <para>
 /// Escape sequences (mouse events, bracketed paste) are transparently decoded by
-/// <see cref="EscapeSequenceParser"/> before being emitted as application events.
+/// <see cref="TerminalInputPipeline"/> before being emitted as application events.
 /// This prevents terminal mouse click sequences from appearing as spurious ESC keypresses.
 /// </para>
 /// </remarks>
 public sealed class PlatformInputSource : IInputSource
 {
     private readonly IPlatformConsole _console;
-    private readonly EscapeSequenceParser _parser;
+    private readonly TerminalInputPipeline _pipeline;
     private IDisposable? _resizeSubscription;
 
     /// <summary>
@@ -37,10 +37,8 @@ public sealed class PlatformInputSource : IInputSource
     public PlatformInputSource(IPlatformConsole console, PlatformInputConfiguration configuration)
     {
         _console = console ?? throw new ArgumentNullException(nameof(console));
-        _parser = new EscapeSequenceParser
-        {
-            KittyReportAllKeysVisible = configuration.KittyReportAllKeysVisible,
-        };
+        _pipeline = new TerminalInputPipeline(
+            kittyReportAllKeysVisible: configuration.KittyReportAllKeysVisible);
     }
 
     /// <inheritdoc />
@@ -64,7 +62,7 @@ public sealed class PlatformInputSource : IInputSource
 
                 // When buffering an incomplete escape sequence, use a short timeout so a
                 // standalone ESC key (e.g., user pressing Esc) can be flushed after 50 ms.
-                if (_parser.IsBufferingEscape)
+                if (_pipeline.IsBufferingEscape)
                 {
                     inputEvent = await ReadInputWithTimeoutAsync(50, cancellationToken);
                     if (inputEvent is null)
@@ -72,7 +70,7 @@ public sealed class PlatformInputSource : IInputSource
                         if (cancellationToken.IsCancellationRequested) break;
 
                         // Timed out — check if the buffered ESC should be flushed
-                        var escEvent = _parser.CheckEscapeTimeout();
+                        var escEvent = _pipeline.CheckEscapeTimeout();
                         if (escEvent is not null)
                             await writer.WriteAsync(escEvent, cancellationToken);
                         continue;
@@ -94,7 +92,7 @@ public sealed class PlatformInputSource : IInputSource
                 {
                     case ConsoleKeyEvent keyEvent:
                         TerminaTrace.Input.Trace(this, "KeyEvent: {0}", keyEvent.KeyInfo.Key);
-                        var events = _parser.Process(keyEvent.KeyInfo);
+                        var events = _pipeline.Process(keyEvent.KeyInfo);
                         foreach (var e in events)
                         {
                             if (e is PasteEvent pe)
@@ -112,7 +110,7 @@ public sealed class PlatformInputSource : IInputSource
 
                     case ConsoleMouseEvent:
                         // Silently consume raw platform mouse events (Windows).
-                        // On Unix, mouse events arrive as SGR escape sequences handled by EscapeSequenceParser.
+                        // On Unix, mouse events arrive as SGR escape sequences handled by the input pipeline.
                         break;
                 }
             }

--- a/src/Termina/Input/TerminalInputPipeline.cs
+++ b/src/Termina/Input/TerminalInputPipeline.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Internal facade for terminal input processing.
+/// </summary>
+/// <remarks>
+/// This currently delegates to <see cref="EscapeSequenceParser"/> to preserve behavior while
+/// introducing the seam where protocol-specific decoders can be extracted incrementally.
+/// </remarks>
+internal sealed class TerminalInputPipeline
+{
+    private readonly EscapeSequenceParser _parser;
+
+    public TerminalInputPipeline(bool kittyReportAllKeysVisible = false, Func<long>? getTick = null)
+    {
+        _parser = new EscapeSequenceParser(getTick)
+        {
+            KittyReportAllKeysVisible = kittyReportAllKeysVisible,
+        };
+    }
+
+    /// <summary>
+    /// Whether the pipeline is currently buffering an incomplete escape sequence.
+    /// </summary>
+    public bool IsBufferingEscape => _parser.IsBufferingEscape;
+
+    /// <summary>
+    /// Process one key-shaped transport event into zero or more current public input events.
+    /// </summary>
+    public IReadOnlyList<IInputEvent> Process(ConsoleKeyInfo key) => _parser.Process(key);
+
+    /// <summary>
+    /// Flush a standalone Escape key if the escape timeout has elapsed.
+    /// </summary>
+    public KeyPressed? CheckEscapeTimeout() => _parser.CheckEscapeTimeout();
+}

--- a/tests/Termina.Tests/Input/TerminalInputPipelineTests.cs
+++ b/tests/Termina.Tests/Input/TerminalInputPipelineTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+using Termina.Platform;
+
+namespace Termina.Tests.Input;
+
+public class TerminalInputPipelineTests
+{
+    [Fact]
+    public void Process_EmitsCurrentPublicEvents()
+    {
+        var pipeline = new TerminalInputPipeline();
+
+        var events = pipeline.Process(Key('a'));
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.A, pressed.KeyInfo.Key);
+        Assert.Equal('a', pressed.KeyInfo.KeyChar);
+    }
+
+    [Fact]
+    public void KittyReportAllKeysVisible_RoutesBareCsiArrowAsKey()
+    {
+        var pipeline = new TerminalInputPipeline(kittyReportAllKeysVisible: true);
+
+        var events = FeedString(pipeline, "\x1b[A");
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.UpArrow, pressed.KeyInfo.Key);
+    }
+
+    [Fact]
+    public void KittyReportAllKeysNotVisible_RoutesBareCsiArrowAsScroll()
+    {
+        var pipeline = new TerminalInputPipeline(kittyReportAllKeysVisible: false);
+
+        var events = FeedString(pipeline, "\x1b[A");
+
+        var scroll = Assert.IsType<MouseScrollEvent>(Assert.Single(events));
+        Assert.Equal(+1, scroll.Delta);
+    }
+
+    [Fact]
+    public void CheckEscapeTimeout_FlushesStandaloneEscape()
+    {
+        var tick = 0L;
+        var pipeline = new TerminalInputPipeline(getTick: () => tick);
+
+        Assert.Empty(pipeline.Process(Key('\x1b')));
+        Assert.True(pipeline.IsBufferingEscape);
+
+        tick += 60;
+        var escape = pipeline.CheckEscapeTimeout();
+
+        var pressed = Assert.IsType<KeyPressed>(escape);
+        Assert.Equal(ConsoleKey.Escape, pressed.KeyInfo.Key);
+        Assert.Equal('\x1b', pressed.KeyInfo.KeyChar);
+        Assert.False(pipeline.IsBufferingEscape);
+    }
+
+    private static List<IInputEvent> FeedString(TerminalInputPipeline pipeline, string input)
+    {
+        var events = new List<IInputEvent>();
+        foreach (var c in input)
+            events.AddRange(pipeline.Process(Key(c)));
+
+        return events;
+    }
+
+    private static ConsoleKeyInfo Key(char c) => c <= byte.MaxValue
+        ? RawByteKeyMapper.ByteToKeyInfo((byte)c)
+        : new ConsoleKeyInfo(c, ConsoleKey.None, false, false, false);
+}


### PR DESCRIPTION
## Summary
- add an internal TerminalInputPipeline facade around EscapeSequenceParser
- route PlatformInputSource through the facade without changing public input behavior
- add focused pipeline tests for key emission, kitty visibility behavior, and ESC timeout flushing

Refs #240
Refs #242

## Tests
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"