### PR TITLE
Route bracketed paste through semantic input

### DIFF
--- a/src/Termina/Input/BracketedPasteDecoder.cs
+++ b/src/Termina/Input/BracketedPasteDecoder.cs
@@ -27,9 +27,9 @@ internal sealed class BracketedPasteDecoder
         _pendingEndSequencePosition = 0;
     }
 
-    public bool TryConsume(ConsoleKeyInfo key, out PasteEvent? pasteEvent)
+    public bool TryConsume(ConsoleKeyInfo key, out PasteInput? pasteInput)
     {
-        pasteEvent = null;
+        pasteInput = null;
 
         var expectedChar = _pendingEndSequencePosition == 0
             ? '\x1b'
@@ -44,7 +44,7 @@ internal sealed class BracketedPasteDecoder
             _pendingEndSequencePosition++;
             if (_pendingEndSequencePosition == EndSequence.Length)
             {
-                pasteEvent = new PasteEvent(_buffer.ToString());
+                pasteInput = new PasteInput(_buffer.ToString());
                 Begin();
                 return true;
             }

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -301,10 +301,10 @@ internal sealed class EscapeSequenceParser
             }
 
             case State.PasteBuffering:
-                if (_pasteDecoder.TryConsume(key, out var pasteEvent))
+                if (_pasteDecoder.TryConsume(key, out var pasteInput))
                 {
-                    TerminaTrace.Input.Debug(this, "ESP: Paste end detected, {0} chars", pasteEvent!.Content.Length);
-                    results.Add(pasteEvent);
+                    TerminaTrace.Input.Debug(this, "ESP: Paste end detected, {0} chars", pasteInput!.Text.Length);
+                    results.AddRange(PublicInputEventAdapter.Adapt(pasteInput));
                     _state = State.Normal;
                 }
                 break;

--- a/tests/Termina.Tests/Input/BracketedPasteDecoderTests.cs
+++ b/tests/Termina.Tests/Input/BracketedPasteDecoderTests.cs
@@ -28,16 +28,16 @@ public class BracketedPasteDecoderTests
     }
 
     [Fact]
-    public void TryConsume_CompletePaste_ReturnsPasteEvent()
+    public void TryConsume_CompletePaste_ReturnsPasteInput()
     {
         var decoder = new BracketedPasteDecoder();
         decoder.Begin();
 
-        var completed = Feed(decoder, "hello world\x1b[201~", out var pasteEvent);
+        var completed = Feed(decoder, "hello world\x1b[201~", out var pasteInput);
 
         Assert.True(completed);
-        Assert.NotNull(pasteEvent);
-        Assert.Equal("hello world", pasteEvent!.Content);
+        Assert.NotNull(pasteInput);
+        Assert.Equal("hello world", pasteInput!.Text);
     }
 
     [Fact]
@@ -46,11 +46,11 @@ public class BracketedPasteDecoderTests
         var decoder = new BracketedPasteDecoder();
         decoder.Begin();
 
-        var completed = Feed(decoder, "foo\x1b[20xbar\x1b[201~", out var pasteEvent);
+        var completed = Feed(decoder, "foo\x1b[20xbar\x1b[201~", out var pasteInput);
 
         Assert.True(completed);
-        Assert.NotNull(pasteEvent);
-        Assert.Equal("foo\x1b[20xbar", pasteEvent!.Content);
+        Assert.NotNull(pasteInput);
+        Assert.Equal("foo\x1b[20xbar", pasteInput!.Text);
     }
 
     [Fact]
@@ -59,27 +59,27 @@ public class BracketedPasteDecoderTests
         var decoder = new BracketedPasteDecoder();
         decoder.Begin();
 
-        Assert.False(decoder.TryConsume(Key('x'), out var pasteEvent));
-        Assert.Null(pasteEvent);
-        Assert.False(decoder.TryConsume(new ConsoleKeyInfo('\0', ConsoleKey.Escape, false, false, false), out pasteEvent));
-        Assert.Null(pasteEvent);
+        Assert.False(decoder.TryConsume(Key('x'), out var pasteInput));
+        Assert.Null(pasteInput);
+        Assert.False(decoder.TryConsume(new ConsoleKeyInfo('\0', ConsoleKey.Escape, false, false, false), out pasteInput));
+        Assert.Null(pasteInput);
 
-        var completed = Feed(decoder, "[201~", out pasteEvent);
+        var completed = Feed(decoder, "[201~", out pasteInput);
 
         Assert.True(completed);
-        Assert.NotNull(pasteEvent);
-        Assert.Equal("x", pasteEvent!.Content);
+        Assert.NotNull(pasteInput);
+        Assert.Equal("x", pasteInput!.Text);
     }
 
-    private static bool Feed(BracketedPasteDecoder decoder, string input, out PasteEvent? pasteEvent)
+    private static bool Feed(BracketedPasteDecoder decoder, string input, out PasteInput? pasteInput)
     {
         foreach (var c in input)
         {
-            if (decoder.TryConsume(Key(c), out pasteEvent))
+            if (decoder.TryConsume(Key(c), out pasteInput))
                 return true;
         }
 
-        pasteEvent = null;
+        pasteInput = null;
         return false;
     }
 


### PR DESCRIPTION
## Summary
- Make BracketedPasteDecoder emit internal PasteInput instead of public PasteEvent
- Adapt PasteInput back to the current public input surface inside EscapeSequenceParser
- Preserve bracketed paste public behavior and update focused decoder tests

## Tests
- dotnet test tests/Termina.Tests/Termina.Tests.csproj --filter FullyQualifiedName~Termina.Tests.Input
- dotnet test tests/Termina.Tests/Termina.Tests.csproj

Refs #242