### PR TITLE
Route unknown SS3 fallback through decoder

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -289,9 +289,7 @@ internal sealed class EscapeSequenceParser
                 else
                 {
                     // Unknown SS3 sequence — flush ESC + 'O' + this char as raw keys.
-                    results.Add(new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)));
-                    results.Add(new KeyPressed(new ConsoleKeyInfo('O', ConsoleKey.O, false, false, false)));
-                    results.Add(new KeyPressed(new ConsoleKeyInfo(key.KeyChar, ConsoleKey.None, false, false, false)));
+                    UnknownSequenceFallbackDecoder.AppendRawSs3KeyEvents(key.KeyChar, results);
                 }
                 _state = State.Normal;
                 break;

--- a/src/Termina/Input/UnknownSequenceFallbackDecoder.cs
+++ b/src/Termina/Input/UnknownSequenceFallbackDecoder.cs
@@ -52,4 +52,11 @@ internal static class UnknownSequenceFallbackDecoder
         foreach (var c in sequence)
             results.Add(new KeyPressed(new ConsoleKeyInfo(c, ConsoleKey.None, false, false, false)));
     }
+
+    public static void AppendRawSs3KeyEvents(char final, List<IInputEvent> results)
+    {
+        results.Add(new KeyPressed(new ConsoleKeyInfo('\x1b', ConsoleKey.Escape, false, false, false)));
+        results.Add(new KeyPressed(new ConsoleKeyInfo('O', ConsoleKey.O, false, false, false)));
+        results.Add(new KeyPressed(new ConsoleKeyInfo(final, ConsoleKey.None, false, false, false)));
+    }
 }

--- a/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
@@ -150,6 +150,18 @@ public class EscapeSequenceParserTests
     }
 
     [Fact]
+    public void UnknownSs3Sequence_FlushesAsRawKeys_AndUnsticksParser()
+    {
+        var parser = new EscapeSequenceParser();
+
+        var events = FeedSequence(parser, new[] { EscKey(), Key('O'), Key('Z') });
+
+        Assert.False(parser.IsBufferingEscape);
+        Assert.Equal(3, events.Count);
+        Assert.Equal("\x1bOZ", new string(events.Select(e => ((KeyPressed)e).KeyInfo.KeyChar).ToArray()));
+    }
+
+    [Fact]
     public void SgrMouseClickPress_IsSilentlyConsumed()
     {
         var parser = new EscapeSequenceParser();

--- a/tests/Termina.Tests/Input/UnknownSequenceFallbackDecoderTests.cs
+++ b/tests/Termina.Tests/Input/UnknownSequenceFallbackDecoderTests.cs
@@ -57,6 +57,19 @@ public class UnknownSequenceFallbackDecoderTests
         AssertKey(events[3], ConsoleKey.None, 'x');
     }
 
+    [Fact]
+    public void AppendRawSs3KeyEvents_FlushesEscapeOAndFinal()
+    {
+        var events = new List<IInputEvent>();
+
+        UnknownSequenceFallbackDecoder.AppendRawSs3KeyEvents('Z', events);
+
+        Assert.Equal(3, events.Count);
+        AssertKey(events[0], ConsoleKey.Escape, '\x1b');
+        AssertKey(events[1], ConsoleKey.O, 'O');
+        AssertKey(events[2], ConsoleKey.None, 'Z');
+    }
+
     private static void AssertKey(IInputEvent inputEvent, ConsoleKey key, char keyChar)
     {
         var pressed = Assert.IsType<KeyPressed>(inputEvent);


### PR DESCRIPTION
## Summary
- Route unknown SS3 raw-key fallback through UnknownSequenceFallbackDecoder
- Add focused fallback helper coverage for ESC O final flushing
- Add parser regression coverage for unknown SS3 unstick behavior

## Tests
- dotnet test tests/Termina.Tests/Termina.Tests.csproj --filter FullyQualifiedName~Termina.Tests.Input
- dotnet test tests/Termina.Tests/Termina.Tests.csproj

Refs #242
Refs #245