### PR TITLE
Expand terminal copy paste conformance coverage

### DIFF
--- a/demos/Termina.Demo.Conformance/Pages/ConformancePage.cs
+++ b/demos/Termina.Demo.Conformance/Pages/ConformancePage.cs
@@ -55,6 +55,10 @@ public sealed class ConformancePage : ReactivePage<ConformanceViewModel>
             })
             .DisposeWith(Subscriptions);
 
+        _input.TextChanged
+            .Subscribe(ViewModel.RecordInputTextChanged)
+            .DisposeWith(Subscriptions);
+
         ViewModel.Input.OfType<IInputEvent, MouseScrollEvent>()
             .Subscribe(scroll =>
             {

--- a/demos/Termina.Demo.Conformance/Pages/ConformanceViewModel.cs
+++ b/demos/Termina.Demo.Conformance/Pages/ConformanceViewModel.cs
@@ -1,4 +1,4 @@
-  using System.Diagnostics;
+using System.Diagnostics;
 using R3;
 using Termina.Input;
 using Termina.Reactive;
@@ -75,6 +75,15 @@ public sealed class ConformanceViewModel : ReactiveViewModel
                 ("phase", "submit"),
                 ("text", text),
                 ("count", SubmittedCount.Value.ToString())));
+    }
+
+    public void RecordInputTextChanged(string text)
+    {
+        _recorder.RecordLine(
+            JsonLine(
+                ("phase", "text"),
+                ("kind", "TextChanged"),
+                ("text", text)));
     }
 
     private void HandleKey(KeyPressed key)

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -5,6 +5,8 @@ This directory holds the first-pass terminal conformance harness for Termina.
 Goals:
 
 - verify that alternate-scroll does not regress native text selection
+- verify that selected screen text can reach the terminal clipboard
+- verify that terminal clipboard paste reaches the focused Termina input
 - verify that wheel input remains distinct from keyboard arrows when raw input + kitty reporting are enabled
 - verify that fallback / baseline terminal behavior still produces the expected setup sequences
 
@@ -13,5 +15,12 @@ The initial automation target is Linux on GitHub-hosted runners:
 - plain PTY capture
 - `tmux`
 - `kitty` under `Xvfb`
+
+Current Linux coverage:
+
+- baseline PTY startup captures legacy mouse-tracking setup bytes
+- kitty under `Xvfb` checks native selection, explicit copy to clipboard, clipboard paste into focused input, alternate-scroll setup, kitty keyboard setup, and no mouse-tracking setup
+- tmux checks raw key routing, tmux mouse on/off metadata, and bracketed paste delivery into focused input
+- kitty + tmux checks native selection, explicit copy to clipboard, clipboard paste into focused input, and no mouse-tracking setup while passing through tmux
 
 The suite intentionally does **not** merge into the main validation workflow yet. It is designed to be iterated on in a dedicated branch until the runner behavior is stable.

--- a/tests/conformance/linux/assert-conformance.py
+++ b/tests/conformance/linux/assert-conformance.py
@@ -24,10 +24,13 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--events", required=True)
     parser.add_argument("--selection")
+    parser.add_argument("--clipboard")
     parser.add_argument("--ansi-capture")
     parser.add_argument("--expect-wheel", action="store_true")
     parser.add_argument("--expect-arrows", action="store_true")
     parser.add_argument("--expect-selection")
+    parser.add_argument("--expect-clipboard")
+    parser.add_argument("--expect-input-text")
     parser.add_argument("--require-alt-scroll-sequence", action="store_true")
     parser.add_argument("--require-alt-scroll-enable-only", action="store_true")
     parser.add_argument("--require-no-mouse-tracking", action="store_true")
@@ -100,6 +103,21 @@ def main():
         require(
             args.expect_selection in selection_text,
             f"selection did not contain '{args.expect_selection}'",
+        )
+
+    if args.expect_clipboard:
+        require(args.clipboard is not None, "--expect-clipboard requires --clipboard")
+        clipboard_text = Path(args.clipboard).read_text()
+        require(
+            args.expect_clipboard in clipboard_text,
+            f"clipboard did not contain '{args.expect_clipboard}'",
+        )
+
+    if args.expect_input_text:
+        text_events = [evt for evt in events if evt.get("phase") == "text"]
+        require(
+            any(args.expect_input_text in evt.get("text", "") for evt in text_events),
+            f"input text events did not contain '{args.expect_input_text}'",
         )
 
     if args.ansi_capture:

--- a/tests/conformance/linux/run-kitty-selection.sh
+++ b/tests/conformance/linux/run-kitty-selection.sh
@@ -10,11 +10,13 @@ CONFORMANCE_DIR="$RUN_ROOT/termina-conformance"
 
 KITTY_CONF="$ARTIFACT_DIR/kitty.conf"
 SELECTION_FILE="$ARTIFACT_DIR/selection.txt"
+CLIPBOARD_FILE="$ARTIFACT_DIR/clipboard.txt"
 EVENTS="$ARTIFACT_DIR/events.jsonl"
 CAPTURE="$ARTIFACT_DIR/ansi-capture.log"
 SOCKET_PATH="${ARTIFACT_DIR}/kitty.sock"
 SOCKET="unix:${SOCKET_PATH}"
 DISPLAY_NUM=":104"
