### PR TITLE
Route kitty second-form input through semantic input

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -259,7 +259,7 @@ internal sealed class EscapeSequenceParser
                     if (KittySecondFormKeyboardDecoder.TryDecode(seq, out var keyEvent) && keyEvent is not null)
                     {
                         TerminaTrace.Input.Debug(this, "ESP: kitty second-form {0} → {1}", seq.Text, keyEvent);
-                        results.Add(keyEvent);
+                        results.AddRange(PublicInputEventAdapter.Adapt(keyEvent));
                     }
                     _seqBuffer.Clear();
                     _state = State.Normal;

--- a/src/Termina/Input/KittySecondFormKeyboardDecoder.cs
+++ b/src/Termina/Input/KittySecondFormKeyboardDecoder.cs
@@ -13,11 +13,11 @@ internal static class KittySecondFormKeyboardDecoder
     /// </summary>
     /// <param name="sequence">The buffered sequence, e.g. <c>[1;5A</c> or <c>[1;2:1A</c>.</param>
     /// <param name="result">
-    /// On <c>true</c> return: the resulting <see cref="KeyPressed"/> when this was a press event,
-    /// or <c>null</c> when a repeat/release event was parsed and intentionally swallowed.
+    /// On <c>true</c> return: the resulting semantic key event, or <c>null</c> when a recognized
+    /// sequence does not map to a supported key or event phase.
     /// </param>
     /// <returns><c>true</c> if the sequence was recognized, whether or not an event is produced.</returns>
-    public static bool TryDecode(InputSequence sequence, out KeyPressed? result)
+    public static bool TryDecode(InputSequence sequence, out KeyStroke? result)
     {
         result = null;
         var text = sequence.Text;
@@ -25,8 +25,8 @@ internal static class KittySecondFormKeyboardDecoder
             return false;
 
         var final = text[^1];
-        var key = CsiFunctionalDecoder.FinalToKey(final);
-        if (key == ConsoleKey.None)
+        var key = ToTerminaKey(CsiFunctionalDecoder.FinalToKey(final));
+        if (key == TerminaKey.None)
             return false;
 
         var inner = text[1..^1];
@@ -43,21 +43,43 @@ internal static class KittySecondFormKeyboardDecoder
         if (!int.TryParse(modPart, out var modValue) || modValue < 1)
             return false;
 
+        var phase = KeyEventPhase.Press;
         if (colon >= 0)
         {
             if (!int.TryParse(rest[(colon + 1)..], out var eventType))
                 return false;
 
-            if (eventType != 1)
+            phase = eventType switch
+            {
+                1 => KeyEventPhase.Press,
+                2 => KeyEventPhase.Repeat,
+                3 => KeyEventPhase.Release,
+                _ => phase,
+            };
+
+            if (eventType is not (1 or 2 or 3))
                 return true;
         }
 
         var modBits = modValue - 1;
-        var shift = (modBits & 1) != 0;
-        var alt = (modBits & 2) != 0;
-        var ctrl = (modBits & 4) != 0;
+        var modifiers = KeyModifiers.None;
+        if ((modBits & 1) != 0) modifiers |= KeyModifiers.Shift;
+        if ((modBits & 2) != 0) modifiers |= KeyModifiers.Alt;
+        if ((modBits & 4) != 0) modifiers |= KeyModifiers.Control;
 
-        result = new KeyPressed(new ConsoleKeyInfo('\0', key, shift, alt, ctrl));
+        result = new KeyStroke(key, modifiers, phase);
         return true;
     }
+
+    private static TerminaKey ToTerminaKey(ConsoleKey key) => key switch
+    {
+        ConsoleKey.UpArrow => TerminaKey.UpArrow,
+        ConsoleKey.DownArrow => TerminaKey.DownArrow,
+        ConsoleKey.RightArrow => TerminaKey.RightArrow,
+        ConsoleKey.LeftArrow => TerminaKey.LeftArrow,
+        ConsoleKey.Home => TerminaKey.Home,
+        ConsoleKey.End => TerminaKey.End,
+        >= ConsoleKey.F1 and <= ConsoleKey.F4 => TerminaKey.F1 + (key - ConsoleKey.F1),
+        _ => TerminaKey.None,
+    };
 }

--- a/tests/Termina.Tests/Input/KittySecondFormKeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/KittySecondFormKeyboardDecoderTests.cs
@@ -12,43 +12,47 @@ public class KittySecondFormKeyboardDecoderTests
     [InlineData("[1;5B", ConsoleKey.DownArrow, false, false, true)]
     [InlineData("[1;8A", ConsoleKey.UpArrow, true, true, true)]
     [InlineData("[1;3C", ConsoleKey.RightArrow, false, true, false)]
