### PR TITLE
Route CSI functional input through semantic input

### DIFF
--- a/src/Termina/Input/CsiFunctionalDecoder.cs
+++ b/src/Termina/Input/CsiFunctionalDecoder.cs
@@ -14,7 +14,7 @@ internal static class CsiFunctionalDecoder
     public static bool TryDecodeBareFinal(
         char final,
         TerminalModeContext context,
-        out IInputEvent? result)
+        out TerminaInputEvent? result)
     {
         result = null;
 
@@ -23,15 +23,21 @@ internal static class CsiFunctionalDecoder
 
         if (context.KittyReportAllKeysVisible)
         {
-            var key = FinalToKey(final);
-            if (key != ConsoleKey.None)
-                result = new KeyPressed(new ConsoleKeyInfo('\0', key, false, false, false));
+            var key = FinalToTerminaKey(final);
+            if (key != TerminaKey.None)
+                result = new KeyStroke(key);
 
             return true;
         }
 
         if (final is 'A' or 'B')
-            result = new MouseScrollEvent(final == 'A' ? +1 : -1);
+        {
+            result = new PointerInput(
+                PointerAction.Wheel,
+                X: 0,
+                Y: 0,
+                final == 'A' ? MouseButton.WheelUp : MouseButton.WheelDown);
+        }
 
         return true;
     }
@@ -60,5 +66,20 @@ internal static class CsiFunctionalDecoder
         'R' => ConsoleKey.F3,
         'S' => ConsoleKey.F4,
         _ => ConsoleKey.None,
+    };
+
+    private static TerminaKey FinalToTerminaKey(char c) => c switch
+    {
+        'A' => TerminaKey.UpArrow,
+        'B' => TerminaKey.DownArrow,
+        'C' => TerminaKey.RightArrow,
+        'D' => TerminaKey.LeftArrow,
+        'H' => TerminaKey.Home,
+        'F' => TerminaKey.End,
+        'P' => TerminaKey.F1,
+        'Q' => TerminaKey.F2,
+        'R' => TerminaKey.F3,
+        'S' => TerminaKey.F4,
+        _ => TerminaKey.None,
     };
 }

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -244,7 +244,7 @@ internal sealed class EscapeSequenceParser
                             _modeContext,
                             out var functionalEvent)
                         && functionalEvent is not null)
-                        results.Add(functionalEvent);
+                        results.AddRange(PublicInputEventAdapter.Adapt(functionalEvent));
 
                     _seqBuffer.Clear();
                     _state = State.Normal;

--- a/tests/Termina.Tests/Input/CsiFunctionalDecoderTests.cs
+++ b/tests/Termina.Tests/Input/CsiFunctionalDecoderTests.cs
@@ -18,7 +18,7 @@ public class CsiFunctionalDecoderTests
     [InlineData('Q', ConsoleKey.F2)]
     [InlineData('R', ConsoleKey.F3)]
     [InlineData('S', ConsoleKey.F4)]
-    public void TryDecodeBareFinal_KittyVisible_ReturnsKeyPressed(char final, ConsoleKey expectedKey)
+    public void TryDecodeBareFinal_KittyVisible_ReturnsKeyStroke(char final, ConsoleKey expectedKey)
     {
         var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
             final,
@@ -26,9 +26,11 @@ public class CsiFunctionalDecoderTests
             out var inputEvent);
 
         Assert.True(decoded);
-        var pressed = Assert.IsType<KeyPressed>(inputEvent);
-        Assert.Equal(expectedKey, pressed.KeyInfo.Key);
-        Assert.Equal('\0', pressed.KeyInfo.KeyChar);
+        var keyStroke = Assert.IsType<KeyStroke>(inputEvent);
+        Assert.Equal(ToTerminaKey(expectedKey), keyStroke.Key);
+        Assert.Equal(KeyEventPhase.Press, keyStroke.Phase);
+        Assert.Equal(KeyModifiers.None, keyStroke.Modifiers);
+        Assert.Null(keyStroke.Text);
     }
 
     [Fact]
@@ -46,7 +48,7 @@ public class CsiFunctionalDecoderTests
     [Theory]
     [InlineData('A', +1)]
     [InlineData('B', -1)]
-    public void TryDecodeBareFinal_KittyInactive_VerticalArrowReturnsMouseScroll(char final, int expectedDelta)
+    public void TryDecodeBareFinal_KittyInactive_VerticalArrowReturnsPointerWheel(char final, int expectedDelta)
     {
         var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
             final,
@@ -54,8 +56,9 @@ public class CsiFunctionalDecoderTests
             out var inputEvent);
 
         Assert.True(decoded);
-        var scroll = Assert.IsType<MouseScrollEvent>(inputEvent);
-        Assert.Equal(expectedDelta, scroll.Delta);
+        var pointerInput = Assert.IsType<PointerInput>(inputEvent);
+        Assert.Equal(PointerAction.Wheel, pointerInput.Action);
+        Assert.Equal(expectedDelta > 0 ? MouseButton.WheelUp : MouseButton.WheelDown, pointerInput.Button);
     }
 
     [Theory]
@@ -96,4 +99,16 @@ public class CsiFunctionalDecoderTests
 
     private static TerminalModeContext Context(bool kittyReportAllKeysVisible) =>
         new(kittyReportAllKeysVisible);
+
+    private static TerminaKey ToTerminaKey(ConsoleKey key) => key switch
+    {
+        ConsoleKey.UpArrow => TerminaKey.UpArrow,
+        ConsoleKey.DownArrow => TerminaKey.DownArrow,
+        ConsoleKey.RightArrow => TerminaKey.RightArrow,
+        ConsoleKey.LeftArrow => TerminaKey.LeftArrow,
+        ConsoleKey.Home => TerminaKey.Home,
+        ConsoleKey.End => TerminaKey.End,
+        >= ConsoleKey.F1 and <= ConsoleKey.F4 => TerminaKey.F1 + (key - ConsoleKey.F1),
+        _ => TerminaKey.None,
+    };
 }


### PR DESCRIPTION
## Summary
- route bare CSI functional key finals through internal KeyStroke when kitty report-all-keys is visible
- represent inactive bare CSI A/B wheel emissions as PointerInput
- adapt semantic CSI functional input back to existing public KeyPressed and MouseScrollEvent output

## Testing
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"