### PR TITLE
Extract kitty second-form keyboard decoder

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -255,7 +255,7 @@ internal sealed class EscapeSequenceParser
                 // disambiguate (bit 1) or report_all_keys (bit 8) flag is set.
                 if (CsiFunctionalDecoder.IsFunctionalFinal(key.KeyChar) && seq.Length >= 3 && seq[1] != '<')
                 {
-                    if (TryParseKittySecondForm(seq, out var keyEvent) && keyEvent is not null)
+                    if (KittySecondFormKeyboardDecoder.TryDecode(seq, out var keyEvent) && keyEvent is not null)
                     {
                         TerminaTrace.Input.Debug(this, "ESP: kitty second-form {0} → {1}", seq, keyEvent);
                         results.Add(keyEvent);
@@ -367,55 +367,6 @@ internal sealed class EscapeSequenceParser
             return true;
 
         return false;
-    }
-
-    /// <summary>
-    /// Attempts to parse a kitty keyboard "second form" sequence: <c>[1;modifiers[:event] final</c>
-    /// where <c>final</c> is one of <c>A B C D E F H P Q R S</c>.
-    /// </summary>
-    /// <param name="seq">The buffered sequence string, e.g. <c>[1;5A</c> or <c>[1;2:1A</c>.</param>
-    /// <param name="result">
-    /// On <c>true</c> return: the resulting <see cref="KeyPressed"/> when this was a press event,
-    /// or <c>null</c> when a repeat/release event was parsed and intentionally swallowed.
-    /// </param>
-    /// <returns>
-    /// <c>true</c> if the sequence was recognized (whether or not an event is produced).
-    /// </returns>
-    private static bool TryParseKittySecondForm(string seq, out KeyPressed? result)
-    {
-        result = null;
-        if (seq.Length < 3 || seq[0] != '[') return false;
-        var final = seq[^1];
-        var key = CsiFunctionalDecoder.FinalToKey(final);
-        if (key == ConsoleKey.None) return false;
-
-        // Strip leading '[' and trailing final → "1;modifiers[:event]"
-        var inner = seq[1..^1];
-        var semicolon = inner.IndexOf(';');
-        if (semicolon < 0) return false;
-
-        // First field must be "1" for the second form.
-        if (inner[..semicolon] != "1") return false;
-        var rest = inner[(semicolon + 1)..];
-
-        // Parse modifiers and optional event-type subfield.
-        var colon = rest.IndexOf(':');
-        var modPart = colon < 0 ? rest : rest[..colon];
-        if (!int.TryParse(modPart, out var modValue) || modValue < 1) return false;
-
-        // Event type: 1 = press (default), 2 = repeat, 3 = release. Only emit press events.
-        if (colon >= 0)
-        {
-            if (!int.TryParse(rest[(colon + 1)..], out var eventType)) return false;
-            if (eventType != 1) return true; // parsed-and-swallowed; result stays null
-        }
-
-        var modBits = modValue - 1;
-        var shift = (modBits & 1) != 0;
-        var alt = (modBits & 2) != 0;
-        var ctrl = (modBits & 4) != 0;
-        result = new KeyPressed(new ConsoleKeyInfo('\0', key, shift, alt, ctrl));
-        return true;
     }
 
     /// <summary>

--- a/src/Termina/Input/KittySecondFormKeyboardDecoder.cs
+++ b/src/Termina/Input/KittySecondFormKeyboardDecoder.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Decodes kitty keyboard protocol second-form CSI keyboard sequences.
+/// </summary>
+internal static class KittySecondFormKeyboardDecoder
+{
+    /// <summary>
+    /// Attempts to parse <c>[1;modifiers[:event] final</c>.
+    /// </summary>
+    /// <param name="sequence">The buffered sequence string, e.g. <c>[1;5A</c> or <c>[1;2:1A</c>.</param>
+    /// <param name="result">
+    /// On <c>true</c> return: the resulting <see cref="KeyPressed"/> when this was a press event,
+    /// or <c>null</c> when a repeat/release event was parsed and intentionally swallowed.
+    /// </param>
+    /// <returns><c>true</c> if the sequence was recognized, whether or not an event is produced.</returns>
+    public static bool TryDecode(string sequence, out KeyPressed? result)
+    {
+        result = null;
+        if (sequence.Length < 3 || sequence[0] != '[')
+            return false;
+
+        var final = sequence[^1];
+        var key = CsiFunctionalDecoder.FinalToKey(final);
+        if (key == ConsoleKey.None)
+            return false;
+
+        var inner = sequence[1..^1];
+        var semicolon = inner.IndexOf(';');
+        if (semicolon < 0)
+            return false;
+
+        if (inner[..semicolon] != "1")
+            return false;
+
+        var rest = inner[(semicolon + 1)..];
+        var colon = rest.IndexOf(':');
+        var modPart = colon < 0 ? rest : rest[..colon];
+        if (!int.TryParse(modPart, out var modValue) || modValue < 1)
+            return false;
+
+        if (colon >= 0)
+        {
+            if (!int.TryParse(rest[(colon + 1)..], out var eventType))
+                return false;
+
+            if (eventType != 1)
+                return true;
+        }
+
+        var modBits = modValue - 1;
+        var shift = (modBits & 1) != 0;
+        var alt = (modBits & 2) != 0;
+        var ctrl = (modBits & 4) != 0;
+
+        result = new KeyPressed(new ConsoleKeyInfo('\0', key, shift, alt, ctrl));
+        return true;
+    }
+}

--- a/tests/Termina.Tests/Input/KittySecondFormKeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/KittySecondFormKeyboardDecoderTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class KittySecondFormKeyboardDecoderTests
+{
+    [Theory]
+    [InlineData("[1;2A", ConsoleKey.UpArrow, true, false, false)]
+    [InlineData("[1;5B", ConsoleKey.DownArrow, false, false, true)]
+    [InlineData("[1;8A", ConsoleKey.UpArrow, true, true, true)]
+    [InlineData("[1;3C", ConsoleKey.RightArrow, false, true, false)]
+    public void TryDecode_PressSequence_ReturnsKeyPressedWithModifiers(
+        string sequence,
+        ConsoleKey expectedKey,
+        bool shift,
+        bool alt,
+        bool ctrl)
+    {
+        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+
+        Assert.True(decoded);
+        Assert.NotNull(keyEvent);
+        Assert.Equal(expectedKey, keyEvent!.KeyInfo.Key);
+        Assert.Equal('\0', keyEvent.KeyInfo.KeyChar);
+        Assert.Equal(shift, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
+        Assert.Equal(alt, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Alt));
+        Assert.Equal(ctrl, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Fact]
+    public void TryDecode_ExplicitPressEvent_ReturnsKeyPressed()
+    {
+        var decoded = KittySecondFormKeyboardDecoder.TryDecode("[1;1:1A", out var keyEvent);
+
+        Assert.True(decoded);
+        Assert.NotNull(keyEvent);
+        Assert.Equal(ConsoleKey.UpArrow, keyEvent!.KeyInfo.Key);
+    }
+
+    [Theory]
+    [InlineData("[1;1:2A")]
+    [InlineData("[1;1:3A")]
+    public void TryDecode_RepeatOrRelease_ReturnsTrueWithoutEvent(string sequence)
+    {
+        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+
+        Assert.True(decoded);
+        Assert.Null(keyEvent);
+    }
+
+    [Theory]
+    [InlineData("[2;1A")]
+    [InlineData("[1A")]
+    [InlineData("[1;0A")]
+    [InlineData("[1;badA")]
+    [InlineData("[1;1:badA")]
+    [InlineData("[1;1E")]
+    [InlineData("1;1A")]
+    public void TryDecode_UnknownOrMalformedSequence_ReturnsFalse(string sequence)
+    {
+        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+
+        Assert.False(decoded);
+        Assert.Null(keyEvent);
+    }
+}


### PR DESCRIPTION
## Summary
- extract kitty CSI second-form keyboard decoding into a focused internal decoder
- preserve the existing EscapeSequenceParser shape gate and ordering
- add focused decoder tests for modifiers, repeat/release swallowing, and malformed non-matches

Refs #240
Refs #242

## Tests
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"