### PR TITLE
Route kitty CSI-u input through semantic input

### DIFF
--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -211,7 +211,7 @@ internal sealed class EscapeSequenceParser
                     if (KittyCsiUKeyboardDecoder.TryDecode(seq, out var csiEvent) && csiEvent is not null)
                     {
                         TerminaTrace.Input.Debug(this, "ESP: CSI u detected: {0}", seq.Text);
-                        results.Add(csiEvent);
+                        results.AddRange(PublicInputEventAdapter.Adapt(csiEvent));
                     }
                     _seqBuffer.Clear();
                     _state = State.Normal;

--- a/src/Termina/Input/KittyCsiUKeyboardDecoder.cs
+++ b/src/Termina/Input/KittyCsiUKeyboardDecoder.cs
@@ -12,9 +12,9 @@ internal static class KittyCsiUKeyboardDecoder
     /// Attempts to parse <c>[keycode[;modifiers[:event][;text...]]u</c>.
     /// </summary>
     /// <param name="sequence">The buffered sequence, e.g. <c>[13;5u</c>.</param>
-    /// <param name="result">The resulting <see cref="KeyPressed"/> event, if one should be emitted.</param>
+    /// <param name="result">The resulting semantic key event, if one should be emitted.</param>
     /// <returns><c>true</c> if the sequence was parsed, whether or not an event is produced.</returns>
-    public static bool TryDecode(InputSequence sequence, out KeyPressed? result)
+    public static bool TryDecode(InputSequence sequence, out KeyStroke? result)
     {
         result = null;
         var text = sequence.Text;
@@ -27,6 +27,7 @@ internal static class KittyCsiUKeyboardDecoder
 
         int keycode;
         var modValue = 1;
+        var phase = KeyEventPhase.Press;
 
         if (semicolon < 0)
         {
@@ -61,7 +62,15 @@ internal static class KittyCsiUKeyboardDecoder
                 if (!int.TryParse(rest[(colon + 1)..], out var eventType))
                     return false;
 
-                if (eventType != 1)
+                phase = eventType switch
+                {
+                    1 => KeyEventPhase.Press,
+                    2 => KeyEventPhase.Repeat,
+                    3 => KeyEventPhase.Release,
+                    _ => phase,
+                };
+
+                if (eventType is not (1 or 2 or 3))
                     return true;
             }
 
@@ -74,50 +83,51 @@ internal static class KittyCsiUKeyboardDecoder
             return true;
 
         var modBits = modValue - 1;
-        var shift = (modBits & 1) != 0;
-        var alt = (modBits & 2) != 0;
-        var ctrl = (modBits & 4) != 0;
+        var modifiers = KeyModifiers.None;
+        if ((modBits & 1) != 0) modifiers |= KeyModifiers.Shift;
+        if ((modBits & 2) != 0) modifiers |= KeyModifiers.Alt;
+        if ((modBits & 4) != 0) modifiers |= KeyModifiers.Control;
 
-        var (consoleKey, keyChar) = MapKeycodeToConsoleKey(keycode);
-        if (consoleKey == ConsoleKey.None && keyChar == '\0')
+        var (key, associatedText) = MapKeycodeToKeyStroke(keycode);
+        if (key == TerminaKey.None && associatedText is null)
             return true;
 
-        result = new KeyPressed(new ConsoleKeyInfo(keyChar, consoleKey, shift, alt, ctrl));
+        result = new KeyStroke(key, modifiers, phase, associatedText);
         return true;
     }
 
