### PR TITLE
Add 0.11 release notes and upgrade advisory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,25 +10,25 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.10.2</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fixes** — `StreamingTextNode` thread-safety and disposal hardening:
+    <VersionPrefix>0.11.0</VersionPrefix>
+    <PackageReleaseNotes>**Terminal Input Reliability and Native Copy/Paste Support**
 
-- **`RebuildBuffer` correctly inserts a newline before block segments after `Clear()`** ([#224](https://github.com/Aaronontheweb/termina/pull/224))
-  - Pre-fix, after `Clear()` reset `HasContentOnCurrentLine`, the first re-added block segment skipped its leading newline during rebuild, causing block content to collide with prior content on the same line.
-  - Moves the block-newline check inline, evaluated *after* prior elements are re-appended so the buffer state reflects the in-progress reconstruction.
+- Added an internal semantic input pipeline that decodes terminal protocol input before adapting back to Termina's existing public input events.
+- Extracted protocol-specific decoders for SGR mouse input, SS3 keyboard input, CSI functional keys, legacy CSI keyboard sequences, Kitty keyboard formats, bracketed paste, and unknown-sequence fallback handling.
+- Preserved the existing public input surface: `KeyPressed`, `MouseScrollEvent`, `PasteEvent`, and `ResizeEvent`.
+- Expanded Linux terminal conformance coverage for baseline PTY, tmux, kitty, and kitty plus tmux scenarios.
+- Added real terminal selection, explicit clipboard copy, and paste-into-focused-input coverage to validate native terminal clipboard workflows.
+- Hardened file trace disposal so buffered trace events drain deterministically.
 
-- **Animation callbacks now hold `_contentLock`** ([#225](https://github.com/Aaronontheweb/termina/pull/225))
-  - Animation `Invalidated` callbacks from `IAnimatedTextSegment` (e.g. `SpinnerSegment` on the R3 timer thread) previously called `RebuildBuffer` without locking, racing with public mutators (`Append`/`AppendTracked`/`Remove`/`Replace`/`Clear`/`Dispose`) that all hold the lock. Symptoms ranged from `InvalidOperationException` ("Collection was modified") on the `foreach` inside `RebuildBuffer` to torn buffer state and `ObjectDisposedException` if `Dispose()` ran while a callback was queued behind the lock.
-  - Funnels both callback sites through a single `OnAnimationInvalidated()` helper that takes `_contentLock`, checks a new volatile `_disposed` flag, then runs `RebuildBuffer` + notification safely.
-  - `Dispose()` is now idempotent and sets `_disposed = true` first so in-flight callbacks bail before touching `_invalidated`.
+**Upgrade Notes**
 
-- **`NotifyChanged` hardened against post-Dispose race** ([#227](https://github.com/Aaronontheweb/termina/pull/227))
-  - Every public mutator released `_contentLock` before calling `NotifyChanged()`, so a racing `Dispose()` could complete `_invalidated.OnCompleted()/Dispose()` in the gap and the mutator's `OnNext` would throw `ObjectDisposedException`. Same shape applied to deliberate use-after-dispose calls.
-  - `NotifyChanged` now reads `_disposed` and try/catches `ObjectDisposedException`. `OnAnimationInvalidated` routes through `NotifyChanged` so the animation path inherits the same hardening.
-
-**Test improvements** ([#226](https://github.com/Aaronontheweb/termina/pull/226)):
-- Restructured the `Replace` thread-safety stress test so the ticker always fires on a live, permanently-tracked spinner (was mostly hitting an already-disposed segment after each `Replace`).
-- Added a reflection-based test that directly exercises the `_disposed` belt-and-suspenders guard inside `OnAnimationInvalidated` (the original `AfterDispose` test was passing for the wrong reason because subscription teardown was hiding the in-flight-callback path).
+- Existing applications continue using `LegacyMouseTracking` by default.
+- Applications that need native terminal text selection should opt into raw input plus alternate-scroll.
+- Built-in text inputs handle bracketed paste automatically.
+- Custom focusable input components should implement `IPasteReceiver` to receive focused paste content.
+- For tmux, enable passthrough with `set -g allow-passthrough on`.
+- When tmux mouse mode captures selection, use Shift-drag plus the terminal copy shortcut, usually `Ctrl+Shift+C`.
+- See the [0.11.0 upgrade advisory](https://aaronstannard.com/termina/guide/upgrade-0.11.html) for the recommended runtime configuration and tmux workflow.
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,26 @@
+#### 0.11.0 June 7th 2026 ####
+
+**Terminal Input Reliability and Native Copy/Paste Support**
+
+- Added an internal semantic input pipeline that decodes terminal protocol input before adapting back to Termina's existing public input events.
+- Extracted protocol-specific decoders for SGR mouse input, SS3 keyboard input, CSI functional keys, legacy CSI keyboard sequences, Kitty keyboard formats, bracketed paste, and unknown-sequence fallback handling.
+- Preserved the existing public input surface: `KeyPressed`, `MouseScrollEvent`, `PasteEvent`, and `ResizeEvent`.
+- Expanded Linux terminal conformance coverage for baseline PTY, tmux, kitty, and kitty plus tmux scenarios.
+- Added real terminal selection, explicit clipboard copy, and paste-into-focused-input coverage to validate native terminal clipboard workflows.
+- Hardened file trace disposal so buffered trace events drain deterministically.
+
+**Upgrade Notes**
+
+- Existing applications continue using `LegacyMouseTracking` by default.
+- Applications that need native terminal text selection should opt into raw input plus alternate-scroll.
+- Built-in text inputs handle bracketed paste automatically.
+- Custom focusable input components should implement `IPasteReceiver` to receive focused paste content.
+- For tmux, enable passthrough with `set -g allow-passthrough on`.
+- When tmux mouse mode captures selection, use Shift-drag plus the terminal copy shortcut, usually `Ctrl+Shift+C`.
+- See the [0.11.0 upgrade advisory](https://aaronstannard.com/termina/guide/upgrade-0.11.html) for the recommended runtime configuration and tmux workflow.
+
+---
+
 #### 0.10.1 May 24th 2026 ####
 
 **Bug Fixes** — `StreamingTextNode` thread-safety and disposal hardening:
@@ -50,4 +73,3 @@
   - Enables consumers to recompute width- or height-sensitive layout on terminal resize
 
 ---
-

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         { text: 'Introduction', link: '/guide/' },
         { text: 'Getting Started', link: '/guide/getting-started' },
         { text: 'Installation', link: '/guide/installation' },
+        { text: 'Upgrading to 0.11.0', link: '/guide/upgrade-0.11' },
         { text: 'Migrating to 0.7.0', link: '/guide/migration-0.7' }
       ],
       '/tutorials/': [

--- a/docs/components/text-input-node.md
+++ b/docs/components/text-input-node.md
@@ -169,6 +169,8 @@ public class MyPage : ReactivePage<MyViewModel>
 
 `TextInputNode` implements `IPasteReceiver` and automatically handles bracketed paste mode. When the user pastes text from the clipboard, Termina detects the terminal's paste escape sequences and delivers the content as a single `PasteEvent` rather than individual key presses.
 
+In Termina 0.11.0, focused paste routing is covered by real terminal conformance tests for direct terminals, tmux, kitty, and kitty plus tmux. See the [0.11.0 upgrade advisory](/guide/upgrade-0.11) if your app needs users to copy text from the screen and paste it into a Termina input.
+
 ### How It Works
 
 1. The user pastes text (Ctrl+V or right-click paste)
@@ -205,6 +207,24 @@ Input.OfType<PasteEvent>()
         ProcessPastedContent(paste.Content);
     })
     .DisposeWith(Subscriptions);
+```
+
+### Custom Input Components
+
+If you build a custom focusable input node, implement `IPasteReceiver` so paste content goes directly to the focused component:
+
+```csharp
+public sealed class CustomInputNode : LayoutNode, IFocusable, IPasteReceiver
+{
+    public bool HandlePaste(PasteEvent paste)
+    {
+        if (string.IsNullOrEmpty(paste.Content))
+            return false;
+
+        InsertTextAtCursor(paste.Content);
+        return true;
+    }
+}
 ```
 
 ## Observables

--- a/docs/concepts/terminal-input-modes.md
+++ b/docs/concepts/terminal-input-modes.md
@@ -3,9 +3,13 @@
 Termina supports two runtime input strategies:
 
 - legacy mouse tracking, which is the compatibility-first default
-- raw input plus alternate-scroll, which is the higher-fidelity mode for apps like Netclaw
+- raw input plus alternate-scroll, which is the higher-fidelity mode for apps like NetClaw
 
 This page explains when to use each mode, how to configure them, and what to expect in tmux and kitty-capable terminals.
+
+::: tip Upgrading to 0.11.0
+If you are upgrading an app that needs native terminal selection, clipboard copy, or paste into focused inputs, start with the [0.11.0 upgrade advisory](/guide/upgrade-0.11).
+:::
 
 ## Recommended Defaults
 
@@ -136,7 +140,7 @@ Older or unsupported terminals still work, but Termina may fall back to legacy m
 
 For existing apps, keep defaults.
 
-For apps like Netclaw, opt in explicitly and test:
+For apps like NetClaw, opt in explicitly and test:
 
 1. direct terminal session
 2. tmux session

--- a/docs/concepts/tmux-configuration.md
+++ b/docs/concepts/tmux-configuration.md
@@ -137,6 +137,23 @@ If selection requires Shift, check your outer terminal's configuration or verify
 - This is expected behavior when `mouse on` is set
 - Either switch to `mouse off`, or use Shift+drag to bypass tmux's mouse handling
 - Shift+drag always works regardless of tmux mouse setting
+- Shift+drag is native terminal selection, not tmux copy-mode; after selecting, use your terminal copy shortcut such as `Ctrl+Shift+C`
+
+### Enter does not copy after Shift-selection
+
+When you hold Shift and drag-select text, the outer terminal owns the selection. Pressing `Enter` does nothing because tmux copy-mode is not active.
+
+Use the native terminal workflow:
+
+```text
+Shift-drag select -> Ctrl+Shift+C -> Ctrl+Shift+V
+```
+
+Use tmux copy-mode only when you want tmux to own the buffer:
+
+```text
+prefix + [ -> select -> Enter -> prefix + ]
+```
 
 ### Paste inserts literal escape sequences
 
@@ -185,5 +202,6 @@ With this configuration, Termina apps running inside tmux will have:
 ## See Also
 
 - [Terminal Input Modes](/concepts/terminal-input-modes) — framework-level input mode configuration
+- [Upgrading to 0.11.0](/guide/upgrade-0.11) — native selection, copy, paste, and input mode guidance
 - [Clipboard And Feedback](/advanced/clipboard-and-feedback) — Termina's clipboard transport architecture
 - [Input Handling](/concepts/input-handling) — keyboard, mouse, and paste event routing

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -87,4 +87,5 @@ Termina is ideal for:
 
 - [Getting Started](/guide/getting-started) - Build your first Termina app
 - [Installation](/guide/installation) - Package installation options
+- [Upgrading to 0.11.0](/guide/upgrade-0.11) - Native selection, copy, paste, and input mode guidance
 - [Counter Tutorial](/tutorials/counter-app) - Step-by-step tutorial

--- a/docs/guide/upgrade-0.11.md
+++ b/docs/guide/upgrade-0.11.md
@@ -1,0 +1,124 @@
+# Upgrading to Termina 0.11.0
+
+Termina 0.11.0 improves terminal input reliability and adds conformance coverage for native selection, clipboard copy, and paste into focused Termina inputs. This is not a breaking public API release: existing applications continue to receive the same public input event types.
+
+This advisory is most relevant if your application needs users to copy text from the terminal screen and paste it back into a Termina input, especially when running inside tmux.
+
+## Summary
+
+| Area | Existing default | Recommended for native selection |
+|------|------------------|-----------------------------------|
+| Input transport | Standard console input | Raw input |
+| Scroll mode | `LegacyMouseTracking` | `AlternateScroll` |
+| Native terminal selection | Captured by mouse tracking | Preserved by the terminal |
+| Wheel input | SGR mouse events | Alternate-scroll sequences |
+| Public events | `KeyPressed`, `MouseScrollEvent`, `PasteEvent`, `ResizeEvent` | Same public events |
+
+Existing apps keep the compatibility-first `LegacyMouseTracking` default. Apps that need native selection and clipboard workflows should opt into raw input plus alternate-scroll.
+
+## Recommended Runtime Configuration
+
+Configure Termina at startup:
+
+```csharp
+using Termina.Hosting;
+
+builder.Services.AddTermina("/", termina =>
+{
+    termina.ConfigureRuntime(options =>
+    {
+        options.PreferRawInput = true;
+        options.ScrollInputMode = ScrollInputMode.AlternateScroll;
+        options.KittyKeyboardMode = KittyKeyboardMode.ReportAllKeysPlusDisambiguate;
+        options.CtrlCHandlingMode = CtrlCHandlingMode.DoublePressWhenRawInput;
+    });
+
+    termina.RegisterRoute<HomePage, HomeViewModel>("/");
+});
+```
+
+`AlternateScroll` only activates when raw input is active. If raw input is unavailable, Termina falls back to legacy mouse tracking rather than starting in a partially working mode.
+
+## What Changed From Earlier Versions
+
+Earlier Termina versions used legacy mouse tracking by default. That mode enables terminal mouse reporting so Termina can receive wheel events, but it also causes the terminal to stop owning normal click-drag text selection.
+
+The recommended 0.11 configuration uses xterm alternate-scroll instead. In this mode Termina does not enable full mouse tracking, so the terminal keeps ownership of screen text selection and clipboard copy. Wheel input still reaches Termina through alternate-scroll sequences when raw input is active.
+
+Termina 0.11 also hardens the internal input path:
+
+- protocol-specific decoders now handle SGR mouse input, SS3 keys, CSI function keys, legacy CSI keys, Kitty keyboard formats, bracketed paste, and unknown sequence fallback
+- decoded input is adapted back to the existing public event surface
+- real Linux conformance tests now cover baseline PTY, tmux, kitty, and kitty plus tmux workflows
+- conformance coverage verifies screen selection, explicit clipboard copy, clipboard paste into focused input, and bracketed paste delivery
+
+## Paste Handling
+
+Built-in Termina text inputs already handle bracketed paste. `TextInputNode` and `TextAreaNode` implement `IPasteReceiver`, so pasted content is routed directly to the focused input.
+
+If you have a custom focusable input component, implement `IPasteReceiver`:
+
+```csharp
+using Termina.Input;
+
+public sealed class CustomInputNode : LayoutNode, IFocusable, IPasteReceiver
+{
+    public bool HandlePaste(PasteEvent paste)
+    {
+        if (string.IsNullOrEmpty(paste.Content))
+            return false;
+
+        InsertTextAtCursor(paste.Content);
+        return true;
+    }
+}
+```
+
+If no focused component handles paste, `PasteEvent` still falls through to the ViewModel input observable.
+
+## tmux Configuration
+
+Enable tmux passthrough so bracketed-paste and Kitty setup sequences can reach the outer terminal:
+
+```bash
+set -g allow-passthrough on
+```
+
+For the simplest native-selection behavior, keep tmux mouse mode off:
+
+```bash
+set -g mouse off
+```
+
+If tmux mouse mode is on, selection may require the terminal override gesture:
+
+```text
+Shift-drag select -> Ctrl+Shift+C -> Ctrl+Shift+V
+```
+
+That workflow uses native terminal selection. Pressing `Enter` after Shift-drag does not copy because you are not in tmux copy-mode. `Enter` copies only when you start selection from tmux copy-mode with `prefix + [`.
+
+See [Running Termina Inside tmux](/concepts/tmux-configuration) for the full tmux setup.
+
+## Validation Checklist
+
+After upgrading, test the workflows your users actually use:
+
+1. Run the app directly in your normal terminal.
+2. Select text from the Termina screen and copy it with the terminal copy shortcut.
+3. Paste into a focused Termina input and submit.
+4. Repeat inside tmux.
+5. If your app has custom input components, verify they implement `IPasteReceiver` or intentionally handle `PasteEvent` in the ViewModel.
+
+If native selection still does not work, confirm that the app is using `PreferRawInput = true` and `ScrollInputMode.AlternateScroll`, then check whether tmux or the terminal emulator is intercepting mouse selection.
+
+## Compatibility
+
+No public input event migration is required for existing apps. These event types remain the supported public surface:
+
+- `KeyPressed`
+- `MouseScrollEvent`
+- `PasteEvent`
+- `ResizeEvent`
+
+The new semantic input model is internal and exists to make terminal protocol decoding more reliable without forcing consumers to rewrite existing input handling code.

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,26 @@
+#### 0.11.0 June 7th 2026 ####
+
+**Terminal Input Reliability and Native Copy/Paste Support**
+
+- Added an internal semantic input pipeline that decodes terminal protocol input before adapting back to Termina's existing public input events.
+- Extracted protocol-specific decoders for SGR mouse input, SS3 keyboard input, CSI functional keys, legacy CSI keyboard sequences, Kitty keyboard formats, bracketed paste, and unknown-sequence fallback handling.
+- Preserved the existing public input surface: `KeyPressed`, `MouseScrollEvent`, `PasteEvent`, and `ResizeEvent`.
+- Expanded Linux terminal conformance coverage for baseline PTY, tmux, kitty, and kitty plus tmux scenarios.
+- Added real terminal selection, explicit clipboard copy, and paste-into-focused-input coverage to validate native terminal clipboard workflows.
+- Hardened file trace disposal so buffered trace events drain deterministically.
+
+**Upgrade Notes**
+
+- Existing applications continue using `LegacyMouseTracking` by default.
+- Applications that need native terminal text selection should opt into raw input plus alternate-scroll.
+- Built-in text inputs handle bracketed paste automatically.
+- Custom focusable input components should implement `IPasteReceiver` to receive focused paste content.
+- For tmux, enable passthrough with `set -g allow-passthrough on`.
+- When tmux mouse mode captures selection, use Shift-drag plus the terminal copy shortcut, usually `Ctrl+Shift+C`.
+- See the [0.11.0 upgrade advisory](https://aaronstannard.com/termina/guide/upgrade-0.11.html) for the recommended runtime configuration and tmux workflow.
+
+---
+
 #### 0.10.2 May 30th 2026 ####
 
 **Bug Fixes** — Input parsing, rendering, and tracing:


### PR DESCRIPTION
## Summary
- bump package version metadata to 0.11.0
- add a 0.11.0 upgrade advisory for native terminal selection, copy, paste, raw input, alternate-scroll, and tmux workflows
- link release notes to the website advisory
- update terminal input, tmux, and text input docs with the upgrade guidance

## Validation
- git diff --check
- dotnet build src/Termina/Termina.csproj -c Release
- npm run build (from docs/)

Refs #243
Refs #246