### PR TITLE
feat: add gradient primitives, GraphNode, and ProgressBarNode

### DIFF
--- a/demos/Termina.Demo.Gallery/Pages/GalleryMenuViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GalleryMenuViewModel.cs
@@ -18,7 +18,8 @@ public partial class GalleryMenuViewModel : ReactiveViewModel
         new("Layouts", "Vertical, horizontal, grid, panels, borders", "/layouts"),
         new("Animations", "Spinners, streaming text, progress indicators", "/animations"),
         new("File Picker", "File/folder selection, directory navigation, fuzzy filtering", "/filepicker"),
-        new("Toast Notifications", "Colors, icons, positions, and presets", "/toasts")
+        new("Toast Notifications", "Colors, icons, positions, and presets", "/toasts"),
+        new("Graphs & Progress", "Live graphs, gradient colors, progress bars", "/graphs")
     };
 
     public void NavigateToGallery(string route)

--- a/demos/Termina.Demo.Gallery/Pages/GraphGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GraphGalleryPage.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Components.Streaming;
+using Termina.Extensions;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Demo.Gallery.Pages;
+
+public sealed class GraphGalleryPage : ReactivePage<GraphGalleryViewModel>
+{
+    private SelectionListNode<GraphStyleItem> _styleList = null!;
+    private readonly Random _random = new(42);
+
+    private GraphNode _demoGraph = null!;
+    private ProgressBarNode _progressBar = null!;
+    private double _progressValue;
+    private readonly List<double> _dataPoints = new();
+
+    public override void OnNavigatedTo()
+    {
+        base.OnNavigatedTo();
+
+        KeyBindings.Register(ConsoleKey.Escape, () => Navigate("/menu"));
+
+        KeyBindings.Register(ConsoleKey.Spacebar, () =>
+        {
+            var highlighted = _styleList.HighlightedItem;
+            if (highlighted != null)
+                ViewModel.SelectedStyle.Value = highlighted.Value.Style;
+        });
+
+        _styleList.SelectionConfirmed
+            .Subscribe(items =>
+            {
+                var item = items.FirstOrDefault();
+                if (item != null)
+                    ViewModel.SelectedStyle.Value = item.Style;
+            })
+            .DisposeWith(Subscriptions);
+
+        ViewModel.SelectedStyle
+            .Subscribe(style => _demoGraph.WithStyle(style))
+            .DisposeWith(Subscriptions);
+
+        Observable.Interval(TimeSpan.FromMilliseconds(200), TimeProvider.System)
+            .Subscribe(_ => PushData())
+            .DisposeWith(Subscriptions);
+
+        Focus.PushFocus(_styleList);
+    }
+
+    private void PushData()
+    {
+        _dataPoints.Add(50 + _random.NextDouble() * 50 * Math.Sin(_dataPoints.Count * 0.15) + _random.NextDouble() * 20);
+        if (_dataPoints.Count > 120)
+            _dataPoints.RemoveAt(0);
+        _demoGraph.SetData(_dataPoints.ToArray());
+
+        _progressValue = (_progressValue + 0.008) % 1.01;
+        _progressBar.WithValue(_progressValue);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        _styleList = new SelectionListNode<GraphStyleItem>(
+            ViewModel.GraphStyles,
+            item => new SelectionItemContent()
+                .AddLine(
+                    new StaticTextSegment(item.Name, Color.BrightCyan, decoration: TextDecoration.Bold),
+                    new StaticTextSegment($"  {item.Description}", Color.Gray)))
+            .WithMode(SelectionMode.Single)
+            .WithShowNumbers(true)
+            .WithHighlightColors(Color.Black, Color.Cyan)
+            .WithVisibleRows(6);
+
+        var gradient = Gradient.Create(Color.FromRgb(0, 100, 255), Color.FromRgb(0, 255, 100), Color.FromRgb(255, 255, 0));
+
+        _demoGraph = new GraphNode(intervalMs: 0)
+            .WithStyle(ViewModel.SelectedStyle.Value)
+            .WithGradient(gradient)
+            .WithRange(0, 100);
+
+        _progressBar = new ProgressBarNode()
+            .WithGradient(Gradient.Create(Color.FromRgb(255, 50, 50), Color.FromRgb(255, 200, 0), Color.FromRgb(50, 255, 50)))
+            .WithValue(0)
+            .WithLabel("{0:P0}");
+
+        var grid = new GridNode()
+            .WithColumns(SizeConstraint.Percentage(30), SizeConstraint.Percentage(70))
+            .WithRows(SizeConstraint.FillRemaining())
+            .WithGridLines(BorderStyle.Single)
+            .WithGridLineColor(Color.BrightBlack);
+
+        grid.SetCell(0, 0,
+            Layouts.Vertical()
+                .WithChild(
+                    new TextNode("Graph Style")
+                        .WithForeground(Color.BrightCyan)
+                        .Bold()
+                        .Height(2))
+                .WithChild(_styleList));
+
+        grid.SetCell(0, 1,
+            Layouts.Vertical()
+                .WithChild(
+                    new TextNode("Live Graph")
+                        .WithForeground(Color.BrightYellow)
+                        .Bold()
+                        .Height(2))
+                .WithChild(_demoGraph.Fill())
+                .WithChild(new EmptyNode().Height(1))
+                .WithChild(
+                    new TextNode("Progress Bar with Gradient")
+                        .WithForeground(Color.BrightYellow)
+                        .Bold()
+                        .Height(1))
+                .WithChild(_progressBar.Height(1)));
+
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Graph & Progress Gallery")
+                    .WithBorder(BorderStyle.Double)
+                    .WithBorderColor(Color.BrightMagenta)
+                    .WithContent(grid)
+                    .Fill())
+            .WithChild(
+                new TextNode("[↑/↓] Navigate  [Enter/Space] Switch Style  [Esc] Menu")
+                    .WithForeground(Color.BrightBlack)
+                    .NoWrap()
+                    .Height(1));
+    }
+}

--- a/demos/Termina.Demo.Gallery/Pages/GraphGalleryViewModel.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GraphGalleryViewModel.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Layout;
+using Termina.Reactive;
+
+namespace Termina.Demo.Gallery.Pages;
+
+public class GraphGalleryViewModel : ReactiveViewModel
+{
+    public ReactiveProperty<GraphStyle> SelectedStyle { get; } = new(GraphStyle.Blocks);
+
+    public IReadOnlyList<GraphStyleItem> GraphStyles { get; } = new List<GraphStyleItem>
+    {
+        new("Blocks", GraphStyle.Blocks, "▁▂▃▄▅▆▇█ filled columns"),
+        new("Outline", GraphStyle.Outline, "Only the top edge is drawn"),
+        new("Braille", GraphStyle.Braille, "Double vertical resolution with braille dots"),
+        new("ASCII", GraphStyle.Ascii, "_ . - ~ ^ * # @ terminal fallback")
+    };
+
+    public override void Dispose()
+    {
+        SelectedStyle.Dispose();
+        base.Dispose();
+    }
+}
+
+public record GraphStyleItem(string Name, GraphStyle Style, string Description);

--- a/demos/Termina.Demo.Gallery/Program.cs
+++ b/demos/Termina.Demo.Gallery/Program.cs
@@ -42,6 +42,7 @@ builder.Services.AddTermina("/menu", termina =>
     termina.RegisterRoute<AnimationsGalleryPage, AnimationsGalleryViewModel>("/animations", NavigationBehavior.PreserveState);
     termina.RegisterRoute<FilePickerGalleryPage, FilePickerGalleryViewModel>("/filepicker", NavigationBehavior.PreserveState);
     termina.RegisterRoute<ToastGalleryPage, ToastGalleryViewModel>("/toasts", NavigationBehavior.PreserveState);
+    termina.RegisterRoute<GraphGalleryPage, GraphGalleryViewModel>("/graphs", NavigationBehavior.PreserveState);
 });
 
 var host = builder.Build();

