### PR TITLE
Route legacy CSI input through semantic input

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -199,7 +199,7 @@ internal sealed class EscapeSequenceParser
                     && legacyKeyEvent is not null)
                 {
                     TerminaTrace.Input.Debug(this, "ESP: legacy CSI tilde {0} → {1}", seq.Text, legacyKeyEvent);
-                    results.Add(legacyKeyEvent);
+                    results.AddRange(PublicInputEventAdapter.Adapt(legacyKeyEvent));
                     _seqBuffer.Clear();
                     _state = State.Normal;
                     break;

--- a/src/Termina/Input/LegacyCsiKeyboardDecoder.cs
+++ b/src/Termina/Input/LegacyCsiKeyboardDecoder.cs
@@ -11,7 +11,7 @@ internal static class LegacyCsiKeyboardDecoder
     /// <summary>
     /// Attempts to decode <c>[num~</c> or <c>[num;modifiers~</c> into a keyboard event.
     /// </summary>
-    public static bool TryDecode(InputSequence sequence, out KeyPressed? result)
+    public static bool TryDecode(InputSequence sequence, out KeyStroke? result)
     {
         result = null;
         var text = sequence.Text;
@@ -24,8 +24,8 @@ internal static class LegacyCsiKeyboardDecoder
         if (!int.TryParse(keyPart, out var keyCode))
             return false;
 
-        var consoleKey = LegacyTildeCodeToKey(keyCode);
-        if (consoleKey == ConsoleKey.None)
+        var key = LegacyTildeCodeToKey(keyCode);
+        if (key == TerminaKey.None)
             return false;
 
         var modValue = 1;
@@ -37,34 +37,35 @@ internal static class LegacyCsiKeyboardDecoder
         }
 
         var modBits = modValue - 1;
-        var shift = (modBits & 1) != 0;
-        var alt = (modBits & 2) != 0;
-        var ctrl = (modBits & 4) != 0;
+        var modifiers = KeyModifiers.None;
+        if ((modBits & 1) != 0) modifiers |= KeyModifiers.Shift;
+        if ((modBits & 2) != 0) modifiers |= KeyModifiers.Alt;
+        if ((modBits & 4) != 0) modifiers |= KeyModifiers.Control;
 
-        result = new KeyPressed(new ConsoleKeyInfo('\0', consoleKey, shift, alt, ctrl));
+        result = new KeyStroke(key, modifiers);
         return true;
     }
 
-    private static ConsoleKey LegacyTildeCodeToKey(int code) => code switch
+    private static TerminaKey LegacyTildeCodeToKey(int code) => code switch
     {
-        1 or 7 => ConsoleKey.Home,
-        2 => ConsoleKey.Insert,
-        3 => ConsoleKey.Delete,
-        4 or 8 => ConsoleKey.End,
-        5 => ConsoleKey.PageUp,
-        6 => ConsoleKey.PageDown,
-        11 => ConsoleKey.F1,
-        12 => ConsoleKey.F2,
-        13 => ConsoleKey.F3,
-        14 => ConsoleKey.F4,
-        15 => ConsoleKey.F5,
-        17 => ConsoleKey.F6,
-        18 => ConsoleKey.F7,
-        19 => ConsoleKey.F8,
-        20 => ConsoleKey.F9,
-        21 => ConsoleKey.F10,
-        23 => ConsoleKey.F11,
-        24 => ConsoleKey.F12,
-        _ => ConsoleKey.None,
+        1 or 7 => TerminaKey.Home,
+        2 => TerminaKey.Insert,
+        3 => TerminaKey.Delete,
+        4 or 8 => TerminaKey.End,
+        5 => TerminaKey.PageUp,
+        6 => TerminaKey.PageDown,
+        11 => TerminaKey.F1,
+        12 => TerminaKey.F2,
+        13 => TerminaKey.F3,
+        14 => TerminaKey.F4,
+        15 => TerminaKey.F5,
+        17 => TerminaKey.F6,
+        18 => TerminaKey.F7,
+        19 => TerminaKey.F8,
+        20 => TerminaKey.F9,
+        21 => TerminaKey.F10,
+        23 => TerminaKey.F11,
+        24 => TerminaKey.F12,
+        _ => TerminaKey.None,
     };
 }

