### PR TITLE
Extract CSI functional decoder

### DIFF
--- a/src/Termina/Input/CsiFunctionalDecoder.cs
+++ b/src/Termina/Input/CsiFunctionalDecoder.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Decodes CSI functional final bytes used by arrows, Home/End, and F1-F4.
+/// </summary>
+internal static class CsiFunctionalDecoder
+{
+    /// <summary>
+    /// Attempts to decode a bare CSI functional sequence final such as <c>ESC[A</c>.
+    /// </summary>
+    public static bool TryDecodeBareFinal(
+        char final,
+        bool kittyReportAllKeysVisible,
+        out IInputEvent? result)
+    {
+        result = null;
+
+        if (!IsFunctionalFinal(final))
+            return false;
+
+        if (kittyReportAllKeysVisible)
+        {
+            var key = FinalToKey(final);
+            if (key != ConsoleKey.None)
+                result = new KeyPressed(new ConsoleKeyInfo('\0', key, false, false, false));
+
+            return true;
+        }
+
+        if (final is 'A' or 'B')
+            result = new MouseScrollEvent(final == 'A' ? +1 : -1);
+
+        return true;
+    }
+
+    /// <summary>True for CSI finals that represent an arrow / Home/End / F1-F4 / KP_Begin.</summary>
+    /// <remarks>
+    /// <c>'E'</c> is KP_Begin (numpad-5 / "center" with NumLock off). It is recognized so
+    /// <c>ESC[E</c> / <c>ESC[1;&lt;mods&gt;E</c> are consumed rather than flushed as raw keys, but
+    /// <see cref="FinalToKey"/> returns <see cref="ConsoleKey.None"/> because there is no
+    /// equivalent <see cref="ConsoleKey"/>.
+    /// </remarks>
+    public static bool IsFunctionalFinal(char c) =>
+        c is 'A' or 'B' or 'C' or 'D' or 'E' or 'F' or 'H' or 'P' or 'Q' or 'R' or 'S';
+
+    /// <summary>Maps a CSI functional final char to a <see cref="ConsoleKey"/>.</summary>
+    public static ConsoleKey FinalToKey(char c) => c switch
+    {
+        'A' => ConsoleKey.UpArrow,
+        'B' => ConsoleKey.DownArrow,
+        'C' => ConsoleKey.RightArrow,
+        'D' => ConsoleKey.LeftArrow,
+        'H' => ConsoleKey.Home,
+        'F' => ConsoleKey.End,
+        'P' => ConsoleKey.F1,
+        'Q' => ConsoleKey.F2,
+        'R' => ConsoleKey.F3,
+        'S' => ConsoleKey.F4,
+        _ => ConsoleKey.None,
+    };
+}

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -236,23 +236,15 @@ internal sealed class EscapeSequenceParser
                 //   - Kitty active: bare CSI A/B/C/D/H/F/P-S are the kitty canonical no-mod
                 //     keyboard form; wheel still emits the DECCKM-controlled SS3 form, so the
                 //     CSI form is unambiguously a real key.