--- a/docs/components/graph-node.md
+++ b/docs/components/graph-node.md
@@ -1,0 +1,127 @@
+# GraphNode
+
+A reactive, self-invalidating layout node that renders live scrolling graphs with optional gradient coloring. Implements `IAnimatedNode` so only the graph region repaints — not the parent layout.
+
+## Basic Usage
+
+```csharp
+var graph = new GraphNode()
+    .WithColor(Color.Cyan)
+    .WithRange(0, 100);
+
+graph.SetData([10, 40, 70, 100, 60, 30]);
+```
+
+## Graph Styles
+
+Four rendering styles are available:
+
+```csharp
+new GraphNode().WithStyle(GraphStyle.Blocks)   // ▁▂▃▄▅▆▇█ filled columns
+new GraphNode().WithStyle(GraphStyle.Outline)  // Only the top edge drawn
+new GraphNode().WithStyle(GraphStyle.Braille)  // Double vertical resolution
+new GraphNode().WithStyle(GraphStyle.Ascii)    // _ . - ~ ^ * # @ fallback
+```
+
+| Style | Characters | Best for |
+|-------|-----------|----------|
+| `Blocks` | `▁▂▃▄▅▆▇█` | General use, high contrast |
+| `Outline` | Top edge only | Sparse data, sparkline feel |
+| `Braille` | `⠀⢀⣀⣤⣶⣿` | Double vertical resolution per row |
+| `Ascii` | `_ . - ~ ^ * # @` | Terminals without Unicode |
+
+## Gradient Coloring
+
+Apply a gradient that maps color by row height:
+
+```csharp
+var gradient = Gradient.Create(
+    Color.FromRgb(0, 100, 255),   // blue at the bottom
+    Color.FromRgb(0, 255, 100),   // green in the middle
+    Color.FromRgb(255, 255, 0));  // yellow at the top
+
+var graph = new GraphNode()
+    .WithGradient(gradient)
+    .WithRange(0, 100);
+```
+
+For a single color, use the convenience method:
+
+```csharp
+new GraphNode().WithColor(Color.Green)
+```
+
+## Data-Driven Updates
+
+`SetData` fires invalidation immediately so the graph repaints as soon as data arrives, independent of the internal timer interval:
+
+```csharp
+Observable.Interval(TimeSpan.FromMilliseconds(200), TimeProvider.System)
+    .Subscribe(_ =>
+    {
+        dataPoints.Add(GetNextValue());
+        graph.SetData(dataPoints.ToArray());
+    });
+```
+
+The graph renders the rightmost `width` data points (or `width * 2` for Braille style). Earlier data scrolls off the left edge.
+
+## Internal Timer
+
+The constructor accepts an interval for periodic self-invalidation. Set `intervalMs: 0` to disable the internal timer entirely and rely only on `SetData` for repaints:
+
+```csharp
+// Timer-driven refresh (default 500ms)
+new GraphNode(intervalMs: 500)
+
+// Data-driven only — no timer overhead
+new GraphNode(intervalMs: 0)
+```
+
+## Testable Timing
+
+Pass a `TimeProvider` for deterministic tests:
+
+```csharp
+var timeProvider = new FakeTimeProvider();
+var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
+
+graph.SetData([50, 100]);
+timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+// graph has now self-invalidated
+```
+
+## API Reference
+
+### Constructor
+
+```csharp
+public GraphNode(int intervalMs = 500, TimeProvider? timeProvider = null)
+```
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `.WithStyle(GraphStyle)` | Set rendering style |
+| `.WithGradient(Gradient)` | Apply gradient coloring by row |
+| `.WithColor(Color)` | Single-color convenience |
+| `.WithRange(double min, double max)` | Set data value range (default 0–100) |
+| `.SetData(double[])` | Push data and trigger repaint |
+| `.Start()` | Start internal timer |
+| `.Stop()` | Stop internal timer |
+
+### GraphStyle Enum
+
+| Style | Description |
+|-------|-------------|
+| `Blocks` | Filled block columns (default) |
+| `Outline` | Top edge only |
+| `Braille` | Double resolution braille dots |
+| `Ascii` | ASCII fallback characters |
+
+## Source Code
+
+::: details View GraphNode implementation
+<<< @/../src/Termina/Layout/GraphNode.cs{csharp}
+:::

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -13,6 +13,8 @@ Termina provides a set of built-in layout nodes (components) for building termin
 | [TextNode](/components/text-node) | Renders styled text with word wrapping |
 | [PanelNode](/components/panel-node) | Bordered container with title |
 | [SpinnerNode](/components/spinner-node) | Animated loading indicator |
+| [GraphNode](/components/graph-node) | Live scrolling graph with gradient coloring |
+| [ProgressBarNode](/components/progress-bar-node) | Progress bar with gradient fill and label |
 | [StreamingTextNode](/components/streaming-text-node) | Streaming text with scrolling |
 
 ## Input Components

--- a/docs/components/progress-bar-node.md
+++ b/docs/components/progress-bar-node.md
@@ -1,0 +1,99 @@
+# ProgressBarNode
+
+A single-row progress bar with gradient fill, customizable characters, and an optional label.
+
+## Basic Usage
+
+```csharp
+new ProgressBarNode()
+    .WithColor(Color.Green)
+    .WithValue(0.5)
+```
+
+## Gradient Fill
+
+Apply a gradient that maps color across the bar width:
+
+```csharp
+var gradient = Gradient.Create(
+    Color.FromRgb(255, 50, 50),   // red at start
+    Color.FromRgb(255, 200, 0),   // yellow in the middle
+    Color.FromRgb(50, 255, 50));  // green at end
+
+new ProgressBarNode()
+    .WithGradient(gradient)
+    .WithValue(0.75)
+```
+
+## Labels
+
+Add a formatted label after the bar. The format string receives the normalized value (0–1):
+
+```csharp
+new ProgressBarNode()
+    .WithColor(Color.Cyan)
+    .WithValue(0.42)
+    .WithLabel("{0:P0}")    // renders "42%"
+```
+
+## Custom Characters
+
+Change the fill and empty characters:
+
+```csharp
+new ProgressBarNode()
+    .WithFillChar('━')
+    .WithEmptyChar('─')
+    .WithEmptyColor(Color.DarkGray)
+    .WithColor(Color.BrightGreen)
+    .WithValue(0.6)
+```
+
+## Custom Range
+
+By default the value range is 0–1. Override with `WithRange`:
+
+```csharp
+new ProgressBarNode()
+    .WithRange(0, 200)
+    .WithValue(150)       // 75% filled
+    .WithLabel("{0:P0}")  // "75%"
+```
+
+## Reactive Updates
+
+`WithValue` fires invalidation, so the bar repaints immediately:
+
+```csharp
+Observable.Interval(TimeSpan.FromMilliseconds(100), TimeProvider.System)
+    .Subscribe(_ => progressBar.WithValue(GetProgress()));
+```
+
+## API Reference
+
+### Constructor
+
+```csharp
+public ProgressBarNode()
+```
+
+Defaults to `Height(1)` and `WidthFill()`.
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `.WithGradient(Gradient)` | Apply gradient across filled portion |
+| `.WithColor(Color)` | Single-color convenience |
+| `.WithValue(double)` | Set current value and trigger repaint |
+| `.WithRange(double min, double max)` | Set value range (default 0–1) |
+| `.WithLabel(string format)` | Format string for label (receives normalized 0–1) |
+| `.WithFillChar(char)` | Filled character (default `█`) |
+| `.WithEmptyChar(char)` | Empty character (default `░`) |
+| `.WithEmptyColor(Color)` | Color for empty portion (default `DarkGray`) |
+
+## Source Code
+
+::: details View ProgressBarNode implementation
+<<< @/../src/Termina/Layout/ProgressBarNode.cs{csharp}
+:::

