### PR TITLE
docs: release 0.12.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,12 +10,18 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.11.1</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fix** — DECCKM arrow disambiguation:
+    <VersionPrefix>0.12.1</VersionPrefix>
+    <PackageReleaseNotes>**New Features**:
 
-- CSI A/B no longer misrouted as wheel events in terminals that ignore DECCKM.
-- Added DeckmConfirmed auto-detection: CSI A/B are keyboard arrows until an SS3 arrow key proves the terminal honors DECCKM.
-- Narrowed DECCKM confirmation to SS3 arrow keys only — VT220 F1-F4 (SS3 P/Q/R/S) no longer false-positive.
+- **WithFooter and WithFooterColor API on ModalNode** ([#292](https://github.com/Aaronontheweb/termina/pull/292))
+  - New `WithFooter(string)` and `WithFooterColor(Color)` builder methods on `ModalNode` for adding a footer line to modal dialogs
+  - Footer renders on the bottom border line with automatic text truncation to fit modal width
+  - Optional color customization via `WithFooterColor` — falls back to reset terminal colors when not specified
+  - Demonstrated with a TodoListPage demo showcasing modals with actionable footers
+
+**Documentation**:
+
+- Updated ModalNode component docs with WithFooter API reference and usage example ([#293](https://github.com/Aaronontheweb/termina/pull/293))
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+#### 0.12.1 June 11th 2026 ####
+
+**New Features**:
+
+- **WithFooter and WithFooterColor API on ModalNode** ([#292](https://github.com/Aaronontheweb/termina/pull/292))
+  - New `WithFooter(string)` and `WithFooterColor(Color)` builder methods on `ModalNode` for adding a footer line to modal dialogs
+  - Footer renders on the bottom border line with automatic text truncation to fit modal width
+  - Optional color customization via `WithFooterColor` — falls back to reset terminal colors when not specified
+  - Demonstrated with a TodoListPage demo showcasing modals with actionable footers
+
+**Documentation**:
+
+- Updated ModalNode component docs with WithFooter API reference and usage example ([#293](https://github.com/Aaronontheweb/termina/pull/293))
+
+---
+
 #### 0.12.0 June 9th 2026 ####
 
 **New Features**:


### PR DESCRIPTION
## 0.12.1 — June 11th 2026

### New Features

- **WithFooter and WithFooterColor API on ModalNode** ([#292](https://github.com/Aaronontheweb/termina/pull/292))
  - New `WithFooter(string)` and `WithFooterColor(Color)` builder methods on `ModalNode` for adding a footer line to modal dialogs
  - Footer renders on the bottom border line with automatic text truncation to fit modal width
  - Optional color customization via `WithFooterColor` — falls back to reset terminal colors when not specified
  - Demonstrated with a TodoListPage demo showcasing modals with actionable footers

### Documentation

- Updated ModalNode component docs with WithFooter API reference and usage example ([#293](https://github.com/Aaronontheweb/termina/pull/293))
