### PR TITLE
Route SS3 input through semantic input

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -285,11 +285,11 @@ internal sealed class EscapeSequenceParser
                 // arrive via the kitty CSI-u / second-form path instead, so any remaining
                 // SS3 OA/OB at this point must be the ?1007h wheel emission under DECCKM on.
                 // (SS3 OC/OD never come from the wheel — there is no horizontal wheel.)
-                if (Ss3KeyboardDecoder.TryDecode(key.KeyChar, _modeContext, out var ss3Event))
+                if (Ss3KeyboardDecoder.TryDecode(key.KeyChar, _modeContext, out var ss3Input))
                 {
-                    TerminaTrace.Input.Debug(this, "ESP: SS3 O{0} → {1}", key.KeyChar, ss3Event);
-                    if (ss3Event is not null)
-                        results.Add(ss3Event);
+                    TerminaTrace.Input.Debug(this, "ESP: SS3 O{0} → {1}", key.KeyChar, ss3Input);
+                    if (ss3Input is not null)
+                        results.AddRange(PublicInputEventAdapter.Adapt(ss3Input));
                 }
                 else
                 {

--- a/src/Termina/Input/Ss3KeyboardDecoder.cs
+++ b/src/Termina/Input/Ss3KeyboardDecoder.cs
@@ -11,35 +11,39 @@ internal static class Ss3KeyboardDecoder
     /// <summary>
     /// Attempts to decode the final byte from an SS3 sequence.
     /// </summary>
-    public static bool TryDecode(char final, TerminalModeContext context, out IInputEvent? result)
+    public static bool TryDecode(char final, TerminalModeContext context, out TerminaInputEvent? result)
     {
         result = null;
 
         if (context.KittyReportAllKeysVisible && final is 'A' or 'B')
         {
-            result = new MouseScrollEvent(final == 'A' ? +1 : -1);
+            result = new PointerInput(
+                PointerAction.Wheel,
+                X: 0,
+                Y: 0,
+                final == 'A' ? MouseButton.WheelUp : MouseButton.WheelDown);
             return true;
         }
 
         var key = final switch
         {
-            'A' => ConsoleKey.UpArrow,
-            'B' => ConsoleKey.DownArrow,
-            'C' => ConsoleKey.RightArrow,
-            'D' => ConsoleKey.LeftArrow,
-            'H' => ConsoleKey.Home,
-            'F' => ConsoleKey.End,
-            'P' => ConsoleKey.F1,
-            'Q' => ConsoleKey.F2,
-            'R' => ConsoleKey.F3,
-            'S' => ConsoleKey.F4,
-            _ => ConsoleKey.None,
+            'A' => TerminaKey.UpArrow,
+            'B' => TerminaKey.DownArrow,
+            'C' => TerminaKey.RightArrow,
+            'D' => TerminaKey.LeftArrow,
+            'H' => TerminaKey.Home,
+            'F' => TerminaKey.End,
+            'P' => TerminaKey.F1,
+            'Q' => TerminaKey.F2,
+            'R' => TerminaKey.F3,
+            'S' => TerminaKey.F4,
+            _ => TerminaKey.None,
         };
 
-        if (key == ConsoleKey.None)
+        if (key == TerminaKey.None)
             return false;
 
-        result = new KeyPressed(new ConsoleKeyInfo('\0', key, false, false, false));
+        result = new KeyStroke(key);
         return true;
     }
 }

--- a/tests/Termina.Tests/Input/Ss3KeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/Ss3KeyboardDecoderTests.cs
@@ -18,7 +18,7 @@ public class Ss3KeyboardDecoderTests
     [InlineData('Q', ConsoleKey.F2)]
     [InlineData('R', ConsoleKey.F3)]
     [InlineData('S', ConsoleKey.F4)]
