### PR TITLE
Add terminal mode context for input decoding

### DIFF
--- a/src/Termina/Input/CsiFunctionalDecoder.cs
+++ b/src/Termina/Input/CsiFunctionalDecoder.cs
@@ -13,7 +13,7 @@ internal static class CsiFunctionalDecoder
     /// </summary>
     public static bool TryDecodeBareFinal(
         char final,
-        bool kittyReportAllKeysVisible,
+        TerminalModeContext context,
         out IInputEvent? result)
     {
         result = null;
@@ -21,7 +21,7 @@ internal static class CsiFunctionalDecoder
         if (!IsFunctionalFinal(final))
             return false;
 
-        if (kittyReportAllKeysVisible)
+        if (context.KittyReportAllKeysVisible)
         {
             var key = FinalToKey(final);
             if (key != ConsoleKey.None)

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -49,6 +49,7 @@ internal sealed class EscapeSequenceParser
     private State _state = State.Normal;
     private readonly StringBuilder _seqBuffer = new();
     private readonly BracketedPasteDecoder _pasteDecoder = new();
+    private TerminalModeContext _modeContext = TerminalModeContext.Default;
     private long _escapeReceivedAt;
 
     // Injected clock for testing; defaults to Environment.TickCount64
@@ -70,7 +71,11 @@ internal sealed class EscapeSequenceParser
     /// bare-CSI-arrow shape to <see cref="KeyPressed"/> (treating any matching SS3 as the wheel
     /// path instead — handled in <see cref="State.InSs3Sequence"/>).
     /// </remarks>
-    public bool KittyReportAllKeysVisible { get; set; }
+    public bool KittyReportAllKeysVisible
+    {
+        get => _modeContext.KittyReportAllKeysVisible;
+        set => _modeContext = _modeContext with { KittyReportAllKeysVisible = value };
+    }
 
     /// <summary>
     /// Creates a parser using the system clock.
@@ -236,7 +241,7 @@ internal sealed class EscapeSequenceParser
                 {
                     if (CsiFunctionalDecoder.TryDecodeBareFinal(
                             key.KeyChar,
-                            KittyReportAllKeysVisible,
+                            _modeContext,
                             out var functionalEvent)
                         && functionalEvent is not null)
                         results.Add(functionalEvent);
@@ -280,7 +285,7 @@ internal sealed class EscapeSequenceParser
                 // arrive via the kitty CSI-u / second-form path instead, so any remaining
                 // SS3 OA/OB at this point must be the ?1007h wheel emission under DECCKM on.
                 // (SS3 OC/OD never come from the wheel — there is no horizontal wheel.)
-                if (Ss3KeyboardDecoder.TryDecode(key.KeyChar, KittyReportAllKeysVisible, out var ss3Event))
+                if (Ss3KeyboardDecoder.TryDecode(key.KeyChar, _modeContext, out var ss3Event))
                 {
                     TerminaTrace.Input.Debug(this, "ESP: SS3 O{0} → {1}", key.KeyChar, ss3Event);
                     if (ss3Event is not null)

--- a/src/Termina/Input/PlatformInputSource.cs
+++ b/src/Termina/Input/PlatformInputSource.cs
@@ -38,7 +38,7 @@ public sealed class PlatformInputSource : IInputSource
     {
         _console = console ?? throw new ArgumentNullException(nameof(console));
         _pipeline = new TerminalInputPipeline(
-            kittyReportAllKeysVisible: configuration.KittyReportAllKeysVisible);
+            new TerminalModeContext(configuration.KittyReportAllKeysVisible));
     }
 
     /// <inheritdoc />

--- a/src/Termina/Input/Ss3KeyboardDecoder.cs
+++ b/src/Termina/Input/Ss3KeyboardDecoder.cs
@@ -11,11 +11,11 @@ internal static class Ss3KeyboardDecoder
     /// <summary>
     /// Attempts to decode the final byte from an SS3 sequence.
     /// </summary>
-    public static bool TryDecode(char final, bool kittyReportAllKeysVisible, out IInputEvent? result)
+    public static bool TryDecode(char final, TerminalModeContext context, out IInputEvent? result)
     {
         result = null;
 
-        if (kittyReportAllKeysVisible && final is 'A' or 'B')
+        if (context.KittyReportAllKeysVisible && final is 'A' or 'B')
         {
             result = new MouseScrollEvent(final == 'A' ? +1 : -1);
             return true;

--- a/src/Termina/Input/TerminalInputPipeline.cs
+++ b/src/Termina/Input/TerminalInputPipeline.cs
@@ -15,10 +15,15 @@ internal sealed class TerminalInputPipeline
     private readonly EscapeSequenceParser _parser;
 
     public TerminalInputPipeline(bool kittyReportAllKeysVisible = false, Func<long>? getTick = null)
+        : this(new TerminalModeContext(kittyReportAllKeysVisible), getTick)
+    {
+    }
+
+    public TerminalInputPipeline(TerminalModeContext modeContext, Func<long>? getTick = null)
     {
         _parser = new EscapeSequenceParser(getTick)
         {
-            KittyReportAllKeysVisible = kittyReportAllKeysVisible,
+            KittyReportAllKeysVisible = modeContext.KittyReportAllKeysVisible,
         };
     }
 

--- a/src/Termina/Input/TerminalModeContext.cs
+++ b/src/Termina/Input/TerminalModeContext.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Captures terminal mode state needed to disambiguate input sequences.
+/// </summary>
+internal readonly record struct TerminalModeContext(bool KittyReportAllKeysVisible)
+{
+    public static TerminalModeContext Default { get; } = new(false);
+}

--- a/tests/Termina.Tests/Input/CsiFunctionalDecoderTests.cs
+++ b/tests/Termina.Tests/Input/CsiFunctionalDecoderTests.cs
@@ -22,7 +22,7 @@ public class CsiFunctionalDecoderTests
     {
         var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
             final,
-            kittyReportAllKeysVisible: true,
+            Context(kittyReportAllKeysVisible: true),
             out var inputEvent);
 
         Assert.True(decoded);
@@ -36,7 +36,7 @@ public class CsiFunctionalDecoderTests
     {
         var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
             'E',
-            kittyReportAllKeysVisible: true,
+            Context(kittyReportAllKeysVisible: true),
             out var inputEvent);
 
         Assert.True(decoded);
@@ -50,7 +50,7 @@ public class CsiFunctionalDecoderTests
     {
         var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
             final,
-            kittyReportAllKeysVisible: false,
+            Context(kittyReportAllKeysVisible: false),
             out var inputEvent);
 
         Assert.True(decoded);
@@ -72,7 +72,7 @@ public class CsiFunctionalDecoderTests
     {
         var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
             final,
-            kittyReportAllKeysVisible: false,
+            Context(kittyReportAllKeysVisible: false),
             out var inputEvent);
 
         Assert.True(decoded);
@@ -87,10 +87,13 @@ public class CsiFunctionalDecoderTests
     {
         var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
             final,
-            kittyReportAllKeysVisible: true,
+            Context(kittyReportAllKeysVisible: true),
             out var inputEvent);
 
         Assert.False(decoded);
         Assert.Null(inputEvent);
     }
+
+    private static TerminalModeContext Context(bool kittyReportAllKeysVisible) =>
+        new(kittyReportAllKeysVisible);
 }

--- a/tests/Termina.Tests/Input/Ss3KeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/Ss3KeyboardDecoderTests.cs
@@ -22,7 +22,7 @@ public class Ss3KeyboardDecoderTests
     {
         var decoded = Ss3KeyboardDecoder.TryDecode(
             final,
-            kittyReportAllKeysVisible: false,
+            Context(kittyReportAllKeysVisible: false),
             out var inputEvent);
 
         Assert.True(decoded);
@@ -38,7 +38,7 @@ public class Ss3KeyboardDecoderTests
     {
         var decoded = Ss3KeyboardDecoder.TryDecode(
             final,
-            kittyReportAllKeysVisible: true,
+            Context(kittyReportAllKeysVisible: true),
             out var inputEvent);
 
         Assert.True(decoded);
@@ -53,7 +53,7 @@ public class Ss3KeyboardDecoderTests
     {
         var decoded = Ss3KeyboardDecoder.TryDecode(
             final,
-            kittyReportAllKeysVisible: true,
+            Context(kittyReportAllKeysVisible: true),
             out var inputEvent);
 
         Assert.True(decoded);
@@ -68,10 +68,13 @@ public class Ss3KeyboardDecoderTests
     {
         var decoded = Ss3KeyboardDecoder.TryDecode(
             final,
-            kittyReportAllKeysVisible: false,
+            Context(kittyReportAllKeysVisible: false),
             out var inputEvent);
 
         Assert.False(decoded);
         Assert.Null(inputEvent);
     }
+
+    private static TerminalModeContext Context(bool kittyReportAllKeysVisible) =>
+        new(kittyReportAllKeysVisible);
 }

--- a/tests/Termina.Tests/Input/TerminalInputPipelineTests.cs
+++ b/tests/Termina.Tests/Input/TerminalInputPipelineTests.cs
@@ -43,6 +43,17 @@ public class TerminalInputPipelineTests
     }
 
     [Fact]
+    public void TerminalModeContext_RoutesBareCsiArrowAsKey()
+    {
+        var pipeline = new TerminalInputPipeline(new TerminalModeContext(KittyReportAllKeysVisible: true));
+
+        var events = FeedString(pipeline, "\x1b[A");
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.UpArrow, pressed.KeyInfo.Key);
+    }
+
+    [Fact]
     public void CheckEscapeTimeout_FlushesStandaloneEscape()
     {
         var tick = 0L;

--- a/tests/Termina.Tests/Input/TerminalModeContextTests.cs
+++ b/tests/Termina.Tests/Input/TerminalModeContextTests.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class TerminalModeContextTests
+{
+    [Fact]
+    public void Default_HasNoModeFlagsEnabled()
+    {
+        Assert.False(TerminalModeContext.Default.KittyReportAllKeysVisible);
+    }
+}


### PR DESCRIPTION
## Summary
- Add internal TerminalModeContext for mode-dependent input decoding
- Route CSI functional and SS3 decoder calls through the context instead of raw booleans
- Keep existing bool-based pipeline constructor as a compatibility shim for current internal callers

## Tests
- dotnet test tests/Termina.Tests/Termina.Tests.csproj --filter FullyQualifiedName~Termina.Tests.Input
- dotnet test tests/Termina.Tests/Termina.Tests.csproj

Refs #242