--- a/docs/styling/colors.md
+++ b/docs/styling/colors.md
@@ -95,6 +95,37 @@ new TextNode("Styled")
     .WithBackground(Color.Blue)
 ```
 
+## Color Interpolation
+
+`Color.Lerp` linearly interpolates between two RGB colors:
+
+```csharp
+var midpoint = Color.Lerp(Color.FromRgb(255, 0, 0), Color.FromRgb(0, 0, 255), 0.5f);
+// Result: purple (127, 0, 127)
+```
+
+If either color is not in RGB mode, `Lerp` returns the first color unchanged.
+
+## Gradients
+
+The `Gradient` record defines a series of color stops and interpolates between them. Use gradients with `GraphNode` and `ProgressBarNode` for smooth color transitions.
+
+```csharp
+// Evenly spaced stops
+var gradient = Gradient.Create(Color.Red, Color.Yellow, Color.Green);
+
+// Custom stop positions
+var custom = Gradient.Create(
+    (0.0f, Color.FromRgb(255, 0, 0)),
+    (0.3f, Color.FromRgb(255, 200, 0)),
+    (1.0f, Color.FromRgb(0, 255, 0)));
+
+// Sample at any position (0–1)
+Color color = gradient.Sample(0.5f);
+```
+
+At least two colors are required. Positions outside the 0–1 range are clamped.
+
 ## Color Support by Component
 
 | Component | Foreground | Background | Other |
@@ -104,6 +135,8 @@ new TextNode("Styled")
 | SpinnerNode | - | - | Spinner, Label |
 | TextInputNode | ✓ | ✓ | Placeholder, Cursor, Selection |
 | StreamingTextNode | ✓ | ✓ | Prefix |
+| GraphNode | - | - | Gradient, Single color |
+| ProgressBarNode | - | - | Gradient, Single color, Empty color |
 
 ## Terminal Compatibility
 

--- a/src/Termina/Layout/GraphNode.cs
+++ b/src/Termina/Layout/GraphNode.cs
@@ -1,0 +1,278 @@
+using R3;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Reactive LayoutNode that renders a live scrolling graph with optional gradient coloring.
+/// Uses IAnimatedNode (like SpinnerNode) so only this region is invalidated,
+/// NOT the parent layout.
+/// </summary>
+public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
+{
+    private static readonly char[] BlockChars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    private static readonly char[] OutlineChars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '▔'];
+    private static readonly char[] AsciiChars = [' ', '_', '.', '-', '~', '^', '*', '#', '@'];
+
+    private static readonly char[][] BrailleChars =
+    [
+        ['⠀', '⢀', '⢠', '⢰', '⢸'],
+        ['⡀', '⣀', '⣠', '⣰', '⣸'],
+        ['⡄', '⣄', '⣤', '⣴', '⣼'],
+        ['⡆', '⣆', '⣦', '⣶', '⣾'],
+        ['⡇', '⣇', '⣧', '⣷', '⣿'],
+    ];
+
+    private readonly Subject<Unit> _invalidated = new();
+    private readonly TimeProvider _timeProvider;
+    private readonly int _intervalMs;
+    private IDisposable? _timerSubscription;
+    private double[] _data = [];
+    private GraphStyle _style = GraphStyle.Blocks;
+    private Gradient? _gradient;
+    private double _minValue;
+    private double _maxValue = 100;
+
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
+    public bool IsAnimating { get; private set; }
+
+    public GraphNode(int intervalMs = 500, TimeProvider? timeProvider = null)
+    {
+        _intervalMs = intervalMs;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        Start();
+    }
+
+    /// <summary>
+    /// Push new data to render.
+    /// </summary>
+    public void SetData(double[] data)
+    {
+        _data = data;
+    }
+
+    public void Start()
+    {
+        if (IsAnimating)
+        {
+            return;
+        }
+
+        _timerSubscription ??= Observable.Interval(TimeSpan.FromMilliseconds(_intervalMs), _timeProvider)
+            .Subscribe(_ => { _invalidated.OnNext(Unit.Default); });
+        IsAnimating = true;
+    }
+
+    public void Stop()
+    {
+        if (!IsAnimating)
+        {
+            return;
+        }
+
+        _timerSubscription?.Dispose();
+        _timerSubscription = null;
+        IsAnimating = false;
+    }
+
+    public GraphNode WithStyle(GraphStyle style)
+    {
+        _style = style;
+        return this;
+    }
+
+    /// <summary>
+    /// Apply a gradient for vertical coloring. Each row samples the gradient
+    /// at <c>row / (height - 1)</c>.
+    /// </summary>
+    public GraphNode WithGradient(Gradient gradient)
+    {
+        _gradient = gradient;
+        return this;
+    }
+
+    /// <summary>
+    /// Convenience: creates a single-color gradient.
+    /// </summary>
+    public GraphNode WithColor(Color color)
+    {
+        _gradient = Gradient.Create(color, color);
+        return this;
+    }
+
+    public GraphNode WithRange(double min, double max)
+    {
+        _minValue = min;
+        _maxValue = max;
+        return this;
+    }
+
+    public override Size Measure(Size available)
+    {
+        var w = WidthConstraint.Compute(available.Width, available.Width, available.Width);
+        var h = HeightConstraint.Compute(available.Height, available.Height, available.Height);
+        return new Size(w, h);
+    }
+
+    public override void Render(IRenderContext context, Rect bounds)
+    {
+        if (!bounds.HasArea)
+        {
+            return;
+        }
+
+        var width = bounds.Width;
+        var height = bounds.Height;
+
+        var maxPoints = _style == GraphStyle.Braille ? width * 2 : width;
+        var data = _data;
+
+        // Create a sub-context clipped to our bounds.
+        var ctx = context.CreateSubContext(bounds);
+
+        switch (_style)
+        {
+            case GraphStyle.Blocks: RenderColumns(ctx, data, width, height, BlockChars); break;
+            case GraphStyle.Outline: RenderOutline(ctx, data, width, height); break;
+            case GraphStyle.Braille: RenderBraille(ctx, data, width, height); break;
+            case GraphStyle.Ascii: RenderColumns(ctx, data, width, height, AsciiChars); break;
+        }
+
+        ctx.ResetColors();
+    }
+
+    private void RenderColumns(IRenderContext ctx, double[] data, int width, int height, char[] chars)
+    {
+        for (var col = 0; col < width; col++)
+        {
+            var dataIdx = data.Length - width + col;
+            var filledRows = dataIdx >= 0 ? Normalize(data[dataIdx]) * height : 0.0;
+
+            for (var row = 0; row < height; row++)
+            {
+                var y = height - 1 - row;
+
+                int charIdx;
+                if (filledRows >= row + 1)
+                {
+                    charIdx = 8;
+                }
+                else if (filledRows > row)
+                {
+                    charIdx = Math.Clamp((int)Math.Ceiling((filledRows - row) * 7.999), 1, 8);
+                }
+                else
+                {
+                    charIdx = 0;
+                }
+
+                if (charIdx > 0 && _gradient is not null)
+                {
+                    var t = height > 1 ? row / (float)(height - 1) : 0f;
+                    ctx.SetForeground(_gradient.Sample(t));
+                }
+
+                ctx.WriteAt(col, y, chars[Math.Min(charIdx, chars.Length - 1)]);
+                ctx.ResetColors();
+            }
+        }
+    }
+
+    private void RenderOutline(IRenderContext ctx, double[] data, int width, int height)
+    {
+        for (var col = 0; col < width; col++)
+        {
+            var dataIdx = data.Length - width + col;
+            var filledRows = dataIdx >= 0 ? Normalize(data[dataIdx]) * height : 0.0;
+            var edgeRow = (int)filledRows;
+
+            for (var row = 0; row < height; row++)
+            {
+                var y = height - 1 - row;
+
+                if (row == edgeRow && filledRows > 0)
+                {
+                    var charIdx = Math.Clamp((int)Math.Ceiling((filledRows - row) * 7.999), 1, 8);
+                    if (_gradient is not null)
+                    {
+                        var t = height > 1 ? row / (float)(height - 1) : 0f;
+                        ctx.SetForeground(_gradient.Sample(t));
+                    }
+
+                    ctx.WriteAt(col, y, OutlineChars[charIdx]);
+                    ctx.ResetColors();
+                }
+                else
+                {
+                    ctx.WriteAt(col, y, ' ');
+                }
+            }
+        }
+    }
+
+    private void RenderBraille(IRenderContext ctx, double[] data, int width, int height)
+    {
+        var subHeight = height * 2;
+
+        for (var col = 0; col < width; col++)
+        {
+            var botIdx = data.Length - width * 2 + col * 2;
+            var topIdx = botIdx + 1;
+
+            var botFilled = botIdx >= 0 && botIdx < data.Length ? Normalize(data[botIdx]) * subHeight : 0.0;
+            var topFilled = topIdx >= 0 && topIdx < data.Length ? Normalize(data[topIdx]) * subHeight : 0.0;
+
+            for (var row = 0; row < height; row++)
+            {
+                var y = height - 1 - row;
+
+                var botSubRow = row * 2;
+                var topSubRow = row * 2 + 1;
+                var botFill = (int)Math.Clamp((botFilled - botSubRow) * 4, 0, 4);
+                var topFill = (int)Math.Clamp((topFilled - topSubRow) * 4, 0, 4);
+                var c = BrailleChars[botFill][topFill];
+
+                if (c != '⠀' && _gradient is not null)
+                {
+                    var t = height > 1 ? row / (float)(height - 1) : 0f;
+                    ctx.SetForeground(_gradient.Sample(t));
+                }
+
+                ctx.WriteAt(col, y, c);
+                ctx.ResetColors();
+            }
+        }
+    }
+
+    private double Normalize(double value)
+    {
+        var range = _maxValue - _minValue;
+        if (range <= 0)
+        {
+            return 0;
+        }
+
+        return Math.Clamp((value - _minValue) / range, 0.0, 1.0);
+    }
+
+    public override void OnActivate()
+    {
+        Start();
+        base.OnActivate();
+    }
+
+    public override void OnDeactivate()
+    {
+        Stop();
+        base.OnDeactivate();
+    }
+
+    public override void Dispose()
+    {
+        Stop();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Termina/Layout/GraphNode.cs
+++ b/src/Termina/Layout/GraphNode.cs
@@ -45,16 +45,19 @@ public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     }
 
     /// <summary>
-    /// Push new data to render.
+    /// Push new data to render. Immediately fires <see cref="Invalidated"/> so the node
+    /// repaints as soon as data arrives, regardless of the internal timer interval.
     /// </summary>
-    public void SetData(double[] data)
+    public GraphNode SetData(double[] data)
     {
         _data = data;
+        _invalidated.OnNext(Unit.Default);
+        return this;
     }
 
     public void Start()
     {
-        if (IsAnimating)
+        if (IsAnimating || _intervalMs <= 0)
         {
             return;
         }

--- a/src/Termina/Layout/GraphStyle.cs
+++ b/src/Termina/Layout/GraphStyle.cs
@@ -1,0 +1,16 @@
+namespace Termina.Layout;
+
+public enum GraphStyle
+{
+    /// <summary>▁▂▃▄▅▆▇█ -- classic filled blocks from bottom</summary>
+    Blocks,
+
+    /// <summary>Only the top edge is drawn -- hollow inside</summary>
+    Outline,
+
+    /// <summary>Braille dots -- double vertical resolution per row</summary>
+    Braille,
+
+    /// <summary>ASCII _ . - ~ ^ * # @ fallback</summary>
+    Ascii,
+}

--- a/src/Termina/Layout/ProgressBarNode.cs
+++ b/src/Termina/Layout/ProgressBarNode.cs
@@ -86,8 +86,11 @@ public sealed class ProgressBarNode : LayoutNode, IInvalidatingNode
 
     public override void Dispose()
     {
-        _invalidated.OnCompleted();
-        _invalidated.Dispose();
+        if (!_invalidated.IsDisposed)
+        {
+            _invalidated.OnCompleted();
+            _invalidated.Dispose();
+        }
         base.Dispose();
     }
 }

--- a/src/Termina/Layout/ProgressBarNode.cs
+++ b/src/Termina/Layout/ProgressBarNode.cs
@@ -1,0 +1,93 @@
+using R3;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Layout;
+
+public sealed class ProgressBarNode : LayoutNode, IInvalidatingNode
+{
+    private readonly Subject<Unit> _invalidated = new();
+    private Gradient? _gradient;
+    private double _value;
+    private double _minValue;
+    private double _maxValue = 1.0;
+    private string? _labelFormat;
+    private char _fillChar = '█';
+    private char _emptyChar = '░';
+    private Color _emptyColor = Color.DarkGray;
+
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
+
+    public ProgressBarNode()
+    {
+        HeightConstraint = new SizeConstraint.Fixed(1);
+        WidthConstraint = new SizeConstraint.Fill();
+    }
+
+    public ProgressBarNode WithGradient(Gradient gradient) { _gradient = gradient; return this; }
+    public ProgressBarNode WithColor(Color color) { _gradient = Gradient.Create(color, color); return this; }
+    public ProgressBarNode WithValue(double value) { _value = value; _invalidated.OnNext(Unit.Default); return this; }
+    public ProgressBarNode WithRange(double min, double max) { _minValue = min; _maxValue = max; return this; }
+    public ProgressBarNode WithLabel(string format) { _labelFormat = format; return this; }
+    public ProgressBarNode WithFillChar(char c) { _fillChar = c; return this; }
+    public ProgressBarNode WithEmptyChar(char c) { _emptyChar = c; return this; }
+    public ProgressBarNode WithEmptyColor(Color color) { _emptyColor = color; return this; }
+
+    public override Size Measure(Size available)
+    {
+        var w = WidthConstraint.Compute(available.Width, available.Width, available.Width);
+        var h = HeightConstraint.Compute(available.Height, 1, available.Height);
+        return new Size(w, h);
+    }
+
+    public override void Render(IRenderContext context, Rect bounds)
+    {
+        if (!bounds.HasArea)
+            return;
+
+        var ctx = context.CreateSubContext(bounds);
+        var totalWidth = bounds.Width;
+        var range = _maxValue - _minValue;
+        var normalized = range > 0 ? Math.Clamp((_value - _minValue) / range, 0.0, 1.0) : 0.0;
+
+        string? label = null;
+        var barWidth = totalWidth;
+
+        if (_labelFormat is not null)
+        {
+            label = string.Format(_labelFormat, normalized);
+            barWidth = Math.Max(1, totalWidth - label.Length - 1);
+        }
+
+        var filledCols = (int)Math.Round(normalized * barWidth);
+
+        for (var col = 0; col < barWidth; col++)
+        {
+            if (col < filledCols)
+            {
+                if (_gradient is not null)
+                {
+                    var t = barWidth > 1 ? col / (float)(barWidth - 1) : 0f;
+                    ctx.SetForeground(_gradient.Sample(t));
+                }
+                ctx.WriteAt(col, 0, _fillChar);
+            }
+            else
+            {
+                ctx.SetForeground(_emptyColor);
+                ctx.WriteAt(col, 0, _emptyChar);
+            }
+            ctx.ResetColors();
+        }
+
+        if (label is not null)
+            ctx.WriteAt(barWidth + 1, 0, label);
+    }
+
+    public override void Dispose()
+    {
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Termina/Terminal/Color.cs
+++ b/src/Termina/Terminal/Color.cs
@@ -131,6 +131,22 @@ public readonly struct Color : IEquatable<Color>
 
     public static bool operator !=(Color left, Color right) => !left.Equals(right);
 
+    /// <summary>
+    /// Linearly interpolate between two RGB colors.
+    /// If either color is not RGB mode, returns <paramref name="a"/> unchanged.
+    /// </summary>
+    public static Color Lerp(Color a, Color b, float t)
+    {
+        if (a.Mode != ColorMode.Rgb || b.Mode != ColorMode.Rgb)
+            return a;
+
+        t = Math.Clamp(t, 0f, 1f);
+        var r = (byte)(a.R + (b.R - a.R) * t);
+        var g = (byte)(a.G + (b.G - a.G) * t);
+        var bl = (byte)(a.B + (b.B - a.B) * t);
+        return FromRgb(r, g, bl);
+    }
+
     public override string ToString() => Mode switch
     {
         ColorMode.Default => "Default",

--- a/src/Termina/Terminal/Gradient.cs
+++ b/src/Termina/Terminal/Gradient.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Terminal;
+
+/// <summary>
+/// An immutable color gradient defined by a series of color stops.
+/// Use <see cref="Sample"/> to interpolate a color at any position along the gradient.
+/// </summary>
+public sealed record Gradient
+{
+    private readonly (float Position, Color Color)[] _stops;
+
+    private Gradient((float Position, Color Color)[] stops)
+    {
+        _stops = stops;
+    }
+
+    /// <summary>
+    /// Create a gradient with evenly distributed color stops.
+    /// At least 2 colors are required.
+    /// </summary>
+    public static Gradient Create() =>
+        throw new ArgumentException("Gradient requires at least 2 colors.", "colors");
+
+    /// <summary>
+    /// Create a gradient with evenly distributed color stops.
+    /// </summary>
+    public static Gradient Create(params Color[] colors)
+    {
+        if (colors.Length < 2)
+            throw new ArgumentException("Gradient requires at least 2 colors.", nameof(colors));
+
+        var stops = new (float, Color)[colors.Length];
+        for (var i = 0; i < colors.Length; i++)
+            stops[i] = (i / (float)(colors.Length - 1), colors[i]);
+
+        return new Gradient(stops);
+    }
+
+    /// <summary>
+    /// Create a gradient with custom stop positions.
+    /// </summary>
+    public static Gradient Create(params (float position, Color color)[] stops)
+    {
+        if (stops.Length < 2)
+            throw new ArgumentException("Gradient requires at least 2 stops.", nameof(stops));
+
+        var sorted = stops.OrderBy(s => s.position).ToArray();
+        return new Gradient(sorted);
+    }
+
+    /// <summary>
+    /// Sample the interpolated color at position <paramref name="t"/> (clamped to 0–1).
+    /// </summary>
+    public Color Sample(float t)
+    {
+        t = Math.Clamp(t, 0f, 1f);
+
+        if (t <= _stops[0].Position)
+            return _stops[0].Color;
+
+        if (t >= _stops[^1].Position)
+            return _stops[^1].Color;
+
+        for (var i = 0; i < _stops.Length - 1; i++)
+        {
+            var (pos0, color0) = _stops[i];
+            var (pos1, color1) = _stops[i + 1];
+
+            if (t >= pos0 && t <= pos1)
+            {
+                var segmentT = (t - pos0) / (pos1 - pos0);
+                return Color.Lerp(color0, color1, segmentT);
+            }
+        }
+
+        return _stops[^1].Color;
+    }
+}

--- a/tests/Termina.Tests/Layout/GraphNodeTests.cs
+++ b/tests/Termina.Tests/Layout/GraphNodeTests.cs
@@ -171,6 +171,32 @@ public class GraphNodeTests
         Assert.True(ctx.WrittenCells.Count > 0);
     }
 
+    [Fact]
+    public void SetData_FiresInvalidated()
+    {
+        var graph = new GraphNode(intervalMs: 0);
+        var invalidated = false;
+        graph.Invalidated.Subscribe(_ => invalidated = true);
+
+        graph.SetData([1, 2, 3]);
+
+        Assert.True(invalidated);
+    }
+
+    [Fact]
+    public void IntervalZero_DisablesInternalTimer()
+    {
+        var time = new FakeTimeProvider();
+        var graph = new GraphNode(intervalMs: 0, timeProvider: time);
+        var fired = 0;
+        graph.Invalidated.Subscribe(_ => fired++);
+
+        time.Advance(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(0, fired);
+        Assert.False(graph.IsAnimating);
+    }
+
     /// <summary>
     /// Minimal render context for testing that captures written content and colors.
     /// </summary>

--- a/tests/Termina.Tests/Layout/GraphNodeTests.cs
+++ b/tests/Termina.Tests/Layout/GraphNodeTests.cs
@@ -1,0 +1,263 @@
+using Microsoft.Extensions.Time.Testing;
+using R3;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+public class GraphNodeTests
+{
+    [Fact]
+    public void WithStyle_ReturnsSelf()
+    {
+        var graph = new GraphNode();
+        var result = graph.WithStyle(GraphStyle.Braille);
+        Assert.Same(graph, result);
+    }
+
+    [Fact]
+    public void WithColor_ReturnsSelf()
+    {
+        var graph = new GraphNode();
+        var result = graph.WithColor(Color.Red);
+        Assert.Same(graph, result);
+    }
+
+    [Fact]
+    public void WithGradient_ReturnsSelf()
+    {
+        var graph = new GraphNode();
+        var gradient = Gradient.Create(Color.Red, Color.Green);
+        var result = graph.WithGradient(gradient);
+        Assert.Same(graph, result);
+    }
+
+    [Fact]
+    public void WithRange_ReturnsSelf()
+    {
+        var graph = new GraphNode();
+        var result = graph.WithRange(0, 200);
+        Assert.Same(graph, result);
+    }
+
+    [Fact]
+    public void Render_EmptyBounds_DoesNotThrow()
+    {
+        var graph = new GraphNode();
+        var ctx = new TestRenderContext(0, 0);
+        graph.Render(ctx, new Rect(0, 0, 0, 0));
+        // No exception means success
+    }
+
+    [Fact]
+    public void Render_WithData_WritesCells()
+    {
+        var graph = new GraphNode()
+            .WithColor(Color.Cyan)
+            .WithRange(0, 100);
+        graph.SetData([50, 100]);
+
+        var ctx = new TestRenderContext(2, 4);
+        graph.Render(ctx, new Rect(0, 0, 2, 4));
+
+        // With data [50, 100], col 0 = 50% filled (2 rows), col 1 = 100% filled (4 rows)
+        // Should have written non-space characters
+        Assert.True(ctx.WrittenCells.Count > 0);
+    }
+
+    [Fact]
+    public void Render_WithGradient_AppliesDifferentColorsPerRow()
+    {
+        var gradient = Gradient.Create(Color.Red, Color.Green);
+        var graph = new GraphNode()
+            .WithGradient(gradient)
+            .WithRange(0, 100);
+        graph.SetData([100]); // fully filled column
+
+        var ctx = new TestRenderContext(1, 4);
+        graph.Render(ctx, new Rect(0, 0, 1, 4));
+
+        // All 4 rows should be filled, each with a different gradient sample
+        var colors = ctx.ForegroundColors.Select(c => c.Color).Distinct().ToList();
+        Assert.True(colors.Count > 1, $"Expected multiple gradient colors, got {colors.Count}");
+    }
+
+    [Fact]
+    public void OnDeactivate_StopsAnimation()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
+
+        Assert.True(graph.IsAnimating);
+
+        graph.OnDeactivate();
+
+        Assert.False(graph.IsAnimating);
+    }
+
+    [Fact]
+    public void OnActivate_ResumesAnimation()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
+
+        graph.OnDeactivate();
+        Assert.False(graph.IsAnimating);
+
+        graph.OnActivate();
+        Assert.True(graph.IsAnimating);
+    }
+
+    [Fact]
+    public void Dispose_CompletesInvalidated()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
+
+        var completed = false;
+        graph.Invalidated.Subscribe(
+            onNext: _ => { },
+            onErrorResume: _ => { },
+            onCompleted: _ => completed = true);
+
+        graph.Dispose();
+
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public void Render_Braille_WithData_WritesBrailleChars()
+    {
+        var graph = new GraphNode()
+            .WithStyle(GraphStyle.Braille)
+            .WithColor(Color.Cyan)
+            .WithRange(0, 100);
+        graph.SetData([100, 100]);
+
+        var ctx = new TestRenderContext(1, 2);
+        graph.Render(ctx, new Rect(0, 0, 1, 2));
+
+        Assert.True(ctx.WrittenCells.Count > 0);
+    }
+
+    [Fact]
+    public void Render_Outline_WithData_WritesOutlineChars()
+    {
+        var graph = new GraphNode()
+            .WithStyle(GraphStyle.Outline)
+            .WithColor(Color.Cyan)
+            .WithRange(0, 100);
+        graph.SetData([50]);
+
+        var ctx = new TestRenderContext(1, 4);
+        graph.Render(ctx, new Rect(0, 0, 1, 4));
+
+        Assert.True(ctx.WrittenCells.Count > 0);
+    }
+
+    [Fact]
+    public void Render_Ascii_WithData_WritesAsciiChars()
+    {
+        var graph = new GraphNode()
+            .WithStyle(GraphStyle.Ascii)
+            .WithColor(Color.Cyan)
+            .WithRange(0, 100);
+        graph.SetData([100]);
+
+        var ctx = new TestRenderContext(1, 2);
+        graph.Render(ctx, new Rect(0, 0, 1, 2));
+
+        Assert.True(ctx.WrittenCells.Count > 0);
+    }
+
+    /// <summary>
+    /// Minimal render context for testing that captures written content and colors.
+    /// </summary>
+    private sealed class TestRenderContext : IRenderContext
+    {
+        private readonly int _width;
+        private readonly int _height;
+        private Color? _currentForeground;
+
+        public List<(int X, int Y, string Text)> WrittenCells { get; } = [];
+        public List<(int X, int Y, Color Color)> ForegroundColors { get; } = [];
+
+        public TestRenderContext(int width, int height)
+        {
+            _width = width;
+            _height = height;
+        }
+
+        public int Width => _width;
+        public int Height => _height;
+
+        public void WriteAt(int x, int y, char c)
+        {
+            WrittenCells.Add((x, y, c.ToString()));
+            if (_currentForeground.HasValue)
+            {
+                ForegroundColors.Add((x, y, _currentForeground.Value));
+            }
+        }
+
+        public void WriteAt(int x, int y, string text)
+        {
+            WrittenCells.Add((x, y, text));
+            if (_currentForeground.HasValue)
+            {
+                ForegroundColors.Add((x, y, _currentForeground.Value));
+            }
+        }
+
+        public void SetForeground(Color color)
+        {
+            _currentForeground = color;
+        }
+
+        public void SetBackground(Color color) { }
+
+        public void ResetColors()
+        {
+            _currentForeground = null;
+        }
+
+        public void SetDecoration(TextDecoration decoration) { }
+        public void ApplyStyle(TextStyle style) { }
+        public void Fill(int x, int y, int width, int height, char c = ' ') { }
+        public void Clear() { }
+
+        public IRenderContext CreateSubContext(Rect bounds)
+        {
+            return new SubContext(this, bounds);
+        }
+
+        private sealed class SubContext : IRenderContext
+        {
+            private readonly TestRenderContext _parent;
+            private readonly Rect _bounds;
+
+            public SubContext(TestRenderContext parent, Rect bounds)
+            {
+                _parent = parent;
+                _bounds = bounds;
+            }
+
+            public int Width => _bounds.Width;
+            public int Height => _bounds.Height;
+
+            public void WriteAt(int x, int y, char c) => _parent.WriteAt(_bounds.X + x, _bounds.Y + y, c);
+            public void WriteAt(int x, int y, string text) => _parent.WriteAt(_bounds.X + x, _bounds.Y + y, text);
+            public void SetForeground(Color color) => _parent.SetForeground(color);
+            public void SetBackground(Color color) => _parent.SetBackground(color);
+            public void ResetColors() => _parent.ResetColors();
+            public void SetDecoration(TextDecoration decoration) { }
+            public void ApplyStyle(TextStyle style) { }
+            public void Fill(int x, int y, int width, int height, char c = ' ') { }
+            public void Clear() { }
+
+            public IRenderContext CreateSubContext(Rect bounds) =>
+                new SubContext(_parent, new Rect(_bounds.X + bounds.X, _bounds.Y + bounds.Y, bounds.Width, bounds.Height));
+        }
+    }
+}

--- a/tests/Termina.Tests/Layout/ProgressBarNodeTests.cs
+++ b/tests/Termina.Tests/Layout/ProgressBarNodeTests.cs
@@ -1,0 +1,220 @@
+using R3;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Termina.Tests.Layout;
+
+public class ProgressBarNodeTests
+{
+    // ── fluent API ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void WithGradient_ReturnsSelf()
+    {
+        var node = new ProgressBarNode();
+        var gradient = Gradient.Create(Color.Green, Color.Red);
+        Assert.Same(node, node.WithGradient(gradient));
+    }
+
+    [Fact]
+    public void WithColor_ReturnsSelf()
+    {
+        var node = new ProgressBarNode();
+        Assert.Same(node, node.WithColor(Color.Cyan));
+    }
+
+    [Fact]
+    public void WithEmptyColor_ReturnsSelf()
+    {
+        var node = new ProgressBarNode();
+        Assert.Same(node, node.WithEmptyColor(Color.DarkGray));
+    }
+
+    // ── render: edge cases ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Render_EmptyBounds_DoesNotThrow()
+    {
+        var node = new ProgressBarNode().WithValue(0.5);
+        var ctx = new TestRenderContext(0, 0);
+        var bounds = new Rect(0, 0, 0, 0);
+
+        var ex = Record.Exception(() => node.Render(ctx, bounds));
+        Assert.Null(ex);
+    }
+
+    // ── render: half-full ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Render_HalfFull_WritesFilledAndEmptyCells()
+    {
+        // width=10, value=0.5 → 5 filled, 5 empty
+        var node = new ProgressBarNode().WithValue(0.5);
+        var ctx = new TestRenderContext(10, 1);
+        var bounds = new Rect(0, 0, 10, 1);
+
+        node.Render(ctx, bounds);
+
+        var cells = ctx.WrittenCells;
+        Assert.Equal(10, cells.Count);
+
+        // First 5 should be fill char
+        for (var i = 0; i < 5; i++)
+            Assert.Equal("█", cells[i].Text);
+
+        // Remaining 5 should be empty char
+        for (var i = 5; i < 10; i++)
+            Assert.Equal("░", cells[i].Text);
+    }
+
+    // ── render: gradient ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Render_WithGradient_AppliesGradientColors()
+    {
+        // Green→Red gradient, value=1.0, width=10 → all 10 cols filled
+        // col 0 → t=0 → green, col 9 → t=1 → red
+        var gradient = Gradient.Create(Color.Green, Color.Red);
+        var node = new ProgressBarNode()
+            .WithGradient(gradient)
+            .WithValue(1.0);
+
+        var ctx = new TestRenderContext(10, 1);
+        node.Render(ctx, new Rect(0, 0, 10, 1));
+
+        var colors = ctx.ForegroundColors;
+        Assert.True(colors.Count >= 2, "Expected at least 2 color entries");
+
+        var firstColor = colors.First(c => c.X == 0).Color;
+        var lastColor = colors.First(c => c.X == 9).Color;
+
+        Assert.Equal(Color.Green, firstColor);
+        Assert.Equal(Color.Red, lastColor);
+    }
+
+    // ── render: label ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Render_WithLabel_RendersLabelContaining67()
+    {
+        // value=0.67, format="{0:P0}" → label contains "67"
+        var node = new ProgressBarNode()
+            .WithValue(0.67)
+            .WithLabel("{0:P0}");
+
+        var ctx = new TestRenderContext(20, 1);
+        node.Render(ctx, new Rect(0, 0, 20, 1));
+
+        var labelCell = ctx.WrittenCells.FirstOrDefault(c => c.Text.Contains("67"));
+        Assert.NotEqual(default, labelCell);
+    }
+
+    // ── render: range normalization ───────────────────────────────────────────
+
+    [Fact]
+    public void Render_WithRange_NormalizesCorrectly()
+    {
+        // range 0-200, value=100 → normalized=0.5 → 5 filled of 10
+        var node = new ProgressBarNode()
+            .WithRange(0, 200)
+            .WithValue(100);
+
+        var ctx = new TestRenderContext(10, 1);
+        node.Render(ctx, new Rect(0, 0, 10, 1));
+
+        var filled = ctx.WrittenCells.Count(c => c.Text == "█");
+        Assert.Equal(5, filled);
+    }
+
+    // ── dispose ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Dispose_CompletesInvalidated()
+    {
+        var node = new ProgressBarNode();
+        var completed = false;
+        node.Invalidated.Subscribe(
+            onNext: _ => { },
+            onErrorResume: _ => { },
+            onCompleted: _ => completed = true
+        );
+
+        node.Dispose();
+
+        Assert.True(completed);
+    }
+
+    // ── shared test context (mirrors GraphNodeTests.TestRenderContext) ─────────
+
+    private sealed class TestRenderContext : IRenderContext
+    {
+        private readonly int _width;
+        private readonly int _height;
+        private Color? _currentForeground;
+
+        public List<(int X, int Y, string Text)> WrittenCells { get; } = [];
+        public List<(int X, int Y, Color Color)> ForegroundColors { get; } = [];
+
+        public TestRenderContext(int width, int height)
+        {
+            _width = width;
+            _height = height;
+        }
+
+        public int Width => _width;
+        public int Height => _height;
+
+        public void WriteAt(int x, int y, char c)
+        {
+            WrittenCells.Add((x, y, c.ToString()));
+            if (_currentForeground.HasValue)
+                ForegroundColors.Add((x, y, _currentForeground.Value));
+        }
+
+        public void WriteAt(int x, int y, string text)
+        {
+            WrittenCells.Add((x, y, text));
+            if (_currentForeground.HasValue)
+                ForegroundColors.Add((x, y, _currentForeground.Value));
+        }
+
+        public void SetForeground(Color color) => _currentForeground = color;
+        public void SetBackground(Color color) { }
+        public void ResetColors() => _currentForeground = null;
+        public void SetDecoration(TextDecoration decoration) { }
+        public void ApplyStyle(TextStyle style) { }
+        public void Fill(int x, int y, int width, int height, char c = ' ') { }
+        public void Clear() { }
+
+        public IRenderContext CreateSubContext(Rect bounds) => new SubContext(this, bounds);
+
+        private sealed class SubContext : IRenderContext
+        {
+            private readonly TestRenderContext _parent;
+            private readonly Rect _bounds;
+
+            public SubContext(TestRenderContext parent, Rect bounds)
+            {
+                _parent = parent;
+                _bounds = bounds;
+            }
+
+            public int Width => _bounds.Width;
+            public int Height => _bounds.Height;
+
+            public void WriteAt(int x, int y, char c) => _parent.WriteAt(_bounds.X + x, _bounds.Y + y, c);
+            public void WriteAt(int x, int y, string text) => _parent.WriteAt(_bounds.X + x, _bounds.Y + y, text);
+            public void SetForeground(Color color) => _parent.SetForeground(color);
+            public void SetBackground(Color color) => _parent.SetBackground(color);
+            public void ResetColors() => _parent.ResetColors();
+            public void SetDecoration(TextDecoration decoration) { }
+            public void ApplyStyle(TextStyle style) { }
+            public void Fill(int x, int y, int width, int height, char c = ' ') { }
+            public void Clear() { }
+
+            public IRenderContext CreateSubContext(Rect bounds) =>
+                new SubContext(_parent, new Rect(_bounds.X + bounds.X, _bounds.Y + bounds.Y, bounds.Width, bounds.Height));
+        }
+    }
+}

--- a/tests/Termina.Tests/Terminal/ColorTests.cs
+++ b/tests/Termina.Tests/Terminal/ColorTests.cs
@@ -229,4 +229,84 @@ public class ColorTests
     {
         Assert.Equal("RGB(255,128,64)", Color.FromRgb(255, 128, 64).ToString());
     }
+
+    [Fact]
+    public void Lerp_BothRgb_InterpolatesMidpoint()
+    {
+        var a = Color.FromRgb(0, 0, 0);
+        var b = Color.FromRgb(200, 100, 50);
+
+        var result = Color.Lerp(a, b, 0.5f);
+
+        Assert.Equal(ColorMode.Rgb, result.Mode);
+        Assert.Equal(100, result.R);
+        Assert.Equal(50, result.G);
+        Assert.Equal(25, result.B);
+    }
+
+    [Fact]
+    public void Lerp_AtZero_ReturnsFirstColor()
+    {
+        var a = Color.FromRgb(10, 20, 30);
+        var b = Color.FromRgb(200, 100, 50);
+
+        var result = Color.Lerp(a, b, 0f);
+
+        Assert.Equal(a, result);
+    }
+
+    [Fact]
+    public void Lerp_AtOne_ReturnsSecondColor()
+    {
+        var a = Color.FromRgb(10, 20, 30);
+        var b = Color.FromRgb(200, 100, 50);
+
+        var result = Color.Lerp(a, b, 1f);
+
+        Assert.Equal(b, result);
+    }
+
+    [Fact]
+    public void Lerp_ClampsBelowZero()
+    {
+        var a = Color.FromRgb(0, 0, 0);
+        var b = Color.FromRgb(200, 100, 50);
+
+        var result = Color.Lerp(a, b, -0.5f);
+
+        Assert.Equal(a, result);
+    }
+
+    [Fact]
+    public void Lerp_ClampsAboveOne()
+    {
+        var a = Color.FromRgb(0, 0, 0);
+        var b = Color.FromRgb(200, 100, 50);
+
+        var result = Color.Lerp(a, b, 1.5f);
+
+        Assert.Equal(b, result);
+    }
+
+    [Fact]
+    public void Lerp_NonRgbColor_ReturnsFirst()
+    {
+        var a = Color.FromIndex(5);
+        var b = Color.FromRgb(200, 100, 50);
+
+        var result = Color.Lerp(a, b, 0.5f);
+
+        Assert.Equal(a, result);
+    }
+
+    [Fact]
+    public void Lerp_DefaultColor_ReturnsFirst()
+    {
+        var a = Color.Default;
+        var b = Color.FromRgb(200, 100, 50);
+
+        var result = Color.Lerp(a, b, 0.5f);
+
+        Assert.Equal(a, result);
+    }
 }

--- a/tests/Termina.Tests/Terminal/GradientTests.cs
+++ b/tests/Termina.Tests/Terminal/GradientTests.cs
@@ -1,0 +1,92 @@
+using Termina.Terminal;
+
+namespace Termina.Tests.Terminal;
+
+public class GradientTests
+{
+    [Fact]
+    public void Create_EvenlyDistributed_SampleAtZero_ReturnsFirstColor()
+    {
+        var g = Gradient.Create(Color.FromRgb(0, 0, 0), Color.FromRgb(255, 255, 255));
+        var result = g.Sample(0f);
+        Assert.Equal(Color.FromRgb(0, 0, 0), result);
+    }
+
+    [Fact]
+    public void Create_EvenlyDistributed_SampleAtOne_ReturnsLastColor()
+    {
+        var g = Gradient.Create(Color.FromRgb(0, 0, 0), Color.FromRgb(255, 255, 255));
+        var result = g.Sample(1f);
+        Assert.Equal(Color.FromRgb(255, 255, 255), result);
+    }
+
+    [Fact]
+    public void Create_EvenlyDistributed_SampleAtMidpoint()
+    {
+        var g = Gradient.Create(Color.FromRgb(0, 0, 0), Color.FromRgb(200, 100, 50));
+        var result = g.Sample(0.5f);
+        Assert.Equal(Color.FromRgb(100, 50, 25), result);
+    }
+
+    [Fact]
+    public void Create_ThreeStops_SampleAtMidpoint_ReturnsMiddleColor()
+    {
+        var green = Color.FromRgb(0, 255, 0);
+        var yellow = Color.FromRgb(255, 255, 0);
+        var red = Color.FromRgb(255, 0, 0);
+        var g = Gradient.Create(green, yellow, red);
+        var result = g.Sample(0.5f);
+        Assert.Equal(yellow, result);
+    }
+
+    [Fact]
+    public void Create_ThreeStops_SampleAtQuarter()
+    {
+        var green = Color.FromRgb(0, 255, 0);
+        var yellow = Color.FromRgb(255, 255, 0);
+        var red = Color.FromRgb(255, 0, 0);
+        var g = Gradient.Create(green, yellow, red);
+        var result = g.Sample(0.25f);
+        Assert.Equal(Color.FromRgb(127, 255, 0), result);
+    }
+
+    [Fact]
+    public void Create_CustomStops_SamplesCorrectly()
+    {
+        var g = Gradient.Create(
+            (0f, Color.FromRgb(0, 0, 0)),
+            (0.8f, Color.FromRgb(200, 200, 200)),
+            (1f, Color.FromRgb(255, 0, 0)));
+        Assert.Equal(Color.FromRgb(0, 0, 0), g.Sample(0f));
+        Assert.Equal(Color.FromRgb(200, 200, 200), g.Sample(0.8f));
+        Assert.Equal(Color.FromRgb(255, 0, 0), g.Sample(1f));
+    }
+
+    [Fact]
+    public void Sample_ClampsToZero()
+    {
+        var g = Gradient.Create(Color.FromRgb(100, 100, 100), Color.FromRgb(200, 200, 200));
+        var result = g.Sample(-1f);
+        Assert.Equal(Color.FromRgb(100, 100, 100), result);
+    }
+
+    [Fact]
+    public void Sample_ClampsToOne()
+    {
+        var g = Gradient.Create(Color.FromRgb(100, 100, 100), Color.FromRgb(200, 200, 200));
+        var result = g.Sample(2f);
+        Assert.Equal(Color.FromRgb(200, 200, 200), result);
+    }
+
+    [Fact]
+    public void Create_SingleColor_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Gradient.Create(Color.FromRgb(0, 0, 0)));
+    }
+
+    [Fact]
+    public void Create_Empty_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Gradient.Create());
+    }
+}


### PR DESCRIPTION
Summary

  - Add Color.Lerp for RGB interpolation and a Gradient record with color stop interpolation, forming the foundation
  for gradient-colored rendering.
  - Add GraphNode — a reactive layout node that renders live scrolling graphs in four styles (Blocks, Outline,
  Braille, ASCII) with gradient coloring, configurable data range, and data-driven invalidation.
  - Add ProgressBarNode — a single-row progress bar with gradient fill, customizable fill/empty characters, and an
  optional label.
  - Add an interactive Graphs & Progress gallery page demonstrating live graph style switching and an animated
  gradient progress bar.
  - Add full component documentation for GraphNode and ProgressBarNode. Update color docs with Color.Lerp and
  Gradient sections.

  Changes

  Color.cs — Add Lerp(Color a, Color b, float t) for linear RGB interpolation.

  Gradient.cs — Immutable color gradient with evenly spaced or custom-positioned stops. Sample(float t) returns the
  interpolated color.

  GraphNode.cs — Reactive layout node with four render styles, gradient support, SetData for immediate invalidation,
  and testable TimeProvider-based timer.

  GraphStyle.cs — Enum: Blocks, Outline, Braille, Ascii.

  ProgressBarNode.cs — Single-row bar with gradient fill, custom chars, label format, and invalidation on value
  change. Guarded against double-dispose.

  GraphGalleryPage.cs / GraphGalleryViewModel.cs — Interactive demo with live data, style switcher, and animated
  progress bar.

  docs/components/graph-node.md — Full component documentation with API reference.

  docs/components/progress-bar-node.md — Full component documentation with API reference.

  docs/styling/colors.md — New Color.Lerp and Gradient sections, updated component table.

  docs/components/index.md — Added GraphNode and ProgressBarNode to display components.

  Test coverage

  - ColorTests — Lerp at boundaries, midpoint, clamp, and non-RGB fallback
  - GradientTests — Even distribution, custom stops, boundary sampling
  - GraphNodeTests — All four render styles, gradient colors, data-driven invalidation, timer lifecycle
  - ProgressBarNodeTests — Half-full rendering, gradient, empty bounds, label, double-dispose safety

  Test plan

  - [x] dotnet test — all new and existing tests pass
  - [x] Run the gallery demo, navigate to Graphs & Progress, switch between all four styles
  - [x] Verify gradient colors render correctly on the graph and progress bar
  - [x] Verify existing gallery pages are unaffected