### PR TITLE
Add input sequence for buffered decoders

### DIFF
--- a/src/Termina/Input/BracketedPasteDecoder.cs
+++ b/src/Termina/Input/BracketedPasteDecoder.cs
@@ -16,10 +16,10 @@ internal sealed class BracketedPasteDecoder
     private readonly StringBuilder _buffer = new();
     private int _pendingEndSequencePosition;
 
-    public static bool IsStartSequence(string sequence) => sequence == StartSequence;
+    public static bool IsStartSequence(InputSequence sequence) => sequence.Text == StartSequence;
 
-    public static bool CouldBeStartSequence(string sequence) =>
-        sequence.Length <= StartSequence.Length && StartSequence.StartsWith(sequence, StringComparison.Ordinal);
+    public static bool CouldBeStartSequence(InputSequence sequence) =>
+        sequence.Length <= StartSequence.Length && StartSequence.StartsWith(sequence.Text, StringComparison.Ordinal);
 
     public void Begin()
     {

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -181,7 +181,7 @@ internal sealed class EscapeSequenceParser
 
             case State.InBracketSequence:
                 _seqBuffer.Append(key.KeyChar);
-                var seq = _seqBuffer.ToString();
+                var seq = new InputSequence(_seqBuffer.ToString());
 
                 // Bracketed paste start: ESC[200~
                 if (BracketedPasteDecoder.IsStartSequence(seq))
@@ -198,7 +198,7 @@ internal sealed class EscapeSequenceParser
                     && LegacyCsiKeyboardDecoder.TryDecode(seq, out var legacyKeyEvent)
                     && legacyKeyEvent is not null)
                 {
-                    TerminaTrace.Input.Debug(this, "ESP: legacy CSI tilde {0} → {1}", seq, legacyKeyEvent);
+                    TerminaTrace.Input.Debug(this, "ESP: legacy CSI tilde {0} → {1}", seq.Text, legacyKeyEvent);
                     results.Add(legacyKeyEvent);
                     _seqBuffer.Clear();
                     _state = State.Normal;
@@ -210,7 +210,7 @@ internal sealed class EscapeSequenceParser
                 {
                     if (KittyCsiUKeyboardDecoder.TryDecode(seq, out var csiEvent) && csiEvent is not null)
                     {
-                        TerminaTrace.Input.Debug(this, "ESP: CSI u detected: {0}", seq);
+                        TerminaTrace.Input.Debug(this, "ESP: CSI u detected: {0}", seq.Text);
                         results.Add(csiEvent);
                     }
                     _seqBuffer.Clear();
@@ -258,7 +258,7 @@ internal sealed class EscapeSequenceParser
                 {
                     if (KittySecondFormKeyboardDecoder.TryDecode(seq, out var keyEvent) && keyEvent is not null)
                     {
-                        TerminaTrace.Input.Debug(this, "ESP: kitty second-form {0} → {1}", seq, keyEvent);
+                        TerminaTrace.Input.Debug(this, "ESP: kitty second-form {0} → {1}", seq.Text, keyEvent);
                         results.Add(keyEvent);
                     }
                     _seqBuffer.Clear();
@@ -269,7 +269,7 @@ internal sealed class EscapeSequenceParser
                 // If this sequence can no longer match any recognized pattern, flush as raw keys
                 if (!UnknownSequenceFallbackDecoder.CouldLeadToRecognizedSequence(seq))
                 {
-                    UnknownSequenceFallbackDecoder.AppendRawKeyEvents(seq, results);
+                    UnknownSequenceFallbackDecoder.AppendRawKeyEvents(seq.Text, results);
                     _seqBuffer.Clear();
                     _state = State.Normal;
                 }

--- a/src/Termina/Input/InputSequence.cs
+++ b/src/Termina/Input/InputSequence.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Buffered terminal escape-sequence text passed between the tokenizer/parser and decoders.
+/// </summary>
+internal readonly record struct InputSequence
+{
+    private readonly string? _text;
+
+    public InputSequence(string text)
+    {
+        _text = text ?? throw new ArgumentNullException(nameof(text));
+    }
+
+    public string Text => _text ?? string.Empty;
+
+    public int Length => Text.Length;
+
+    public bool IsEmpty => Length == 0;
+
+    public char this[int index] => Text[index];
+
+    public override string ToString() => Text;
+
+    public static implicit operator InputSequence(string text) => new(text);
+}

--- a/src/Termina/Input/KittyCsiUKeyboardDecoder.cs
+++ b/src/Termina/Input/KittyCsiUKeyboardDecoder.cs
@@ -11,17 +11,18 @@ internal static class KittyCsiUKeyboardDecoder
     /// <summary>
     /// Attempts to parse <c>[keycode[;modifiers[:event][;text...]]u</c>.
     /// </summary>
-    /// <param name="sequence">The buffered sequence string, e.g. <c>[13;5u</c>.</param>
+    /// <param name="sequence">The buffered sequence, e.g. <c>[13;5u</c>.</param>
     /// <param name="result">The resulting <see cref="KeyPressed"/> event, if one should be emitted.</param>
     /// <returns><c>true</c> if the sequence was parsed, whether or not an event is produced.</returns>
-    public static bool TryDecode(string sequence, out KeyPressed? result)
+    public static bool TryDecode(InputSequence sequence, out KeyPressed? result)
     {
         result = null;
+        var text = sequence.Text;
 
-        if (sequence.Length < 3 || sequence[0] != '[' || sequence[^1] != 'u')
+        if (text.Length < 3 || text[0] != '[' || text[^1] != 'u')
             return false;
 
-        var inner = sequence[1..^1];
+        var inner = text[1..^1];
         var semicolon = inner.IndexOf(';');
 
         int keycode;

--- a/src/Termina/Input/KittySecondFormKeyboardDecoder.cs
+++ b/src/Termina/Input/KittySecondFormKeyboardDecoder.cs
@@ -11,24 +11,25 @@ internal static class KittySecondFormKeyboardDecoder
     /// <summary>
     /// Attempts to parse <c>[1;modifiers[:event] final</c>.
     /// </summary>
-    /// <param name="sequence">The buffered sequence string, e.g. <c>[1;5A</c> or <c>[1;2:1A</c>.</param>
+    /// <param name="sequence">The buffered sequence, e.g. <c>[1;5A</c> or <c>[1;2:1A</c>.</param>
     /// <param name="result">
     /// On <c>true</c> return: the resulting <see cref="KeyPressed"/> when this was a press event,
     /// or <c>null</c> when a repeat/release event was parsed and intentionally swallowed.
     /// </param>
     /// <returns><c>true</c> if the sequence was recognized, whether or not an event is produced.</returns>
-    public static bool TryDecode(string sequence, out KeyPressed? result)
+    public static bool TryDecode(InputSequence sequence, out KeyPressed? result)
     {
         result = null;
-        if (sequence.Length < 3 || sequence[0] != '[')
+        var text = sequence.Text;
+        if (text.Length < 3 || text[0] != '[')
             return false;
 
-        var final = sequence[^1];
+        var final = text[^1];
         var key = CsiFunctionalDecoder.FinalToKey(final);
         if (key == ConsoleKey.None)
             return false;
 
-        var inner = sequence[1..^1];
+        var inner = text[1..^1];
         var semicolon = inner.IndexOf(';');
         if (semicolon < 0)
             return false;

--- a/src/Termina/Input/LegacyCsiKeyboardDecoder.cs
+++ b/src/Termina/Input/LegacyCsiKeyboardDecoder.cs
@@ -11,13 +11,14 @@ internal static class LegacyCsiKeyboardDecoder
     /// <summary>
     /// Attempts to decode <c>[num~</c> or <c>[num;modifiers~</c> into a keyboard event.
     /// </summary>
-    public static bool TryDecode(string sequence, out KeyPressed? result)
+    public static bool TryDecode(InputSequence sequence, out KeyPressed? result)
     {
         result = null;
-        if (sequence.Length < 3 || sequence[0] != '[' || sequence[^1] != '~')
+        var text = sequence.Text;
+        if (text.Length < 3 || text[0] != '[' || text[^1] != '~')
             return false;
 
-        var inner = sequence[1..^1];
+        var inner = text[1..^1];
         var semicolon = inner.IndexOf(';');
         var keyPart = semicolon < 0 ? inner : inner[..semicolon];
         if (!int.TryParse(keyPart, out var keyCode))

--- a/src/Termina/Input/SgrMouseDecoder.cs
+++ b/src/Termina/Input/SgrMouseDecoder.cs
@@ -15,18 +15,19 @@ internal static class SgrMouseDecoder
     /// <c>true</c> when the sequence is a recognized SGR mouse sequence. Scroll sequences produce
     /// a <see cref="MouseScrollEvent"/>; click, release, and drag sequences are consumed with no event.
     /// </returns>
-    public static bool TryDecode(string sequence, out MouseScrollEvent? result)
+    public static bool TryDecode(InputSequence sequence, out MouseScrollEvent? result)
     {
         result = null;
+        var text = sequence.Text;
 
-        if (sequence.Length < 4 || sequence[0] != '[' || sequence[1] != '<')
+        if (text.Length < 4 || text[0] != '[' || text[1] != '<')
             return false;
 
-        var terminator = sequence[^1];
+        var terminator = text[^1];
         if (terminator is not ('M' or 'm'))
             return false;
 
-        var inner = sequence[2..^1];
+        var inner = text[2..^1];
         var semicolon = inner.IndexOf(';');
         if (semicolon < 0)
             return false;

--- a/src/Termina/Input/UnknownSequenceFallbackDecoder.cs
+++ b/src/Termina/Input/UnknownSequenceFallbackDecoder.cs
@@ -12,28 +12,30 @@ internal static class UnknownSequenceFallbackDecoder
     /// Returns <c>true</c> if the accumulated bracket sequence could still lead to a recognized
     /// escape sequence.
     /// </summary>
-    public static bool CouldLeadToRecognizedSequence(string sequence)
+    public static bool CouldLeadToRecognizedSequence(InputSequence sequence)
     {
+        var text = sequence.Text;
+
         if (BracketedPasteDecoder.CouldBeStartSequence(sequence))
             return true;
 
         // Complete but still-unrecognized CSI tilde-terminated sequences flush as raw
         // KeyPressed events rather than keeping the parser stuck in InBracketSequence.
-        if (sequence.Length >= 3 && sequence[^1] == '~')
+        if (text.Length >= 3 && text[^1] == '~')
             return false;
 
         // Could be a CSI u sequence "[keycode;modifiersu".
-        if (sequence.Length >= 2
-            && sequence.Length <= 32
-            && (char.IsDigit(sequence[1]) || sequence[1] == ';' || sequence[1] == ':'))
+        if (text.Length >= 2
+            && text.Length <= 32
+            && (char.IsDigit(text[1]) || text[1] == ';' || text[1] == ':'))
             return true;
 
         // Could be an SGR mouse event "[<button;x;yM".
-        if (sequence.Length >= 2 && sequence[1] == '<' && sequence.Length <= 30)
+        if (text.Length >= 2 && text[1] == '<' && text.Length <= 30)
             return true;
 
         // Could still become a bare CSI functional final: "[A" / "[B" etc.
-        if (sequence == "[")
+        if (text == "[")
             return true;
 
         return false;

--- a/tests/Termina.Tests/Input/InputSequenceTests.cs
+++ b/tests/Termina.Tests/Input/InputSequenceTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Input;
+
+namespace Termina.Tests.Input;
+
+public class InputSequenceTests
+{
+    [Fact]
+    public void Constructor_CapturesTextAndLength()
+    {
+        var sequence = new InputSequence("[13;5u");
+
+        Assert.Equal("[13;5u", sequence.Text);
+        Assert.Equal(6, sequence.Length);
+        Assert.Equal('[', sequence[0]);
+        Assert.False(sequence.IsEmpty);
+        Assert.Equal("[13;5u", sequence.ToString());
+    }
+
+    [Fact]
+    public void EmptyText_IsEmpty()
+    {
+        var sequence = new InputSequence(string.Empty);
+
+        Assert.True(sequence.IsEmpty);
+        Assert.Equal(0, sequence.Length);
+    }
+
+    [Fact]
+    public void Default_IsEmpty()
+    {
+        var sequence = default(InputSequence);
+
+        Assert.True(sequence.IsEmpty);
+        Assert.Equal(string.Empty, sequence.Text);
+        Assert.Equal(string.Empty, sequence.ToString());
+    }
+
+    [Fact]
+    public void Constructor_RejectsNullText()
+    {
+        Assert.Throws<ArgumentNullException>(() => new InputSequence(null!));
+    }
+}


### PR DESCRIPTION
## Summary
- Add internal InputSequence value type for buffered escape-sequence text
- Route buffered parser-to-decoder calls through InputSequence
- Preserve string-friendly decoder tests via implicit conversion and add InputSequence coverage

## Tests
- dotnet test tests/Termina.Tests/Termina.Tests.csproj --filter FullyQualifiedName~Termina.Tests.Input
- dotnet test tests/Termina.Tests/Termina.Tests.csproj

Refs #242