### PR TITLE
Extract unknown sequence fallback decoder

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -262,13 +262,9 @@ internal sealed class EscapeSequenceParser
                 }
 
                 // If this sequence can no longer match any recognized pattern, flush as raw keys
-                if (!CouldLeadToRecognizedSequence(seq))
+                if (!UnknownSequenceFallbackDecoder.CouldLeadToRecognizedSequence(seq))
                 {
-                    results.Add(new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)));
-                    foreach (var c in seq)
-                    {
-                        results.Add(new KeyPressed(new ConsoleKeyInfo(c, ConsoleKey.None, false, false, false)));
-                    }
+                    UnknownSequenceFallbackDecoder.AppendRawKeyEvents(seq, results);
                     _seqBuffer.Clear();
                     _state = State.Normal;
                 }
@@ -310,35 +306,6 @@ internal sealed class EscapeSequenceParser
                 }
                 break;
         }
-    }
-
-    /// <summary>
-    /// Returns <c>true</c> if the accumulated bracket sequence could still lead to a recognized
-    /// escape sequence. Used to decide whether to keep buffering or flush the sequence as raw keys.
-    /// </summary>
-    private static bool CouldLeadToRecognizedSequence(string seq)
-    {
-        if (BracketedPasteDecoder.CouldBeStartSequence(seq))
-            return true;
-
-        // Complete but still-unrecognized CSI tilde-terminated sequences flush as raw
-        // KeyPressed events rather than keeping the parser stuck in InBracketSequence.
-        if (seq.Length >= 3 && seq[^1] == '~')
-            return false;
-
-        // Could be a CSI u sequence "[keycode;modifiersu" — digits, semicolons, colons, up to ~32 chars
-        if (seq.Length >= 2 && seq.Length <= 32 && (char.IsDigit(seq[1]) || seq[1] == ';' || seq[1] == ':'))
-            return true;
-
-        // Could be an SGR mouse event "[<button;x;yM" — open-ended length up to ~30 chars
-        if (seq.Length >= 2 && seq[1] == '<' && seq.Length <= 30)
-            return true;
-
-        // Could be wheel-as-CSI-arrow under ?1007h: "[A" or "[B" / kitty second-form "[1;NA"
-        if (seq == "[")
-            return true;
-
-        return false;
     }
 
 }

--- a/src/Termina/Input/UnknownSequenceFallbackDecoder.cs
+++ b/src/Termina/Input/UnknownSequenceFallbackDecoder.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Handles incomplete and unrecognized CSI sequences without leaving the parser stuck.
+/// </summary>
+internal static class UnknownSequenceFallbackDecoder
+{
+    /// <summary>
+    /// Returns <c>true</c> if the accumulated bracket sequence could still lead to a recognized
+    /// escape sequence.
+    /// </summary>
+    public static bool CouldLeadToRecognizedSequence(string sequence)
+    {
+        if (BracketedPasteDecoder.CouldBeStartSequence(sequence))
+            return true;
+
+        // Complete but still-unrecognized CSI tilde-terminated sequences flush as raw
+        // KeyPressed events rather than keeping the parser stuck in InBracketSequence.
+        if (sequence.Length >= 3 && sequence[^1] == '~')
+            return false;
+
+        // Could be a CSI u sequence "[keycode;modifiersu".
+        if (sequence.Length >= 2
+            && sequence.Length <= 32
+            && (char.IsDigit(sequence[1]) || sequence[1] == ';' || sequence[1] == ':'))
+            return true;
+
+        // Could be an SGR mouse event "[<button;x;yM".
+        if (sequence.Length >= 2 && sequence[1] == '<' && sequence.Length <= 30)
+            return true;
+
+        // Could still become a bare CSI functional final: "[A" / "[B" etc.
+        if (sequence == "[")
+            return true;
+
+        return false;
+    }
+
+    public static IReadOnlyList<IInputEvent> ToRawKeyEvents(string sequence)
+    {
+        var results = new List<IInputEvent>(sequence.Length + 1);
+        AppendRawKeyEvents(sequence, results);
+        return results;
+    }
+
+    public static void AppendRawKeyEvents(string sequence, List<IInputEvent> results)
+    {
+        results.Add(new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)));
+        foreach (var c in sequence)
+            results.Add(new KeyPressed(new ConsoleKeyInfo(c, ConsoleKey.None, false, false, false)));
+    }
+}

--- a/tests/Termina.Tests/Input/UnknownSequenceFallbackDecoderTests.cs
+++ b/tests/Termina.Tests/Input/UnknownSequenceFallbackDecoderTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class UnknownSequenceFallbackDecoderTests
+{
+    [Theory]
+    [InlineData("[")]
+    [InlineData("[2")]
+    [InlineData("[200")]
+    [InlineData("[13;")]
+    [InlineData("[<64;5")]
+    public void CouldLeadToRecognizedSequence_ReturnsTrueForRecognizedPrefixes(string sequence)
+    {
+        Assert.True(UnknownSequenceFallbackDecoder.CouldLeadToRecognizedSequence(sequence));
+    }
+
+    [Theory]
+    [InlineData("[9~")]
+    [InlineData("[25;5~")]
+    [InlineData("[x")]
+    [InlineData("[?25h")]
+    public void CouldLeadToRecognizedSequence_ReturnsFalseForUnknownCompleteOrInvalidPrefixes(string sequence)
+    {
+        Assert.False(UnknownSequenceFallbackDecoder.CouldLeadToRecognizedSequence(sequence));
+    }
+
+    [Fact]
+    public void ToRawKeyEvents_PrependsEscapeAndFlushesSequenceCharacters()
+    {
+        var events = UnknownSequenceFallbackDecoder.ToRawKeyEvents("[9~");
+
+        Assert.Equal(4, events.Count);
+        AssertKey(events[0], ConsoleKey.Escape, '\x1b');
+        AssertKey(events[1], ConsoleKey.None, '[');
+        AssertKey(events[2], ConsoleKey.None, '9');
+        AssertKey(events[3], ConsoleKey.None, '~');
+    }
+
+    [Fact]
+    public void AppendRawKeyEvents_AppendsWithoutClearingExistingEvents()
+    {
+        var events = new List<IInputEvent>
+        {
+            new KeyPressed(new ConsoleKeyInfo('x', ConsoleKey.X, false, false, false))
+        };
+
+        UnknownSequenceFallbackDecoder.AppendRawKeyEvents("[x", events);
+
+        Assert.Equal(4, events.Count);
+        AssertKey(events[0], ConsoleKey.X, 'x');
+        AssertKey(events[1], ConsoleKey.Escape, '\x1b');
+        AssertKey(events[2], ConsoleKey.None, '[');
+        AssertKey(events[3], ConsoleKey.None, 'x');
+    }
+
+    private static void AssertKey(IInputEvent inputEvent, ConsoleKey key, char keyChar)
+    {
+        var pressed = Assert.IsType<KeyPressed>(inputEvent);
+        Assert.Equal(key, pressed.KeyInfo.Key);
+        Assert.Equal(keyChar, pressed.KeyInfo.KeyChar);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract incomplete/unknown CSI continuation checks into UnknownSequenceFallbackDecoder
- Move raw key fallback emission out of EscapeSequenceParser
- Add focused fallback tests for recognized prefixes, invalid prefixes, and raw key flushing

## Tests
- dotnet test tests/Termina.Tests/Termina.Tests.csproj --filter FullyQualifiedName~Termina.Tests.Input
- dotnet test tests/Termina.Tests/Termina.Tests.csproj

Refs #242
Refs #243
Refs #245