-                if (seq.Length == 2 && IsArrowOrFunctionalFinal(key.KeyChar))
+                if (seq.Length == 2 && CsiFunctionalDecoder.IsFunctionalFinal(key.KeyChar))
                 {
-                    if (KittyReportAllKeysVisible)
-                    {
-                        var ck = FunctionalFinalToKey(key.KeyChar);
-                        if (ck != ConsoleKey.None)
-                        {
-                            TerminaTrace.Input.Debug(this, "ESP: CSI {0} (kitty no-mod) → KeyPressed({1})", key.KeyChar, ck);
-                            results.Add(new KeyPressed(new ConsoleKeyInfo('\0', ck, false, false, false)));
-                        }
-                    }
-                    else if (key.KeyChar == 'A' || key.KeyChar == 'B')
-                    {
-                        var delta = key.KeyChar == 'A' ? +1 : -1;
-                        TerminaTrace.Input.Debug(this, "ESP: CSI {0} → MouseScrollEvent({1})", key.KeyChar, delta);
-                        results.Add(new MouseScrollEvent(delta));
-                    }
+                    if (CsiFunctionalDecoder.TryDecodeBareFinal(
+                            key.KeyChar,
+                            KittyReportAllKeysVisible,
+                            out var functionalEvent)
+                        && functionalEvent is not null)
+                        results.Add(functionalEvent);
+
                     _seqBuffer.Clear();
                     _state = State.Normal;
                     break;
@@ -261,7 +253,7 @@ internal sealed class EscapeSequenceParser
                 // Kitty "second form" with parameters: CSI 1;<mods>[:<event>] [ABCDEFHPQRS]
                 // Real arrows / function keys with a modifier pressed when kitty's
                 // disambiguate (bit 1) or report_all_keys (bit 8) flag is set.
-                if (IsArrowOrFunctionalFinal(key.KeyChar) && seq.Length >= 3 && seq[1] != '<')
+                if (CsiFunctionalDecoder.IsFunctionalFinal(key.KeyChar) && seq.Length >= 3 && seq[1] != '<')
                 {
                     if (TryParseKittySecondForm(seq, out var keyEvent) && keyEvent is not null)
                     {
@@ -377,36 +369,6 @@ internal sealed class EscapeSequenceParser
         return false;
     }
 
-    /// <summary>True for CSI finals that represent an arrow / Home/End / F1-F4 / KP_Begin.</summary>
-    /// <remarks>
-    /// <c>'E'</c> is KP_Begin (numpad-5 / "center" with NumLock off). It is recognized here so
-    /// the shape <c>ESC[E</c> / <c>ESC[1;&lt;mods&gt;E</c> is consumed rather than flushed as raw
-    /// keys, but <see cref="FunctionalFinalToKey"/> has no mapping for it (no equivalent
-    /// <see cref="ConsoleKey"/>), so it is intentionally swallowed.
-    /// </remarks>
-    private static bool IsArrowOrFunctionalFinal(char c) =>
-        c is 'A' or 'B' or 'C' or 'D' or 'E' or 'F' or 'H' or 'P' or 'Q' or 'R' or 'S';
-
-    /// <summary>Maps the CSI second-form final char to a <see cref="ConsoleKey"/>.</summary>
-    /// <remarks>
-    /// <c>'E'</c> (KP_Begin) returns <see cref="ConsoleKey.None"/> on purpose — call sites
-    /// treat that as "recognized but no event to emit" so the sequence is consumed silently.
-    /// </remarks>
-    private static ConsoleKey FunctionalFinalToKey(char c) => c switch
-    {
-        'A' => ConsoleKey.UpArrow,
-        'B' => ConsoleKey.DownArrow,
-        'C' => ConsoleKey.RightArrow,
-        'D' => ConsoleKey.LeftArrow,
-        'H' => ConsoleKey.Home,
-        'F' => ConsoleKey.End,
-        'P' => ConsoleKey.F1,
-        'Q' => ConsoleKey.F2,
-        'R' => ConsoleKey.F3,
-        'S' => ConsoleKey.F4,
-        _ => ConsoleKey.None,
-    };
-
     /// <summary>
     /// Attempts to parse a kitty keyboard "second form" sequence: <c>[1;modifiers[:event] final</c>
     /// where <c>final</c> is one of <c>A B C D E F H P Q R S</c>.
@@ -424,7 +386,7 @@ internal sealed class EscapeSequenceParser
         result = null;
         if (seq.Length < 3 || seq[0] != '[') return false;
         var final = seq[^1];
-        var key = FunctionalFinalToKey(final);
+        var key = CsiFunctionalDecoder.FinalToKey(final);
         if (key == ConsoleKey.None) return false;
 
         // Strip leading '[' and trailing final → "1;modifiers[:event]"

--- a/tests/Termina.Tests/Input/CsiFunctionalDecoderTests.cs
+++ b/tests/Termina.Tests/Input/CsiFunctionalDecoderTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class CsiFunctionalDecoderTests
+{
+    [Theory]
+    [InlineData('A', ConsoleKey.UpArrow)]
+    [InlineData('B', ConsoleKey.DownArrow)]
+    [InlineData('C', ConsoleKey.RightArrow)]
+    [InlineData('D', ConsoleKey.LeftArrow)]
+    [InlineData('H', ConsoleKey.Home)]
+    [InlineData('F', ConsoleKey.End)]
+    [InlineData('P', ConsoleKey.F1)]
+    [InlineData('Q', ConsoleKey.F2)]
+    [InlineData('R', ConsoleKey.F3)]
+    [InlineData('S', ConsoleKey.F4)]
+    public void TryDecodeBareFinal_KittyVisible_ReturnsKeyPressed(char final, ConsoleKey expectedKey)
+    {
+        var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
+            final,
+            kittyReportAllKeysVisible: true,
+            out var inputEvent);
+
+        Assert.True(decoded);
+        var pressed = Assert.IsType<KeyPressed>(inputEvent);
+        Assert.Equal(expectedKey, pressed.KeyInfo.Key);
+        Assert.Equal('\0', pressed.KeyInfo.KeyChar);
+    }
+
+    [Fact]
+    public void TryDecodeBareFinal_KittyVisible_KpBeginConsumesWithoutEvent()
+    {
+        var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
+            'E',
+            kittyReportAllKeysVisible: true,
+            out var inputEvent);
+
+        Assert.True(decoded);
+        Assert.Null(inputEvent);
+    }
+
+    [Theory]
+    [InlineData('A', +1)]
+    [InlineData('B', -1)]
+    public void TryDecodeBareFinal_KittyInactive_VerticalArrowReturnsMouseScroll(char final, int expectedDelta)
+    {
+        var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
+            final,
+            kittyReportAllKeysVisible: false,
+            out var inputEvent);
+
+        Assert.True(decoded);
+        var scroll = Assert.IsType<MouseScrollEvent>(inputEvent);
+        Assert.Equal(expectedDelta, scroll.Delta);
+    }
+
+    [Theory]
+    [InlineData('C')]
+    [InlineData('D')]
+    [InlineData('E')]
+    [InlineData('H')]
+    [InlineData('F')]
+    [InlineData('P')]
+    [InlineData('Q')]
+    [InlineData('R')]
+    [InlineData('S')]
+    public void TryDecodeBareFinal_KittyInactive_OtherFunctionalFinalConsumesWithoutEvent(char final)
+    {
+        var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
+            final,
+            kittyReportAllKeysVisible: false,
+            out var inputEvent);
+
+        Assert.True(decoded);
+        Assert.Null(inputEvent);
+    }
+
+    [Theory]
+    [InlineData('~')]
+    [InlineData('u')]
+    [InlineData('x')]
+    public void TryDecodeBareFinal_NonFunctionalFinal_ReturnsFalse(char final)
+    {
+        var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
+            final,
+            kittyReportAllKeysVisible: true,
+            out var inputEvent);
+
+        Assert.False(decoded);
+        Assert.Null(inputEvent);
+    }
+}


### PR DESCRIPTION
## Summary
- extract bare CSI functional final decoding into a focused internal decoder
- preserve kitty-visible keyboard routing and kitty-inactive alternate-scroll behavior
- keep parser ordering and exact two-byte bare CSI gate in EscapeSequenceParser

Refs #240
Refs #242

## Tests
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"