### PR TITLE
feat: add footer to modal

### DIFF
--- a/src/Termina/Layout/ModalNode.cs
+++ b/src/Termina/Layout/ModalNode.cs
@@ -30,6 +30,8 @@ public sealed class ModalNode : LayoutNode, IFocusable, IInvalidatingNode
     private ILayoutNode? _content;
     private string? _title;
     private Color? _titleColor;
+    private string? _footer;
+    private Color? _footerColor;
     private BorderStyle _borderStyle = BorderStyle.Rounded;
     private Color? _borderColor;
     private BackdropStyle _backdrop = BackdropStyle.Dim;
@@ -117,6 +119,24 @@ public sealed class ModalNode : LayoutNode, IFocusable, IInvalidatingNode
     public ModalNode WithTitleColor(Color color)
     {
         _titleColor = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the modal footer text, rendered in the bottom border line.
+    /// </summary>
+    public ModalNode WithFooter(string footer)
+    {
+        _footer = footer;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the footer color.
+    /// </summary>
+    public ModalNode WithFooterColor(Color color)
+    {
+        _footerColor = color;
         return this;
     }
 
@@ -351,6 +371,22 @@ public sealed class ModalNode : LayoutNode, IFocusable, IInvalidatingNode
                 panelContext.ResetColors();
 
             panelContext.WriteAt(titleX, 0, titleText);
+        }
+
+        // Draw footer if present (on bottom border line)
+        if (!string.IsNullOrEmpty(_footer))
+        {
+            var maxFooterLen = bounds.Width - 4;
+            var displayFooter = _footer.Length > maxFooterLen ? _footer[..maxFooterLen] : _footer;
+            var footerText = $" {displayFooter} ";
+            var footerX = 2;
+
+            if (_footerColor.HasValue)
+                panelContext.SetForeground(_footerColor.Value);
+            else
+                panelContext.ResetColors();
+
+            panelContext.WriteAt(footerX, bounds.Height - 1, footerText);
         }
 
         panelContext.ResetColors();


### PR DESCRIPTION
## Summary

Adds `WithFooter(string)` and `WithFooterColor(Color)` to `ModalNode`, enabling text to be rendered in the bottom
border line — mirroring the existing `WithTitle`/`WithTitleColor` pattern for the top border.

**Use case:** Keyboard hints, status text, or context info displayed directly in the modal frame without consuming
  content area space.

```csharp
var modal = new ModalNode()
    .WithTitle(" Settings ")
    .WithTitleColor(Color.BrightCyan)
    .WithFooter(" Esc: Close | Enter: Save ")
    .WithFooterColor(Color.Gray);

Rendering:
╭─ Settings ────────────────────────────╮
│ content...                            │
╰─ Esc: Close | Enter: Save ────────────╯
```
Changes
 - ModalNode.cs: Added _footer/_footerColor fields, WithFooter()/WithFooterColor() fluent methods, and footer rendering in RenderPanel() at the bottom border line (position 2, y = bounds.Height - 1)
 - Footer text is truncated to bounds.Width - 4 if too long
 - Custom color applied if set, otherwise uses default terminal colors
 - Zero breaking changes — fully additive, footer is null by default

Fixes #

## Changes

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
