### PR TITLE
fix: parse CSI Z (backtab) as Shift+Tab

### DIFF
--- a/src/Termina/Input/CsiFunctionalDecoder.cs
+++ b/src/Termina/Input/CsiFunctionalDecoder.cs
@@ -25,7 +25,7 @@ internal static class CsiFunctionalDecoder
         {
             var key = FinalToTerminaKey(final);
             if (key != TerminaKey.None)
-                result = new KeyStroke(key);
+                result = new KeyStroke(key, Modifiers: FinalToKeyModifiers(final));
 
             return true;
         }
@@ -47,7 +47,7 @@ internal static class CsiFunctionalDecoder
             // as CSI form; misrouting them as wheel breaks all navigation.
             var key = FinalToTerminaKey(final);
             if (key != TerminaKey.None)
-                result = new KeyStroke(key);
+                result = new KeyStroke(key, Modifiers: FinalToKeyModifiers(final));
         }
 
         return true;
@@ -61,7 +61,7 @@ internal static class CsiFunctionalDecoder
     /// equivalent <see cref="ConsoleKey"/>.
     /// </remarks>
     public static bool IsFunctionalFinal(char c) =>
-        c is 'A' or 'B' or 'C' or 'D' or 'E' or 'F' or 'H' or 'P' or 'Q' or 'R' or 'S';
+        c is 'A' or 'B' or 'C' or 'D' or 'E' or 'F' or 'H' or 'P' or 'Q' or 'R' or 'S' or 'Z';
 
     /// <summary>Maps a CSI functional final char to a <see cref="ConsoleKey"/>.</summary>
     public static ConsoleKey FinalToKey(char c) => c switch
@@ -76,7 +76,20 @@ internal static class CsiFunctionalDecoder
         'Q' => ConsoleKey.F2,
         'R' => ConsoleKey.F3,
         'S' => ConsoleKey.F4,
+        'Z' => ConsoleKey.Tab,
         _ => ConsoleKey.None,
+    };
+
+    public static ConsoleModifiers FinalToModifiers(char c) => c switch
+    {
+        'Z' => ConsoleModifiers.Shift,
+        _ => 0,
+    };
+
+    private static KeyModifiers FinalToKeyModifiers(char c) => c switch
+    {
+        'Z' => KeyModifiers.Shift,
+        _ => KeyModifiers.None,
     };
 
     private static TerminaKey FinalToTerminaKey(char c) => c switch
@@ -91,6 +104,7 @@ internal static class CsiFunctionalDecoder
         'Q' => TerminaKey.F2,
         'R' => TerminaKey.F3,
         'S' => TerminaKey.F4,
+        'Z' => TerminaKey.Tab,
         _ => TerminaKey.None,
     };
 }

--- a/tests/Termina.Tests/Input/CsiFunctionalDecoderTests.cs
+++ b/tests/Termina.Tests/Input/CsiFunctionalDecoderTests.cs
@@ -117,6 +117,40 @@ public class CsiFunctionalDecoderTests
         Assert.NotEqual(TerminaKey.None, keyStroke.Key);
     }
 
+    [Fact]
+    public void TryDecodeBareFinal_BacktabZ_ReturnsTabWithShift()
+    {
+        var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
+            'Z',
+            Context(kittyReportAllKeysVisible: false, deckmConfirmed: false),
+            out var inputEvent);
+
+        Assert.True(decoded);
+        var keyStroke = Assert.IsType<KeyStroke>(inputEvent);
+        Assert.Equal(TerminaKey.Tab, keyStroke.Key);
+        Assert.Equal(KeyModifiers.Shift, keyStroke.Modifiers);
+    }
+
+    [Fact]
+    public void TryDecodeBareFinal_BacktabZ_KittyVisible_ReturnsTabWithShift()
+    {
+        var decoded = CsiFunctionalDecoder.TryDecodeBareFinal(
+            'Z',
+            Context(kittyReportAllKeysVisible: true),
+            out var inputEvent);
+
+        Assert.True(decoded);
+        var keyStroke = Assert.IsType<KeyStroke>(inputEvent);
+        Assert.Equal(TerminaKey.Tab, keyStroke.Key);
+        Assert.Equal(KeyModifiers.Shift, keyStroke.Modifiers);
+    }
+
+    [Fact]
+    public void IsFunctionalFinal_Z_ReturnsTrue()
+    {
+        Assert.True(CsiFunctionalDecoder.IsFunctionalFinal('Z'));
+    }
+
     [Theory]
     [InlineData('~')]
     [InlineData('u')]

--- a/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
@@ -578,6 +578,22 @@ public class EscapeSequenceParserTests
     }
 
     [Fact]
+    public void CsiZ_Backtab_EmitsTabWithShift()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[Z"));
+
+        Assert.False(parser.IsBufferingEscape);
+
+        var press = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.Tab, press.KeyInfo.Key);
+        Assert.True(press.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
+    }
+
+    [Fact]
     public void BracketedPaste_StillWorks_WithTildeFlushGuard()
     {
         // Guards against the tilde-flush returning false for the paste start "[200~" or end


### PR DESCRIPTION
Fix CSI Z (backtab / reverse tab) not being recognized as Shift+Tab. Previously, the Z final byte was not in the
  functional key set, so terminals that emit ESC [ Z for Shift+Tab produced no usable input event. Now it correctly
  maps to Tab with the Shift modifier.

  Problem

  Many terminals (xterm, GNOME Terminal, Windows Terminal in legacy mode) emit CSI Z when the user presses
  Shift+Tab. Termina's CSI decoder did not recognize Z as a functional final byte, so backtab input was silently
  dropped. This broke Shift+Tab navigation in pages that register it (e.g. clipboard gallery's focus cycling).

  Changes

  CsiFunctionalDecoder.cs — Add Z to IsFunctionalFinal, map it to ConsoleKey.Tab / TerminaKey.Tab, and attach the
  Shift modifier via new FinalToModifiers / FinalToKeyModifiers helpers.

  CsiFunctionalDecoderTests.cs — Three new tests: bare Z final returns Tab+Shift, same under Kitty-visible mode, and
  IsFunctionalFinal('Z') returns true.

  EscapeSequenceParserTests.cs — Integration test: full ESC [ Z sequence emits KeyPressed with ConsoleKey.Tab +
  Shift.

  Test plan

  - [x] dotnet test — all new and existing input parser tests pass
  - [x] Run the gallery demo, use Shift+Tab to cycle focus backward on the Clipboard page
  - [x] Verify regular Tab still cycles forward (no regression)