### PR TITLE
Extract legacy CSI keyboard decoder

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -194,7 +194,7 @@ internal sealed class EscapeSequenceParser
                 // Legacy xterm/VT function-key form: ESC[<num>~ or ESC[<num>;<mods>~.
                 // Keep this after bracketed paste so ESC[200~ remains the paste sentinel.
                 if (key.KeyChar == '~'
-                    && TryParseLegacyCsiTilde(seq, out var legacyKeyEvent)
+                    && LegacyCsiKeyboardDecoder.TryDecode(seq, out var legacyKeyEvent)
                     && legacyKeyEvent is not null)
                 {
                     TerminaTrace.Input.Debug(this, "ESP: legacy CSI tilde {0} → {1}", seq, legacyKeyEvent);
@@ -404,62 +404,6 @@ internal sealed class EscapeSequenceParser
         'Q' => ConsoleKey.F2,
         'R' => ConsoleKey.F3,
         'S' => ConsoleKey.F4,
-        _ => ConsoleKey.None,
-    };
-
-    /// <summary>
-    /// Attempts to parse the legacy xterm/VT tilde-terminated key form:
-    /// <c>[num~</c> or <c>[num;modifiers~</c>.
-    /// </summary>
-    private static bool TryParseLegacyCsiTilde(string seq, out KeyPressed? result)
-    {
-        result = null;
-        if (seq.Length < 3 || seq[0] != '[' || seq[^1] != '~') return false;
-
-        var inner = seq[1..^1];
-        var semicolon = inner.IndexOf(';');
-        var keyPart = semicolon < 0 ? inner : inner[..semicolon];
-        if (!int.TryParse(keyPart, out var keyCode)) return false;
-
-        var consoleKey = LegacyTildeCodeToKey(keyCode);
-        if (consoleKey == ConsoleKey.None) return false;
-
-        var modValue = 1;
-        if (semicolon >= 0)
-        {
-            var modPart = inner[(semicolon + 1)..];
-            if (!int.TryParse(modPart, out modValue) || modValue < 1) return false;
-        }
-
-        var modBits = modValue - 1;
-        var shift = (modBits & 1) != 0;
-        var alt = (modBits & 2) != 0;
-        var ctrl = (modBits & 4) != 0;
-
-        result = new KeyPressed(new ConsoleKeyInfo('\0', consoleKey, shift, alt, ctrl));
-        return true;
-    }
-
-    private static ConsoleKey LegacyTildeCodeToKey(int code) => code switch
-    {
-        1 or 7 => ConsoleKey.Home,
-        2 => ConsoleKey.Insert,
-        3 => ConsoleKey.Delete,
-        4 or 8 => ConsoleKey.End,
-        5 => ConsoleKey.PageUp,
-        6 => ConsoleKey.PageDown,
-        11 => ConsoleKey.F1,
-        12 => ConsoleKey.F2,
-        13 => ConsoleKey.F3,
-        14 => ConsoleKey.F4,
-        15 => ConsoleKey.F5,
-        17 => ConsoleKey.F6,
-        18 => ConsoleKey.F7,
-        19 => ConsoleKey.F8,
-        20 => ConsoleKey.F9,
-        21 => ConsoleKey.F10,
-        23 => ConsoleKey.F11,
-        24 => ConsoleKey.F12,
         _ => ConsoleKey.None,
     };
 

--- a/src/Termina/Input/LegacyCsiKeyboardDecoder.cs
+++ b/src/Termina/Input/LegacyCsiKeyboardDecoder.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Decodes legacy xterm/VT CSI tilde keyboard sequences.
+/// </summary>
+internal static class LegacyCsiKeyboardDecoder
+{
+    /// <summary>
+    /// Attempts to decode <c>[num~</c> or <c>[num;modifiers~</c> into a keyboard event.
+    /// </summary>
+    public static bool TryDecode(string sequence, out KeyPressed? result)
+    {
+        result = null;
+        if (sequence.Length < 3 || sequence[0] != '[' || sequence[^1] != '~')
+            return false;
+
+        var inner = sequence[1..^1];
+        var semicolon = inner.IndexOf(';');
+        var keyPart = semicolon < 0 ? inner : inner[..semicolon];
+        if (!int.TryParse(keyPart, out var keyCode))
+            return false;
+
+        var consoleKey = LegacyTildeCodeToKey(keyCode);
+        if (consoleKey == ConsoleKey.None)
+            return false;
+
+        var modValue = 1;
+        if (semicolon >= 0)
+        {
+            var modPart = inner[(semicolon + 1)..];
+            if (!int.TryParse(modPart, out modValue) || modValue < 1)
+                return false;
+        }
+
+        var modBits = modValue - 1;
+        var shift = (modBits & 1) != 0;
+        var alt = (modBits & 2) != 0;
+        var ctrl = (modBits & 4) != 0;
+
+        result = new KeyPressed(new ConsoleKeyInfo('\0', consoleKey, shift, alt, ctrl));
+        return true;
+    }
+
+    private static ConsoleKey LegacyTildeCodeToKey(int code) => code switch
+    {
+        1 or 7 => ConsoleKey.Home,
+        2 => ConsoleKey.Insert,
+        3 => ConsoleKey.Delete,
+        4 or 8 => ConsoleKey.End,
+        5 => ConsoleKey.PageUp,
+        6 => ConsoleKey.PageDown,
+        11 => ConsoleKey.F1,
+        12 => ConsoleKey.F2,
+        13 => ConsoleKey.F3,
+        14 => ConsoleKey.F4,
+        15 => ConsoleKey.F5,
+        17 => ConsoleKey.F6,
+        18 => ConsoleKey.F7,
+        19 => ConsoleKey.F8,
+        20 => ConsoleKey.F9,
+        21 => ConsoleKey.F10,
+        23 => ConsoleKey.F11,
+        24 => ConsoleKey.F12,
+        _ => ConsoleKey.None,
+    };
+}