--- a/tests/Termina.Tests/Input/LegacyCsiKeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/LegacyCsiKeyboardDecoderTests.cs
@@ -28,15 +28,16 @@ public class LegacyCsiKeyboardDecoderTests
     [InlineData("[21~", ConsoleKey.F10)]
     [InlineData("[23~", ConsoleKey.F11)]
     [InlineData("[24~", ConsoleKey.F12)]
-    public void TryDecode_KnownTildeSequence_ReturnsKeyPressed(string sequence, ConsoleKey expectedKey)
+    public void TryDecode_KnownTildeSequence_ReturnsKeyStroke(string sequence, ConsoleKey expectedKey)
     {
-        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.True(decoded);
-        Assert.NotNull(keyEvent);
-        Assert.Equal(expectedKey, keyEvent!.KeyInfo.Key);
-        Assert.Equal('\0', keyEvent.KeyInfo.KeyChar);
-        Assert.Equal((ConsoleModifiers)0, keyEvent.KeyInfo.Modifiers);
+        Assert.NotNull(keyStroke);
+        Assert.Equal(ToTerminaKey(expectedKey), keyStroke!.Key);
+        Assert.Equal(KeyModifiers.None, keyStroke.Modifiers);
+        Assert.Equal(KeyEventPhase.Press, keyStroke.Phase);
+        Assert.Null(keyStroke.Text);
     }
 
     [Theory]
@@ -44,20 +45,20 @@ public class LegacyCsiKeyboardDecoderTests
     [InlineData("[5;3~", false, true, false)]
     [InlineData("[5;5~", false, false, true)]
     [InlineData("[5;8~", true, true, true)]
-    public void TryDecode_ModifiedTildeSequence_ReturnsKeyPressedWithModifiers(
+    public void TryDecode_ModifiedTildeSequence_ReturnsKeyStrokeWithModifiers(
         string sequence,
         bool shift,
         bool alt,
         bool ctrl)
     {
-        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.True(decoded);
-        Assert.NotNull(keyEvent);
-        Assert.Equal(ConsoleKey.PageUp, keyEvent!.KeyInfo.Key);
-        Assert.Equal(shift, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
-        Assert.Equal(alt, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Alt));
-        Assert.Equal(ctrl, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+        Assert.NotNull(keyStroke);
+        Assert.Equal(TerminaKey.PageUp, keyStroke!.Key);
+        Assert.Equal(shift, keyStroke.Modifiers.HasFlag(KeyModifiers.Shift));
+        Assert.Equal(alt, keyStroke.Modifiers.HasFlag(KeyModifiers.Alt));
+        Assert.Equal(ctrl, keyStroke.Modifiers.HasFlag(KeyModifiers.Control));
     }
 
     [Theory]
@@ -69,9 +70,21 @@ public class LegacyCsiKeyboardDecoderTests
     [InlineData("5~")]
     public void TryDecode_UnknownOrMalformedSequence_ReturnsFalse(string sequence)
     {
-        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = LegacyCsiKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.False(decoded);
-        Assert.Null(keyEvent);
+        Assert.Null(keyStroke);
     }
+
+    private static TerminaKey ToTerminaKey(ConsoleKey key) => key switch
+    {
+        ConsoleKey.Insert => TerminaKey.Insert,
+        ConsoleKey.Delete => TerminaKey.Delete,
+        ConsoleKey.Home => TerminaKey.Home,
+        ConsoleKey.End => TerminaKey.End,
+        ConsoleKey.PageUp => TerminaKey.PageUp,
+        ConsoleKey.PageDown => TerminaKey.PageDown,
+        >= ConsoleKey.F1 and <= ConsoleKey.F12 => TerminaKey.F1 + (key - ConsoleKey.F1),
+        _ => TerminaKey.None,
+    };
 }


### PR DESCRIPTION
## Summary
- route legacy CSI tilde key decoding through internal KeyStroke
- preserve xterm modifier-bit handling in semantic modifiers
- adapt semantic legacy CSI input back to existing public KeyPressed output

## Testing
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"