### PR TITLE
Route SGR mouse through semantic input

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -221,8 +221,8 @@ internal sealed class EscapeSequenceParser
                 // SGR mouse event: ESC[<button;x;yM (press) or ESC[<button;x;ym (release)
                 if (seq.Length >= 2 && seq[1] == '<' && (key.KeyChar == 'M' || key.KeyChar == 'm'))
                 {
-                    if (SgrMouseDecoder.TryDecode(seq, out var mouseEvent) && mouseEvent is not null)
-                        results.Add(mouseEvent);
+                    if (SgrMouseDecoder.TryDecode(seq, out var pointerInput) && pointerInput is not null)
+                        results.AddRange(PublicInputEventAdapter.Adapt(pointerInput));
 
                     _seqBuffer.Clear();
                     _state = State.Normal;

--- a/src/Termina/Input/SgrMouseDecoder.cs
+++ b/src/Termina/Input/SgrMouseDecoder.cs
@@ -13,9 +13,9 @@ internal static class SgrMouseDecoder
     /// </summary>
     /// <returns>
     /// <c>true</c> when the sequence is a recognized SGR mouse sequence. Scroll sequences produce
-    /// a <see cref="MouseScrollEvent"/>; click, release, and drag sequences are consumed with no event.
+    /// a <see cref="PointerInput"/>; click, release, and drag sequences are consumed with no event.
     /// </returns>
-    public static bool TryDecode(InputSequence sequence, out MouseScrollEvent? result)
+    public static bool TryDecode(InputSequence sequence, out PointerInput? result)
     {
         result = null;
         var text = sequence.Text;
@@ -35,13 +35,27 @@ internal static class SgrMouseDecoder
         if (!int.TryParse(inner[..semicolon], out var button))
             return false;
 
+        var (x, y) = ParseCoordinates(inner[(semicolon + 1)..]);
+
         result = button switch
         {
-            64 => new MouseScrollEvent(+1),
-            65 => new MouseScrollEvent(-1),
+            64 => new PointerInput(PointerAction.Wheel, x, y, MouseButton.WheelUp),
+            65 => new PointerInput(PointerAction.Wheel, x, y, MouseButton.WheelDown),
             _ => null,
         };
 
         return true;
+    }
+
+    private static (int X, int Y) ParseCoordinates(string coordinateText)
+    {
+        var semicolon = coordinateText.IndexOf(';');
+        if (semicolon < 0)
+            return (0, 0);
+
+        return int.TryParse(coordinateText[..semicolon], out var x)
+            && int.TryParse(coordinateText[(semicolon + 1)..], out var y)
+            ? (x, y)
+            : (0, 0);
     }
 }

--- a/tests/Termina.Tests/Input/SgrMouseDecoderTests.cs
+++ b/tests/Termina.Tests/Input/SgrMouseDecoderTests.cs
@@ -8,16 +8,23 @@ namespace Termina.Tests.Input;
 public class SgrMouseDecoderTests
 {
     [Theory]
-    [InlineData("[<64;5;10M", +1)]
-    [InlineData("[<65;5;10M", -1)]
-    [InlineData("[<64;200;50M", +1)]
-    public void TryDecode_ScrollSequence_ReturnsMouseScrollEvent(string sequence, int expectedDelta)
+    [InlineData("[<64;5;10M", MouseButton.WheelUp, 5, 10)]
+    [InlineData("[<65;5;10M", MouseButton.WheelDown, 5, 10)]
+    [InlineData("[<64;200;50M", MouseButton.WheelUp, 200, 50)]
+    public void TryDecode_ScrollSequence_ReturnsPointerInput(
+        string sequence,
+        MouseButton expectedButton,
+        int expectedX,
+        int expectedY)
     {
-        var decoded = SgrMouseDecoder.TryDecode(sequence, out var mouseEvent);
+        var decoded = SgrMouseDecoder.TryDecode(sequence, out var pointerInput);
 
         Assert.True(decoded);
-        Assert.NotNull(mouseEvent);
-        Assert.Equal(expectedDelta, mouseEvent!.Delta);
+        Assert.NotNull(pointerInput);
+        Assert.Equal(PointerAction.Wheel, pointerInput!.Action);
+        Assert.Equal(expectedButton, pointerInput.Button);
+        Assert.Equal(expectedX, pointerInput.X);
+        Assert.Equal(expectedY, pointerInput.Y);
     }
 
     [Theory]
@@ -26,10 +33,10 @@ public class SgrMouseDecoderTests
     [InlineData("[<2;10;20M")]
     public void TryDecode_NonScrollMouseSequence_ReturnsTrueWithoutEvent(string sequence)
     {
-        var decoded = SgrMouseDecoder.TryDecode(sequence, out var mouseEvent);
+        var decoded = SgrMouseDecoder.TryDecode(sequence, out var pointerInput);
 
         Assert.True(decoded);
-        Assert.Null(mouseEvent);
+        Assert.Null(pointerInput);
     }
 
     [Theory]
@@ -39,9 +46,9 @@ public class SgrMouseDecoderTests
     [InlineData("[<64;5;10~")]
     public void TryDecode_NonSgrMouseSequence_ReturnsFalse(string sequence)
     {
-        var decoded = SgrMouseDecoder.TryDecode(sequence, out var mouseEvent);
+        var decoded = SgrMouseDecoder.TryDecode(sequence, out var pointerInput);
 
         Assert.False(decoded);
-        Assert.Null(mouseEvent);
+        Assert.Null(pointerInput);
     }
 }


### PR DESCRIPTION
## Summary
- route SGR mouse wheel decoding through internal PointerInput
- adapt decoded pointer wheel events back to public MouseScrollEvent output
- update focused SGR mouse decoder tests to assert semantic pointer data

## Testing
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"