--- a/tests/Termina.Tests/Input/LegacyCsiKeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/LegacyCsiKeyboardDecoderTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class LegacyCsiKeyboardDecoderTests
+{
+    [Theory]
+    [InlineData("[1~", ConsoleKey.Home)]
+    [InlineData("[2~", ConsoleKey.Insert)]
+    [InlineData("[3~", ConsoleKey.Delete)]
+    [InlineData("[4~", ConsoleKey.End)]
+    [InlineData("[5~", ConsoleKey.PageUp)]
+    [InlineData("[6~", ConsoleKey.PageDown)]
+    [InlineData("[7~", ConsoleKey.Home)]
+    [InlineData("[8~", ConsoleKey.End)]
+    [InlineData("[11~", ConsoleKey.F1)]
+    [InlineData("[12~", ConsoleKey.F2)]
+    [InlineData("[13~", ConsoleKey.F3)]
+    [InlineData("[14~", ConsoleKey.F4)]
+    [InlineData("[15~", ConsoleKey.F5)]
+    [InlineData("[17~", ConsoleKey.F6)]
+    [InlineData("[18~", ConsoleKey.F7)]
+    [InlineData("[19~", ConsoleKey.F8)]
+    [InlineData("[20~", ConsoleKey.F9)]
+    [InlineData("[21~", ConsoleKey.F10)]
+    [InlineData("[23~", ConsoleKey.F11)]
+    [InlineData("[24~", ConsoleKey.F12)]
+    public void TryDecode_KnownTildeSequence_ReturnsKeyPressed(string sequence, ConsoleKey expectedKey)
+    {
+        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+
+        Assert.True(decoded);
+        Assert.NotNull(keyEvent);
+        Assert.Equal(expectedKey, keyEvent!.KeyInfo.Key);
+        Assert.Equal('\0', keyEvent.KeyInfo.KeyChar);
+        Assert.Equal((ConsoleModifiers)0, keyEvent.KeyInfo.Modifiers);
+    }
+
+    [Theory]
+    [InlineData("[5;2~", true, false, false)]
+    [InlineData("[5;3~", false, true, false)]
+    [InlineData("[5;5~", false, false, true)]
+    [InlineData("[5;8~", true, true, true)]
+    public void TryDecode_ModifiedTildeSequence_ReturnsKeyPressedWithModifiers(
+        string sequence,
+        bool shift,
+        bool alt,
+        bool ctrl)
+    {
+        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+
+        Assert.True(decoded);
+        Assert.NotNull(keyEvent);
+        Assert.Equal(ConsoleKey.PageUp, keyEvent!.KeyInfo.Key);
+        Assert.Equal(shift, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
+        Assert.Equal(alt, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Alt));
+        Assert.Equal(ctrl, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Theory]
+    [InlineData("[9~")]
+    [InlineData("[25;5~")]
+    [InlineData("[200~")]
+    [InlineData("[5;0~")]
+    [InlineData("[5;bad~")]
+    [InlineData("5~")]
+    public void TryDecode_UnknownOrMalformedSequence_ReturnsFalse(string sequence)
+    {
+        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+
+        Assert.False(decoded);
+        Assert.Null(keyEvent);
+    }
+}


### PR DESCRIPTION
## Summary
- extract legacy xterm/VT CSI tilde keyboard decoding into a focused internal decoder
- preserve parser ordering by keeping bracketed paste detection before legacy tilde decoding
- add focused decoder tests for key mapping, modifiers, and non-matches

Refs #240
Refs #242

## Tests
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"