+PASTE_TEXT="netclaw config pasted value"
 
 cat >"$KITTY_CONF" <<'EOF'
 allow_remote_control socket
@@ -23,7 +25,7 @@ enable_audio_bell no
 font_size 16.0
 window_padding_width 0
 tab_bar_style hidden
-copy_on_select clipboard
+copy_on_select no
 shell_integration no-rc no-cursor
 EOF
 
@@ -79,8 +81,10 @@ CELL_W=$((WIDTH / COLS))
 CELL_H=$((HEIGHT / LINES))
 START_X=$((CELL_W * 3 + CELL_W / 2))
 START_Y=$((CELL_H * 3 + CELL_H / 2))
-END_X=$((CELL_W * 31))
+END_X=$((CELL_W * (COLS - 2)))
 END_Y=$START_Y
+
+printf '%s' '__termina_empty_clipboard__' | xsel --clipboard --input >/dev/null 2>&1 || true
 
 xdotool key --window "$WINDOW_ID" a b c Left Left Up Down Return
 sleep 1
@@ -95,6 +99,28 @@ xdotool mouseup --window "$WINDOW_ID" 1
 sleep 1
 
 kitty @ --to "$SOCKET" get-text --extent selection >"$SELECTION_FILE"
+xdotool key --window "$WINDOW_ID" ctrl+shift+c
+
+for _ in $(seq 1 30); do
+  xsel --clipboard --output >"$CLIPBOARD_FILE" 2>/dev/null || true
+  if python3 - "$CLIPBOARD_FILE" <<'PY'
+import sys
+from pathlib import Path
+
+sys.exit(0 if "SELECTABLE SENTINEL" in Path(sys.argv[1]).read_text() else 1)
+PY
+  then
+    break
+  fi
+
+  sleep 1
+done
+
+printf '%s' "$PASTE_TEXT" | xsel --clipboard --input >/dev/null 2>&1
+xdotool key --window "$WINDOW_ID" ctrl+shift+v
+sleep 1
+xdotool key --window "$WINDOW_ID" Return
+sleep 1
 
 # Let the app exit cleanly so the capture includes kitty/alternate-scroll teardown.
 xdotool key --window "$WINDOW_ID" ctrl+q
@@ -121,9 +147,13 @@ cp "$CONFORMANCE_DIR/events.jsonl" "$EVENTS"
 python3 "$ROOT_DIR/tests/conformance/linux/assert-conformance.py" \
   --events "$EVENTS" \
   --selection "$SELECTION_FILE" \
+  --clipboard "$CLIPBOARD_FILE" \
   --ansi-capture "$CAPTURE" \
   --expect-arrows \
   --expect-selection "SELECTABLE" \
+  --expect-clipboard "SELECTABLE SENTINEL" \
+  --expect-input-text "$PASTE_TEXT" \
+  --expect-submitted "$PASTE_TEXT" \
   --require-alt-scroll-enable-only \
   --require-no-mouse-tracking \
   --require-kitty-sequence 9

--- a/tests/conformance/linux/run-kitty-tmux-selection.sh
+++ b/tests/conformance/linux/run-kitty-tmux-selection.sh
@@ -18,6 +18,7 @@ SOCKET="unix:${SOCKET_PATH}"
 DISPLAY_NUM=":104"
 TMUX_SOCKET="termina-ci"
 TMUX_SESSION="conformance"
+PASTE_TEXT="netclaw config pasted value"
 
 cat >"$KITTY_CONF" <<'EOF'
 allow_remote_control socket
@@ -26,7 +27,7 @@ enable_audio_bell no
 font_size 16.0
 window_padding_width 0
 tab_bar_style hidden
-copy_on_select clipboard
+copy_on_select no
 shell_integration no-rc no-cursor
 EOF
 
@@ -94,8 +95,10 @@ CELL_W=$((WIDTH / COLS))
 CELL_H=$((HEIGHT / LINES))
 START_X=$((CELL_W * 3 + CELL_W / 2))
 START_Y=$((CELL_H * 3 + CELL_H / 2))
-END_X=$((CELL_W * 31))
+END_X=$((CELL_W * (COLS - 2)))
 END_Y=$START_Y
+
+printf '%s' '__termina_empty_clipboard__' | xsel --clipboard --input >/dev/null 2>&1 || true
 
 xdotool key --window "$WINDOW_ID" a b c Left Left
 printf '\x1b[A' | tmux -L "$TMUX_SOCKET" load-buffer -
@@ -112,7 +115,28 @@ xdotool mouseup --window "$WINDOW_ID" 1
 sleep 1
 
 kitty @ --to "$SOCKET" get-text --extent selection >"$SELECTION_FILE"