-    public void TryDecode_PressSequence_ReturnsKeyPressedWithModifiers(
+    public void TryDecode_PressSequence_ReturnsKeyStrokeWithModifiers(
         string sequence,
         ConsoleKey expectedKey,
         bool shift,
         bool alt,
         bool ctrl)
     {
-        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.True(decoded);
-        Assert.NotNull(keyEvent);
-        Assert.Equal(expectedKey, keyEvent!.KeyInfo.Key);
-        Assert.Equal('\0', keyEvent.KeyInfo.KeyChar);
-        Assert.Equal(shift, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
-        Assert.Equal(alt, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Alt));
-        Assert.Equal(ctrl, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+        Assert.NotNull(keyStroke);
+        Assert.Equal(ToTerminaKey(expectedKey), keyStroke!.Key);
+        Assert.Equal(KeyEventPhase.Press, keyStroke.Phase);
+        Assert.Equal(shift, keyStroke.Modifiers.HasFlag(KeyModifiers.Shift));
+        Assert.Equal(alt, keyStroke.Modifiers.HasFlag(KeyModifiers.Alt));
+        Assert.Equal(ctrl, keyStroke.Modifiers.HasFlag(KeyModifiers.Control));
+        Assert.Null(keyStroke.Text);
     }
 
     [Fact]
-    public void TryDecode_ExplicitPressEvent_ReturnsKeyPressed()
+    public void TryDecode_ExplicitPressEvent_ReturnsKeyStroke()
     {
-        var decoded = KittySecondFormKeyboardDecoder.TryDecode("[1;1:1A", out var keyEvent);
+        var decoded = KittySecondFormKeyboardDecoder.TryDecode("[1;1:1A", out var keyStroke);
 
         Assert.True(decoded);
-        Assert.NotNull(keyEvent);
-        Assert.Equal(ConsoleKey.UpArrow, keyEvent!.KeyInfo.Key);
+        Assert.NotNull(keyStroke);
+        Assert.Equal(TerminaKey.UpArrow, keyStroke!.Key);
+        Assert.Equal(KeyEventPhase.Press, keyStroke.Phase);
     }
 
     [Theory]
-    [InlineData("[1;1:2A")]
-    [InlineData("[1;1:3A")]
-    public void TryDecode_RepeatOrRelease_ReturnsTrueWithoutEvent(string sequence)
+    [InlineData("[1;1:2A", 2)]
+    [InlineData("[1;1:3A", 3)]
+    public void TryDecode_RepeatOrRelease_ReturnsKeyStrokeWithPhase(string sequence, int eventType)
     {
-        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.True(decoded);
-        Assert.Null(keyEvent);
+        Assert.NotNull(keyStroke);
+        Assert.Equal(TerminaKey.UpArrow, keyStroke!.Key);
+        Assert.Equal(ToPhase(eventType), keyStroke.Phase);
     }
 
     [Theory]
@@ -61,9 +65,28 @@ public class KittySecondFormKeyboardDecoderTests
     [InlineData("1;1A")]
     public void TryDecode_UnknownOrMalformedSequence_ReturnsFalse(string sequence)
     {
-        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = KittySecondFormKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.False(decoded);
-        Assert.Null(keyEvent);
+        Assert.Null(keyStroke);
     }
+
+    private static TerminaKey ToTerminaKey(ConsoleKey key) => key switch
+    {
+        ConsoleKey.UpArrow => TerminaKey.UpArrow,
+        ConsoleKey.DownArrow => TerminaKey.DownArrow,
+        ConsoleKey.RightArrow => TerminaKey.RightArrow,
+        ConsoleKey.LeftArrow => TerminaKey.LeftArrow,
+        ConsoleKey.Home => TerminaKey.Home,
+        ConsoleKey.End => TerminaKey.End,
+        >= ConsoleKey.F1 and <= ConsoleKey.F4 => TerminaKey.F1 + (key - ConsoleKey.F1),
+        _ => TerminaKey.None,
+    };
+
+    private static KeyEventPhase ToPhase(int eventType) => eventType switch
+    {
+        2 => KeyEventPhase.Repeat,
+        3 => KeyEventPhase.Release,
+        _ => KeyEventPhase.Press,
+    };
 }


### PR DESCRIPTION
## Summary
- route kitty second-form functional key decoding through internal KeyStroke
- preserve xterm/kitty modifier bits as semantic modifiers
- represent kitty press/repeat/release subfields as KeyStroke phases while public adapter keeps current press-only output

## Testing
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"