### PR TITLE
Extract bracketed paste decoder

### DIFF
--- a/src/Termina/Input/BracketedPasteDecoder.cs
+++ b/src/Termina/Input/BracketedPasteDecoder.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Termina.Input;
+
+/// <summary>
+/// Decodes content between bracketed paste start and end sentinels.
+/// </summary>
+internal sealed class BracketedPasteDecoder
+{
+    private const string StartSequence = "[200~";
+    private const string EndSequence = "\x1b[201~";
+
+    private readonly StringBuilder _buffer = new();
+    private int _pendingEndSequencePosition;
+
+    public static bool IsStartSequence(string sequence) => sequence == StartSequence;
+
+    public static bool CouldBeStartSequence(string sequence) =>
+        sequence.Length <= StartSequence.Length && StartSequence.StartsWith(sequence, StringComparison.Ordinal);
+
+    public void Begin()
+    {
+        _buffer.Clear();
+        _pendingEndSequencePosition = 0;
+    }
+
+    public bool TryConsume(ConsoleKeyInfo key, out PasteEvent? pasteEvent)
+    {
+        pasteEvent = null;
+
+        var expectedChar = _pendingEndSequencePosition == 0
+            ? '\x1b'
+            : EndSequence[_pendingEndSequencePosition];
+        var isEscChar = key.Key == ConsoleKey.Escape || key.KeyChar == '\x1b';
+        var charMatches = _pendingEndSequencePosition == 0
+            ? isEscChar
+            : key.KeyChar == expectedChar;
+
+        if (charMatches)
+        {
+            _pendingEndSequencePosition++;
+            if (_pendingEndSequencePosition == EndSequence.Length)
+            {
+                pasteEvent = new PasteEvent(_buffer.ToString());
+                Begin();
+                return true;
+            }
+        }
+        else if (_pendingEndSequencePosition > 0)
+        {
+            _buffer.Append(EndSequence[.._pendingEndSequencePosition]);
+            _pendingEndSequencePosition = 0;
+            _buffer.Append(key.KeyChar);
+        }
+        else
+        {
+            _buffer.Append(key.KeyChar);
+        }
+
+        return false;
+    }
+}

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -48,11 +48,8 @@ internal sealed class EscapeSequenceParser
 
     private State _state = State.Normal;
     private readonly StringBuilder _seqBuffer = new();
-    private readonly StringBuilder _pasteBuffer = new();
+    private readonly BracketedPasteDecoder _pasteDecoder = new();
     private long _escapeReceivedAt;
-    private int _pendingEndSeqPos;
-
-    private const string PasteEndSeq = "\x1b[201~";
 
     // Injected clock for testing; defaults to Environment.TickCount64
     private readonly Func<long> _getTick;
@@ -182,10 +179,9 @@ internal sealed class EscapeSequenceParser
                 var seq = _seqBuffer.ToString();
 
                 // Bracketed paste start: ESC[200~
-                if (seq == "[200~")
+                if (BracketedPasteDecoder.IsStartSequence(seq))
                 {
-                    _pasteBuffer.Clear();
-                    _pendingEndSeqPos = 0;
+                    _pasteDecoder.Begin();
                     _state = State.PasteBuffering;
                     TerminaTrace.Input.Debug(this, "ESP: Paste start detected → PasteBuffering");
                     break;
@@ -306,33 +302,11 @@ internal sealed class EscapeSequenceParser
             }
 
             case State.PasteBuffering:
-                // Detect ESC[201~ end sentinel one character at a time
-                var expectedChar = _pendingEndSeqPos == 0 ? '\x1b' : PasteEndSeq[_pendingEndSeqPos];
-                var isEscChar = key.Key == ConsoleKey.Escape || key.KeyChar == '\x1b';
-                var charMatches = _pendingEndSeqPos == 0 ? isEscChar : key.KeyChar == expectedChar;
-
-                if (charMatches)
+                if (_pasteDecoder.TryConsume(key, out var pasteEvent))
                 {
-                    _pendingEndSeqPos++;
-                    if (_pendingEndSeqPos == PasteEndSeq.Length)
-                    {
-                        TerminaTrace.Input.Debug(this, "ESP: Paste end detected, {0} chars", _pasteBuffer.Length);
-                        results.Add(new PasteEvent(_pasteBuffer.ToString()));
-                        _pasteBuffer.Clear();
-                        _pendingEndSeqPos = 0;
-                        _state = State.Normal;
-                    }
-                }
-                else if (_pendingEndSeqPos > 0)
-                {
-                    // Partial end-sequence match failed — the buffered chars belong to paste content
-                    _pasteBuffer.Append(PasteEndSeq[.._pendingEndSeqPos]);
-                    _pendingEndSeqPos = 0;
-                    _pasteBuffer.Append(key.KeyChar);
-                }
-                else
-                {
-                    _pasteBuffer.Append(key.KeyChar);
+                    TerminaTrace.Input.Debug(this, "ESP: Paste end detected, {0} chars", pasteEvent!.Content.Length);
+                    results.Add(pasteEvent);
+                    _state = State.Normal;
                 }
                 break;
         }