-    private static (ConsoleKey Key, char Char) MapKeycodeToConsoleKey(int keycode) => keycode switch
+    private static (TerminaKey Key, string? Text) MapKeycodeToKeyStroke(int keycode) => keycode switch
     {
-        13 => (ConsoleKey.Enter, '\r'),
-        9 => (ConsoleKey.Tab, '\t'),
-        127 => (ConsoleKey.Backspace, '\b'),
-        27 => (ConsoleKey.Escape, '\x1b'),
-        >= 32 and <= 126 => (CharToConsoleKey((char)keycode), (char)keycode),
-        57344 => (ConsoleKey.Escape, '\x1b'),
-        57345 => (ConsoleKey.Enter, '\r'),
-        57346 => (ConsoleKey.Tab, '\t'),
-        57347 => (ConsoleKey.Backspace, '\b'),
-        57348 => (ConsoleKey.Insert, '\0'),
-        57349 => (ConsoleKey.Delete, '\0'),
-        57350 => (ConsoleKey.LeftArrow, '\0'),
-        57351 => (ConsoleKey.RightArrow, '\0'),
-        57352 => (ConsoleKey.UpArrow, '\0'),
-        57353 => (ConsoleKey.DownArrow, '\0'),
-        57354 => (ConsoleKey.PageUp, '\0'),
-        57355 => (ConsoleKey.PageDown, '\0'),
-        57356 => (ConsoleKey.Home, '\0'),
-        57357 => (ConsoleKey.End, '\0'),
-        57358 => (ConsoleKey.None, '\0'),
-        >= 57364 and <= 57375 => (ConsoleKey.F1 + (keycode - 57364), '\0'),
-        _ => (ConsoleKey.None, keycode < 128 ? (char)keycode : '\0')
+        13 => (TerminaKey.Enter, "\r"),
+        9 => (TerminaKey.Tab, "\t"),
+        127 => (TerminaKey.Backspace, "\b"),
+        27 => (TerminaKey.Escape, "\x1b"),
+        >= 32 and <= 126 => (CharToTerminaKey((char)keycode), ((char)keycode).ToString()),
+        57344 => (TerminaKey.Escape, null),
+        57345 => (TerminaKey.Enter, null),
+        57346 => (TerminaKey.Tab, null),
+        57347 => (TerminaKey.Backspace, null),
+        57348 => (TerminaKey.Insert, null),
+        57349 => (TerminaKey.Delete, null),
+        57350 => (TerminaKey.LeftArrow, null),
+        57351 => (TerminaKey.RightArrow, null),
+        57352 => (TerminaKey.UpArrow, null),
+        57353 => (TerminaKey.DownArrow, null),
+        57354 => (TerminaKey.PageUp, null),
+        57355 => (TerminaKey.PageDown, null),
+        57356 => (TerminaKey.Home, null),
+        57357 => (TerminaKey.End, null),
+        57358 => (TerminaKey.None, null),
+        >= 57364 and <= 57375 => (TerminaKey.F1 + (keycode - 57364), null),
+        _ => (TerminaKey.None, keycode is > 0 and < 128 ? ((char)keycode).ToString() : null)
     };
 
-    private static ConsoleKey CharToConsoleKey(char c) => c switch
+    private static TerminaKey CharToTerminaKey(char c) => c switch
     {
-        >= 'a' and <= 'z' => ConsoleKey.A + (c - 'a'),
-        >= 'A' and <= 'Z' => ConsoleKey.A + (c - 'A'),
-        >= '0' and <= '9' => ConsoleKey.D0 + (c - '0'),
-        ' ' => ConsoleKey.Spacebar,
-        _ => ConsoleKey.None
+        >= 'a' and <= 'z' => TerminaKey.A + (c - 'a'),
+        >= 'A' and <= 'Z' => TerminaKey.A + (c - 'A'),
+        >= '0' and <= '9' => TerminaKey.D0 + (c - '0'),
+        ' ' => TerminaKey.Space,
+        _ => TerminaKey.None
     };
 }

--- a/tests/Termina.Tests/Input/KittyCsiUKeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/KittyCsiUKeyboardDecoderTests.cs
@@ -13,7 +13,7 @@ public class KittyCsiUKeyboardDecoderTests
     [InlineData("[13;6u", ConsoleKey.Enter, '\r', true, false, true)]
     [InlineData("[13u", ConsoleKey.Enter, '\r', false, false, false)]
     [InlineData("[97;2;65u", ConsoleKey.A, 'a', true, false, false)]
-    public void TryDecode_StandardSequence_ReturnsKeyPressed(
+    public void TryDecode_StandardSequence_ReturnsKeyStroke(
         string sequence,
         ConsoleKey expectedKey,
         char expectedChar,
@@ -21,15 +21,16 @@ public class KittyCsiUKeyboardDecoderTests
         bool alt,
         bool ctrl)
     {
-        var decoded = KittyCsiUKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = KittyCsiUKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.True(decoded);
-        Assert.NotNull(keyEvent);
-        Assert.Equal(expectedKey, keyEvent!.KeyInfo.Key);
-        Assert.Equal(expectedChar, keyEvent.KeyInfo.KeyChar);
-        Assert.Equal(shift, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
-        Assert.Equal(alt, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Alt));
-        Assert.Equal(ctrl, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control));
+        Assert.NotNull(keyStroke);
+        Assert.Equal(ToTerminaKey(expectedKey), keyStroke!.Key);
+        Assert.Equal(expectedChar.ToString(), keyStroke.Text);
+        Assert.Equal(KeyEventPhase.Press, keyStroke.Phase);
+        Assert.Equal(shift, keyStroke.Modifiers.HasFlag(KeyModifiers.Shift));
+        Assert.Equal(alt, keyStroke.Modifiers.HasFlag(KeyModifiers.Alt));
+        Assert.Equal(ctrl, keyStroke.Modifiers.HasFlag(KeyModifiers.Control));
     }
 
     [Theory]
@@ -37,32 +38,44 @@ public class KittyCsiUKeyboardDecoderTests
     [InlineData("[57352;2u", ConsoleKey.UpArrow, true)]
     [InlineData("[57368u", ConsoleKey.F5, false)]
     [InlineData("[57348u", ConsoleKey.Insert, false)]