-    public void TryDecode_KnownFinal_ReturnsKeyPressed(char final, ConsoleKey expectedKey)
+    public void TryDecode_KnownFinal_ReturnsKeyStroke(char final, ConsoleKey expectedKey)
     {
         var decoded = Ss3KeyboardDecoder.TryDecode(
             final,
@@ -26,15 +26,17 @@ public class Ss3KeyboardDecoderTests
             out var inputEvent);
 
         Assert.True(decoded);
-        var pressed = Assert.IsType<KeyPressed>(inputEvent);
-        Assert.Equal(expectedKey, pressed.KeyInfo.Key);
-        Assert.Equal('\0', pressed.KeyInfo.KeyChar);
+        var keyStroke = Assert.IsType<KeyStroke>(inputEvent);
+        Assert.Equal(ToTerminaKey(expectedKey), keyStroke.Key);
+        Assert.Equal(KeyEventPhase.Press, keyStroke.Phase);
+        Assert.Equal(KeyModifiers.None, keyStroke.Modifiers);
+        Assert.Null(keyStroke.Text);
     }
 
     [Theory]
     [InlineData('A', +1)]
     [InlineData('B', -1)]
-    public void TryDecode_KittyVisibleVerticalArrow_ReturnsMouseScroll(char final, int expectedDelta)
+    public void TryDecode_KittyVisibleVerticalArrow_ReturnsPointerWheel(char final, int expectedDelta)
     {
         var decoded = Ss3KeyboardDecoder.TryDecode(
             final,
@@ -42,14 +44,15 @@ public class Ss3KeyboardDecoderTests
             out var inputEvent);
 
         Assert.True(decoded);
-        var scroll = Assert.IsType<MouseScrollEvent>(inputEvent);
-        Assert.Equal(expectedDelta, scroll.Delta);
+        var pointerInput = Assert.IsType<PointerInput>(inputEvent);
+        Assert.Equal(PointerAction.Wheel, pointerInput.Action);
+        Assert.Equal(expectedDelta > 0 ? MouseButton.WheelUp : MouseButton.WheelDown, pointerInput.Button);
     }
 
     [Theory]
     [InlineData('C', ConsoleKey.RightArrow)]
     [InlineData('D', ConsoleKey.LeftArrow)]
-    public void TryDecode_KittyVisibleHorizontalArrow_ReturnsKeyPressed(char final, ConsoleKey expectedKey)
+    public void TryDecode_KittyVisibleHorizontalArrow_ReturnsKeyStroke(char final, ConsoleKey expectedKey)
     {
         var decoded = Ss3KeyboardDecoder.TryDecode(
             final,
@@ -57,8 +60,8 @@ public class Ss3KeyboardDecoderTests
             out var inputEvent);
 
         Assert.True(decoded);
-        var pressed = Assert.IsType<KeyPressed>(inputEvent);
-        Assert.Equal(expectedKey, pressed.KeyInfo.Key);
+        var keyStroke = Assert.IsType<KeyStroke>(inputEvent);
+        Assert.Equal(ToTerminaKey(expectedKey), keyStroke.Key);
     }
 
     [Theory]
@@ -77,4 +80,16 @@ public class Ss3KeyboardDecoderTests
 
     private static TerminalModeContext Context(bool kittyReportAllKeysVisible) =>
         new(kittyReportAllKeysVisible);
+
+    private static TerminaKey ToTerminaKey(ConsoleKey key) => key switch
+    {
+        ConsoleKey.UpArrow => TerminaKey.UpArrow,
+        ConsoleKey.DownArrow => TerminaKey.DownArrow,
+        ConsoleKey.RightArrow => TerminaKey.RightArrow,
+        ConsoleKey.LeftArrow => TerminaKey.LeftArrow,
+        ConsoleKey.Home => TerminaKey.Home,
+        ConsoleKey.End => TerminaKey.End,
+        >= ConsoleKey.F1 and <= ConsoleKey.F4 => TerminaKey.F1 + (key - ConsoleKey.F1),
+        _ => TerminaKey.None,
+    };
 }


### PR DESCRIPTION
## Summary
- route SS3 keyboard finals through internal KeyStroke
- represent the existing kitty-visible SS3 wheel exception as PointerInput
- adapt SS3 semantic input back to existing public KeyPressed and MouseScrollEvent output

## Testing
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"