@@ -344,9 +318,7 @@ internal sealed class EscapeSequenceParser
     /// </summary>
     private static bool CouldLeadToRecognizedSequence(string seq)
     {
-        // Could still be paste start "[200~"
-        const string pasteStart = "[200~";
-        if (seq.Length <= pasteStart.Length && pasteStart.StartsWith(seq, StringComparison.Ordinal))
+        if (BracketedPasteDecoder.CouldBeStartSequence(seq))
             return true;
 
         // Complete but still-unrecognized CSI tilde-terminated sequences flush as raw

--- a/tests/Termina.Tests/Input/BracketedPasteDecoderTests.cs
+++ b/tests/Termina.Tests/Input/BracketedPasteDecoderTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class BracketedPasteDecoderTests
+{
+    [Theory]
+    [InlineData("[")]
+    [InlineData("[2")]
+    [InlineData("[20")]
+    [InlineData("[200")]
+    [InlineData("[200~")]
+    public void CouldBeStartSequence_ReturnsTrueForPartialStart(string sequence)
+    {
+        Assert.True(BracketedPasteDecoder.CouldBeStartSequence(sequence));
+    }
+
+    [Theory]
+    [InlineData("[201~")]
+    [InlineData("[20x")]
+    [InlineData("[200~x")]
+    public void CouldBeStartSequence_ReturnsFalseForNonStart(string sequence)
+    {
+        Assert.False(BracketedPasteDecoder.CouldBeStartSequence(sequence));
+    }
+
+    [Fact]
+    public void TryConsume_CompletePaste_ReturnsPasteEvent()
+    {
+        var decoder = new BracketedPasteDecoder();
+        decoder.Begin();
+
+        var completed = Feed(decoder, "hello world\x1b[201~", out var pasteEvent);
+
+        Assert.True(completed);
+        Assert.NotNull(pasteEvent);
+        Assert.Equal("hello world", pasteEvent!.Content);
+    }
+
+    [Fact]
+    public void TryConsume_PreservesFailedPartialEndSentinel()
+    {
+        var decoder = new BracketedPasteDecoder();
+        decoder.Begin();
+
+        var completed = Feed(decoder, "foo\x1b[20xbar\x1b[201~", out var pasteEvent);
+
+        Assert.True(completed);
+        Assert.NotNull(pasteEvent);
+        Assert.Equal("foo\x1b[20xbar", pasteEvent!.Content);
+    }
+
+    [Fact]
+    public void TryConsume_EscapeConsoleKeyStartsEndSentinel()
+    {
+        var decoder = new BracketedPasteDecoder();
+        decoder.Begin();
+
+        Assert.False(decoder.TryConsume(Key('x'), out var pasteEvent));
+        Assert.Null(pasteEvent);
+        Assert.False(decoder.TryConsume(new ConsoleKeyInfo('\0', ConsoleKey.Escape, false, false, false), out pasteEvent));
+        Assert.Null(pasteEvent);
+
+        var completed = Feed(decoder, "[201~", out pasteEvent);
+
+        Assert.True(completed);
+        Assert.NotNull(pasteEvent);
+        Assert.Equal("x", pasteEvent!.Content);
+    }
+
+    private static bool Feed(BracketedPasteDecoder decoder, string input, out PasteEvent? pasteEvent)
+    {
+        foreach (var c in input)
+        {
+            if (decoder.TryConsume(Key(c), out pasteEvent))
+                return true;
+        }
+
+        pasteEvent = null;
+        return false;
+    }
+
+    private static ConsoleKeyInfo Key(char c) => new(c, c == '\x1b' ? ConsoleKey.Escape : ConsoleKey.None, false, false, false);
+}


### PR DESCRIPTION
## Summary
- Extract bracketed paste buffering into `BracketedPasteDecoder`
- Keep `EscapeSequenceParser` responsible for high-level parser state transitions
- Add focused decoder tests for start matching, paste completion, partial end-sentinel preservation, and Escape-key sentinel matching

## Tests
- `dotnet test tests/Termina.Tests/Termina.Tests.csproj --filter FullyQualifiedName~Termina.Tests.Input`
- `dotnet test tests/Termina.Tests/Termina.Tests.csproj`

Refs #242
Refs #243