### PR TITLE
Extract SGR mouse decoder

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -220,7 +220,9 @@ internal sealed class EscapeSequenceParser
                 // SGR mouse event: ESC[<button;x;yM (press) or ESC[<button;x;ym (release)
                 if (seq.Length >= 2 && seq[1] == '<' && (key.KeyChar == 'M' || key.KeyChar == 'm'))
                 {
-                    EmitMouseSgrEvent(seq, results);
+                    if (SgrMouseDecoder.TryDecode(seq, out var mouseEvent) && mouseEvent is not null)
+                        results.Add(mouseEvent);
+
                     _seqBuffer.Clear();
                     _state = State.Normal;
                     break;
@@ -653,29 +655,4 @@ internal sealed class EscapeSequenceParser
         ' ' => ConsoleKey.Spacebar,
         _ => ConsoleKey.None
     };
-
-    /// <summary>
-    /// Parses an SGR mouse sequence and appends a <see cref="MouseScrollEvent"/> to <paramref name="results"/>
-    /// when the button code indicates a scroll event (64 = up, 65 = down).
-    /// Other mouse events (clicks, releases) are silently consumed — no event is appended.
-    /// </summary>
-    /// <param name="seq">The buffered sequence string, e.g. <c>[&lt;64;5;10M</c>.</param>
-    /// <param name="results">List to append events into.</param>
-    private static void EmitMouseSgrEvent(string seq, List<IInputEvent> results)
-    {
-        // seq = "[<button;x;yM" or "[<button;x;ym"
-        // Strip leading "[<" and trailing terminator char
-        if (seq.Length < 3) return;
-        var inner = seq[2..^1]; // "button;x;y"
-        var semicolon = inner.IndexOf(';');
-        if (semicolon < 0) return;
-        if (!int.TryParse(inner[..semicolon], out var button)) return;
-
-        // SGR button 64 = wheel up, 65 = wheel down
-        if (button == 64)
-            results.Add(new MouseScrollEvent(+1));
-        else if (button == 65)
-            results.Add(new MouseScrollEvent(-1));
-        // All other buttons (clicks, releases, drags) are silently consumed
-    }
 }

--- a/src/Termina/Input/SgrMouseDecoder.cs
+++ b/src/Termina/Input/SgrMouseDecoder.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Decodes SGR mouse sequences of the form <c>[&lt;button;x;yM</c> or <c>[&lt;button;x;ym</c>.
+/// </summary>
+internal static class SgrMouseDecoder
+{
+    /// <summary>
+    /// Attempts to decode an SGR mouse sequence.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the sequence is a recognized SGR mouse sequence. Scroll sequences produce
+    /// a <see cref="MouseScrollEvent"/>; click, release, and drag sequences are consumed with no event.
+    /// </returns>
+    public static bool TryDecode(string sequence, out MouseScrollEvent? result)
+    {
+        result = null;
+
+        if (sequence.Length < 4 || sequence[0] != '[' || sequence[1] != '<')
+            return false;
+
+        var terminator = sequence[^1];
+        if (terminator is not ('M' or 'm'))
+            return false;
+
+        var inner = sequence[2..^1];
+        var semicolon = inner.IndexOf(';');
+        if (semicolon < 0)
+            return false;
+
+        if (!int.TryParse(inner[..semicolon], out var button))
+            return false;
+
+        result = button switch
+        {
+            64 => new MouseScrollEvent(+1),
+            65 => new MouseScrollEvent(-1),
+            _ => null,
+        };
+
+        return true;
+    }
+}

--- a/tests/Termina.Tests/Input/SgrMouseDecoderTests.cs
+++ b/tests/Termina.Tests/Input/SgrMouseDecoderTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class SgrMouseDecoderTests
+{
+    [Theory]
+    [InlineData("[<64;5;10M", +1)]
+    [InlineData("[<65;5;10M", -1)]
+    [InlineData("[<64;200;50M", +1)]
+    public void TryDecode_ScrollSequence_ReturnsMouseScrollEvent(string sequence, int expectedDelta)
+    {
+        var decoded = SgrMouseDecoder.TryDecode(sequence, out var mouseEvent);
+
+        Assert.True(decoded);
+        Assert.NotNull(mouseEvent);
+        Assert.Equal(expectedDelta, mouseEvent!.Delta);
+    }
+
+    [Theory]
+    [InlineData("[<0;5;10M")]
+    [InlineData("[<0;5;10m")]
+    [InlineData("[<2;10;20M")]
+    public void TryDecode_NonScrollMouseSequence_ReturnsTrueWithoutEvent(string sequence)
+    {
+        var decoded = SgrMouseDecoder.TryDecode(sequence, out var mouseEvent);
+
+        Assert.True(decoded);
+        Assert.Null(mouseEvent);
+    }
+
+    [Theory]
+    [InlineData("[64;5;10M")]
+    [InlineData("[<64M")]
+    [InlineData("[<wheel;5;10M")]
+    [InlineData("[<64;5;10~")]
+    public void TryDecode_NonSgrMouseSequence_ReturnsFalse(string sequence)
+    {
+        var decoded = SgrMouseDecoder.TryDecode(sequence, out var mouseEvent);
+
+        Assert.False(decoded);
+        Assert.Null(mouseEvent);
+    }
+}


### PR DESCRIPTION
## Summary
- extract SGR mouse sequence decoding into a focused internal decoder
- keep EscapeSequenceParser state handling and sequence ordering unchanged
- add focused decoder tests for scroll, consumed non-scroll mouse events, and non-matches

Refs #240
Refs #242

## Tests
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"