### PR TITLE
Extract SS3 keyboard decoder

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -288,7 +288,7 @@ internal sealed class EscapeSequenceParser
 
             case State.InSs3Sequence:
             {
-                // ESC O A/B/C/D → arrow keys delivered by the terminal under DECCKM (?1h).
+                // ESC O A/B/C/D -> arrow keys delivered by the terminal under DECCKM (?1h).
                 // We re-emit these as the same ConsoleKeyInfo shape Console.ReadKey used to
                 // produce for arrow keys, so existing focus/scroll handlers see no difference.
                 //
@@ -296,32 +296,11 @@ internal sealed class EscapeSequenceParser
                 // arrive via the kitty CSI-u / second-form path instead, so any remaining
                 // SS3 OA/OB at this point must be the ?1007h wheel emission under DECCKM on.
                 // (SS3 OC/OD never come from the wheel — there is no horizontal wheel.)
-                if (KittyReportAllKeysVisible && (key.KeyChar == 'A' || key.KeyChar == 'B'))
+                if (Ss3KeyboardDecoder.TryDecode(key.KeyChar, KittyReportAllKeysVisible, out var ss3Event))
                 {
-                    var delta = key.KeyChar == 'A' ? +1 : -1;
-                    TerminaTrace.Input.Debug(this, "ESP: SS3 O{0} (kitty active) → MouseScrollEvent({1})", key.KeyChar, delta);
-                    results.Add(new MouseScrollEvent(delta));
-                    _state = State.Normal;
-                    break;
-                }
-
-                var ck = key.KeyChar switch
-                {
-                    'A' => ConsoleKey.UpArrow,
-                    'B' => ConsoleKey.DownArrow,
-                    'C' => ConsoleKey.RightArrow,
-                    'D' => ConsoleKey.LeftArrow,
-                    'H' => ConsoleKey.Home,
-                    'F' => ConsoleKey.End,
-                    'P' => ConsoleKey.F1,
-                    'Q' => ConsoleKey.F2,
-                    'R' => ConsoleKey.F3,
-                    'S' => ConsoleKey.F4,
-                    _ => ConsoleKey.None,
-                };
-                if (ck != ConsoleKey.None)
-                {
-                    results.Add(new KeyPressed(new ConsoleKeyInfo('\0', ck, false, false, false)));
+                    TerminaTrace.Input.Debug(this, "ESP: SS3 O{0} → {1}", key.KeyChar, ss3Event);
+                    if (ss3Event is not null)
+                        results.Add(ss3Event);
                 }
                 else
                 {

--- a/src/Termina/Input/Ss3KeyboardDecoder.cs
+++ b/src/Termina/Input/Ss3KeyboardDecoder.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Decodes SS3 keyboard sequences of the form <c>ESC O final</c>.
+/// </summary>
+internal static class Ss3KeyboardDecoder
+{
+    /// <summary>
+    /// Attempts to decode the final byte from an SS3 sequence.
+    /// </summary>
+    public static bool TryDecode(char final, bool kittyReportAllKeysVisible, out IInputEvent? result)
+    {
+        result = null;
+
+        if (kittyReportAllKeysVisible && final is 'A' or 'B')
+        {
+            result = new MouseScrollEvent(final == 'A' ? +1 : -1);
+            return true;
+        }
+
+        var key = final switch
+        {
+            'A' => ConsoleKey.UpArrow,
+            'B' => ConsoleKey.DownArrow,
+            'C' => ConsoleKey.RightArrow,
+            'D' => ConsoleKey.LeftArrow,
+            'H' => ConsoleKey.Home,
+            'F' => ConsoleKey.End,
+            'P' => ConsoleKey.F1,
+            'Q' => ConsoleKey.F2,
+            'R' => ConsoleKey.F3,
+            'S' => ConsoleKey.F4,
+            _ => ConsoleKey.None,
+        };
+
+        if (key == ConsoleKey.None)
+            return false;
+
+        result = new KeyPressed(new ConsoleKeyInfo('\0', key, false, false, false));
+        return true;
+    }
+}

--- a/tests/Termina.Tests/Input/Ss3KeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/Ss3KeyboardDecoderTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class Ss3KeyboardDecoderTests
+{
+    [Theory]
+    [InlineData('A', ConsoleKey.UpArrow)]
+    [InlineData('B', ConsoleKey.DownArrow)]
+    [InlineData('C', ConsoleKey.RightArrow)]
+    [InlineData('D', ConsoleKey.LeftArrow)]
+    [InlineData('H', ConsoleKey.Home)]
+    [InlineData('F', ConsoleKey.End)]
+    [InlineData('P', ConsoleKey.F1)]
+    [InlineData('Q', ConsoleKey.F2)]
+    [InlineData('R', ConsoleKey.F3)]
+    [InlineData('S', ConsoleKey.F4)]
+    public void TryDecode_KnownFinal_ReturnsKeyPressed(char final, ConsoleKey expectedKey)
+    {
+        var decoded = Ss3KeyboardDecoder.TryDecode(
+            final,
+            kittyReportAllKeysVisible: false,
+            out var inputEvent);
+
+        Assert.True(decoded);
+        var pressed = Assert.IsType<KeyPressed>(inputEvent);
+        Assert.Equal(expectedKey, pressed.KeyInfo.Key);
+        Assert.Equal('\0', pressed.KeyInfo.KeyChar);
+    }
+
+    [Theory]
+    [InlineData('A', +1)]
+    [InlineData('B', -1)]
+    public void TryDecode_KittyVisibleVerticalArrow_ReturnsMouseScroll(char final, int expectedDelta)
+    {
+        var decoded = Ss3KeyboardDecoder.TryDecode(
+            final,
+            kittyReportAllKeysVisible: true,
+            out var inputEvent);
+
+        Assert.True(decoded);
+        var scroll = Assert.IsType<MouseScrollEvent>(inputEvent);
+        Assert.Equal(expectedDelta, scroll.Delta);
+    }
+
+    [Theory]
+    [InlineData('C', ConsoleKey.RightArrow)]
+    [InlineData('D', ConsoleKey.LeftArrow)]
+    public void TryDecode_KittyVisibleHorizontalArrow_ReturnsKeyPressed(char final, ConsoleKey expectedKey)
+    {
+        var decoded = Ss3KeyboardDecoder.TryDecode(
+            final,
+            kittyReportAllKeysVisible: true,
+            out var inputEvent);
+
+        Assert.True(decoded);
+        var pressed = Assert.IsType<KeyPressed>(inputEvent);
+        Assert.Equal(expectedKey, pressed.KeyInfo.Key);
+    }
+
+    [Theory]
+    [InlineData('E')]
+    [InlineData('x')]
+    public void TryDecode_UnknownFinal_ReturnsFalse(char final)
+    {
+        var decoded = Ss3KeyboardDecoder.TryDecode(
+            final,
+            kittyReportAllKeysVisible: false,
+            out var inputEvent);
+
+        Assert.False(decoded);
+        Assert.Null(inputEvent);
+    }
+}


### PR DESCRIPTION
## Summary
- extract SS3 final-byte decoding into a focused internal decoder
- preserve kitty-visible SS3 A/B alternate-scroll routing
- keep unknown SS3 fallback behavior in EscapeSequenceParser

Refs #240
Refs #242

## Tests
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"