-    public void TryDecode_PuaFunctionalKey_ReturnsKeyPressed(
+    public void TryDecode_PuaFunctionalKey_ReturnsKeyStroke(
         string sequence,
         ConsoleKey expectedKey,
         bool shift)
     {
-        var decoded = KittyCsiUKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = KittyCsiUKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.True(decoded);
-        Assert.NotNull(keyEvent);
-        Assert.Equal(expectedKey, keyEvent!.KeyInfo.Key);
-        Assert.Equal('\0', keyEvent.KeyInfo.KeyChar);
-        Assert.Equal(shift, keyEvent.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
+        Assert.NotNull(keyStroke);
+        Assert.Equal(ToTerminaKey(expectedKey), keyStroke!.Key);
+        Assert.Null(keyStroke.Text);
+        Assert.Equal(KeyEventPhase.Press, keyStroke.Phase);
+        Assert.Equal(shift, keyStroke.Modifiers.HasFlag(KeyModifiers.Shift));
     }
 
     [Theory]
     [InlineData("[57441u")]
     [InlineData("[57448u")]
     [InlineData("[57441;1:3u")]
-    [InlineData("[97;1:3u")]
     [InlineData("[20000u")]
     public void TryDecode_SwallowedSequence_ReturnsTrueWithoutEvent(string sequence)
     {
-        var decoded = KittyCsiUKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = KittyCsiUKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.True(decoded);
-        Assert.Null(keyEvent);
+        Assert.Null(keyStroke);
+    }
+
+    [Fact]
+    public void TryDecode_ReleaseEvent_ReturnsKeyStrokeWithReleasePhase()
+    {
+        var decoded = KittyCsiUKeyboardDecoder.TryDecode("[97;1:3u", out var keyStroke);
+
+        Assert.True(decoded);
+        Assert.NotNull(keyStroke);
+        Assert.Equal(TerminaKey.A, keyStroke!.Key);
+        Assert.Equal("a", keyStroke.Text);
+        Assert.Equal(KeyEventPhase.Release, keyStroke.Phase);
     }
 
     [Theory]
@@ -74,9 +87,32 @@ public class KittyCsiUKeyboardDecoderTests
     [InlineData("13;1u")]
     public void TryDecode_MalformedSequence_ReturnsFalse(string sequence)
     {
-        var decoded = KittyCsiUKeyboardDecoder.TryDecode(sequence, out var keyEvent);
+        var decoded = KittyCsiUKeyboardDecoder.TryDecode(sequence, out var keyStroke);
 
         Assert.False(decoded);
-        Assert.Null(keyEvent);
+        Assert.Null(keyStroke);
     }
+
+    private static TerminaKey ToTerminaKey(ConsoleKey key) => key switch
+    {
+        ConsoleKey.Escape => TerminaKey.Escape,
+        ConsoleKey.Enter => TerminaKey.Enter,
+        ConsoleKey.Tab => TerminaKey.Tab,
+        ConsoleKey.Backspace => TerminaKey.Backspace,
+        ConsoleKey.Spacebar => TerminaKey.Space,
+        ConsoleKey.Insert => TerminaKey.Insert,
+        ConsoleKey.Delete => TerminaKey.Delete,
+        ConsoleKey.Home => TerminaKey.Home,
+        ConsoleKey.End => TerminaKey.End,
+        ConsoleKey.PageUp => TerminaKey.PageUp,
+        ConsoleKey.PageDown => TerminaKey.PageDown,
+        ConsoleKey.UpArrow => TerminaKey.UpArrow,
+        ConsoleKey.DownArrow => TerminaKey.DownArrow,
+        ConsoleKey.LeftArrow => TerminaKey.LeftArrow,
+        ConsoleKey.RightArrow => TerminaKey.RightArrow,
+        >= ConsoleKey.A and <= ConsoleKey.Z => TerminaKey.A + (key - ConsoleKey.A),
+        >= ConsoleKey.D0 and <= ConsoleKey.D9 => TerminaKey.D0 + (key - ConsoleKey.D0),
+        >= ConsoleKey.F1 and <= ConsoleKey.F12 => TerminaKey.F1 + (key - ConsoleKey.F1),
+        _ => TerminaKey.None,
+    };
 }


### PR DESCRIPTION
## Summary
- route kitty CSI-u decoding through internal KeyStroke
- preserve existing public key character behavior by carrying decoded text through KeyStroke.Text
- represent kitty repeat/release event subfields as KeyStroke phases while public adapter keeps current press-only output

## Testing
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj" --filter "FullyQualifiedName~Termina.Tests.Input"
- dotnet test "tests/Termina.Tests/Termina.Tests.csproj"