-xsel --clipboard --output >"$CLIPBOARD_FILE" 2>/dev/null || true
+xdotool key --window "$WINDOW_ID" ctrl+shift+c
+
+for _ in $(seq 1 30); do
+  xsel --clipboard --output >"$CLIPBOARD_FILE" 2>/dev/null || true
+  if python3 - "$CLIPBOARD_FILE" <<'PY'
+import sys
+from pathlib import Path
+
+sys.exit(0 if "SELECTABLE SENTINEL" in Path(sys.argv[1]).read_text() else 1)
+PY
+  then
+    break
+  fi
+
+  sleep 1
+done
+
+printf '%s' "$PASTE_TEXT" | xsel --clipboard --input >/dev/null 2>&1
+xdotool key --window "$WINDOW_ID" ctrl+shift+v
+sleep 1
+xdotool key --window "$WINDOW_ID" Return
+sleep 1
 
 xdotool key --window "$WINDOW_ID" ctrl+q
 
@@ -137,9 +161,13 @@ cp "$CONFORMANCE_DIR/events.jsonl" "$EVENTS"
 python3 "$ROOT_DIR/tests/conformance/linux/assert-conformance.py" \
   --events "$EVENTS" \
   --selection "$SELECTION_FILE" \
+  --clipboard "$CLIPBOARD_FILE" \
   --ansi-capture "$CAPTURE" \
   --expect-tmux true \
   --expect-tmux-mouse off \
   --expect-arrows \
   --expect-selection "SELECTABLE" \
+  --expect-clipboard "SELECTABLE SENTINEL" \
+  --expect-input-text "$PASTE_TEXT" \
+  --expect-submitted "$PASTE_TEXT" \
   --require-no-mouse-tracking

--- a/tests/conformance/linux/run-tmux-capture.sh
+++ b/tests/conformance/linux/run-tmux-capture.sh
@@ -13,6 +13,7 @@ EVENTS="$ARTIFACT_DIR/events.jsonl"
 SESSION="termina-conformance"
 TMUX_SOCKET="termina-ci"
 TMUX_MOUSE="${TMUX_CONFORMANCE_MOUSE:-off}"
+PASTE_TEXT="tmux bracketed paste value"
 
 export TERMINA_RAW_INPUT=1
 export TERMINA_KITTY_KEYBOARD=9
@@ -35,6 +36,9 @@ tmux -L "$TMUX_SOCKET" paste-buffer -t "$SESSION" -d
 printf '\x1b[B' | tmux -L "$TMUX_SOCKET" load-buffer -
 tmux -L "$TMUX_SOCKET" paste-buffer -t "$SESSION" -d
 tmux -L "$TMUX_SOCKET" send-keys -t "$SESSION" Enter
+printf '\x1b[200~%s\x1b[201~' "$PASTE_TEXT" | tmux -L "$TMUX_SOCKET" load-buffer -
+tmux -L "$TMUX_SOCKET" paste-buffer -t "$SESSION" -d
+tmux -L "$TMUX_SOCKET" send-keys -t "$SESSION" Enter
 sleep 1
 tmux -L "$TMUX_SOCKET" capture-pane -p -t "$SESSION" >"$CAPTURE"
 
@@ -47,7 +51,9 @@ python3 "$ROOT_DIR/tests/conformance/linux/assert-conformance.py" \
   --events "$EVENTS" \
   --expect-tmux true \
   --expect-tmux-mouse "$TMUX_MOUSE" \
-  --expect-arrows
+  --expect-arrows \
+  --expect-input-text "$PASTE_TEXT" \
+  --expect-submitted "$PASTE_TEXT"
 
 tmux -L "$TMUX_SOCKET" kill-session -t "$SESSION" >/dev/null 2>&1 || true
 tmux -L "$TMUX_SOCKET" kill-server >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- record focused input text changes in the conformance demo
- assert clipboard contents and pasted input text in the Linux conformance checker
- expand kitty, kitty+tmux, and tmux harnesses to cover selection copy and paste into a focused Termina input
- document the current Linux conformance matrix

## Validation
- bash -n tests/conformance/linux/run-kitty-selection.sh && bash -n tests/conformance/linux/run-kitty-tmux-selection.sh && bash -n tests/conformance/linux/run-tmux-capture.sh && python3 -m py_compile tests/conformance/linux/assert-conformance.py
- dotnet build demos/Termina.Demo.Conformance/Termina.Demo.Conformance.csproj -c Release
- dotnet test tests/Termina.Tests/Termina.Tests.csproj --filter FullyQualifiedName~Termina.Tests.Input
- dotnet test tests/Termina.Tests/Termina.Tests.csproj
- bash tests/conformance/linux/run-baseline-capture.sh /tmp/opencode/termina-conformance-baseline
- TMUX_CONFORMANCE_MOUSE=off bash tests/conformance/linux/run-tmux-capture.sh /tmp/opencode/termina-conformance-tmux-off
- TMUX_CONFORMANCE_MOUSE=on bash tests/conformance/linux/run-tmux-capture.sh /tmp/opencode/termina-conformance-tmux-on
- bash tests/conformance/linux/run-kitty-selection.sh /tmp/opencode/termina-conformance-kitty
- bash tests/conformance/linux/run-kitty-tmux-selection.sh /tmp/opencode/termina-conformance-kitty-tmux

Refs #243