### PR TITLE
Add layout runtime context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,17 @@ _selectionConfirmed.OnNext(selectedItems);
 
 **Testable timing with TimeProvider:**
 ```csharp
-// Production: uses TimeProvider.System by default
-public SpinnerNode(int intervalMs = 80, TimeProvider? timeProvider = null)
+// Production: runtime context is supplied by the page/application lifecycle
+public SpinnerNode(int intervalMs = 80)
 
-// Test: use FakeTimeProvider for deterministic control
+// Test: supply FakeTimeProvider through LayoutRuntimeContext
 var timeProvider = new FakeTimeProvider();
-var spinner = new SpinnerNode(intervalMs: 80, timeProvider: timeProvider);
-timeProvider.Advance(TimeSpan.FromMilliseconds(80)); // Deterministic frame advance
+using var frameProvider = new TerminaRenderFrameProvider(() => { }, timeProvider, TimeSpan.FromMilliseconds(10));
+var spinner = new SpinnerNode(intervalMs: 80);
+spinner.SetRuntimeContext(new LayoutRuntimeContext(frameProvider, timeProvider, () => { }));
+spinner.OnActivate();
+timeProvider.Advance(TimeSpan.FromMilliseconds(80));
+frameProvider.AdvanceFrame(); // Deterministic frame delivery
 ```
 
 **Incorrect:**

--- a/demos/Termina.Demo.Conformance/Pages/ConformancePage.cs
+++ b/demos/Termina.Demo.Conformance/Pages/ConformancePage.cs
@@ -36,7 +36,7 @@ public sealed class ConformancePage : ReactivePage<ConformanceViewModel>
             .WithForeground(Color.Yellow)
             .NoWrap();
 
-        _input = new TextInputNode(frameProvider: RenderFrameProvider)
+        _input = new TextInputNode()
             .WithPlaceholder("Type here, press Enter to submit. Up/Down should still be keyboard input.")
             .WithForeground(Color.Cyan);
     }

--- a/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/AnimationsGalleryPage.cs
@@ -136,7 +136,7 @@ public class AnimationsGalleryPage : ReactivePage<AnimationsGalleryViewModel>
                                 Layouts.Horizontal()
                                     .WithChild(new TextNode("  ").WidthAuto())
                                     .WithChild(
-                                        new SpinnerNode(style, intervalMs: 80, frameProvider: RenderFrameProvider)
+                                        new SpinnerNode(style, intervalMs: 80)
                                             .WithSpinnerColor(color))
                                     .Height(1))
                             .WithChild(new TextNode(" ").Height(1))
@@ -144,7 +144,7 @@ public class AnimationsGalleryPage : ReactivePage<AnimationsGalleryViewModel>
                                 Layouts.Horizontal()
                                     .WithChild(new TextNode("  ").WidthAuto())
                                     .WithChild(
-                                        new SpinnerNode(style, intervalMs: 80, frameProvider: RenderFrameProvider)
+                                        new SpinnerNode(style, intervalMs: 80)
                                             .WithLabel("Loading...")
                                             .WithSpinnerColor(color)
                                             .WithLabelColor(Color.White))
@@ -154,7 +154,7 @@ public class AnimationsGalleryPage : ReactivePage<AnimationsGalleryViewModel>
                                 Layouts.Horizontal()
                                     .WithChild(new TextNode("  ").WidthAuto())
                                     .WithChild(
-                                        new SpinnerNode(style, intervalMs: 120, frameProvider: RenderFrameProvider)
+                                        new SpinnerNode(style, intervalMs: 120)
                                             .WithLabel("Processing request...")
                                             .WithSpinnerColor(color)
                                             .WithLabelColor(Color.Gray))

--- a/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/ClipboardGalleryPage.cs
@@ -65,7 +65,7 @@ public sealed class ClipboardGalleryPage : ReactivePage<ClipboardGalleryViewMode
             .WithCopyBindings(new CopyKeyBinding(ConsoleKey.Enter), new CopyKeyBinding(ConsoleKey.C, ConsoleModifiers.Control))
             .WithHint("Use Ctrl+A to select all, Enter or Ctrl+C to copy");
 
-        _pasteInput = new TextInputNode(frameProvider: RenderFrameProvider)
+        _pasteInput = new TextInputNode()
             .WithPlaceholder("Paste text here with Ctrl+Shift+V or your terminal paste shortcut...");
     }
 

--- a/demos/Termina.Demo.Gallery/Pages/GraphGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/GraphGalleryPage.cs
@@ -82,7 +82,7 @@ public sealed class GraphGalleryPage : ReactivePage<GraphGalleryViewModel>
 
         var gradient = Gradient.Create(Color.FromRgb(0, 100, 255), Color.FromRgb(0, 255, 100), Color.FromRgb(255, 255, 0));
 
-        _demoGraph = new GraphNode(intervalMs: 0, frameProvider: RenderFrameProvider)
+        _demoGraph = new GraphNode(intervalMs: 0)
             .WithStyle(ViewModel.SelectedStyle.Value)
             .WithGradient(gradient)
             .WithRange(0, 100);

--- a/demos/Termina.Demo.Gallery/Pages/TextInputGalleryPage.cs
+++ b/demos/Termina.Demo.Gallery/Pages/TextInputGalleryPage.cs
@@ -61,12 +61,12 @@ public class TextInputGalleryPage : ReactivePage<TextInputGalleryViewModel>
 
     public override ILayoutNode BuildLayout()
     {
-        _basicInput = new TextInputNode(frameProvider: RenderFrameProvider);
+        _basicInput = new TextInputNode();
 
-        _placeholderInput = new TextInputNode(frameProvider: RenderFrameProvider)
+        _placeholderInput = new TextInputNode()
             .WithPlaceholder("Type something here...");
 
-        _textArea = new TextAreaNode(frameProvider: RenderFrameProvider)
+        _textArea = new TextAreaNode()
             .WithPlaceholder("Enter multi-line text...")
             .WithMaxHeight(6);
 

--- a/demos/Termina.Demo.KittyScroll/Pages/KittyScrollPage.cs
+++ b/demos/Termina.Demo.KittyScroll/Pages/KittyScrollPage.cs
@@ -47,7 +47,7 @@ public class KittyScrollPage : ReactivePage<KittyScrollViewModel>
                 Color.White);
         }
 
-        _input = new TextInputNode(frameProvider: RenderFrameProvider)
+        _input = new TextInputNode()
             .WithPlaceholder("Type a message and press Enter (Ctrl+C twice to quit)…")
             .WithForeground(Color.Cyan);
     }

--- a/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
+++ b/demos/Termina.Demo.Streaming/Pages/StreamingChatPage.cs
@@ -34,7 +34,7 @@ public class StreamingChatPage : ReactivePage<StreamingChatViewModel>
             .WithPrefix("  ", Color.Gray)
             .WithScrollbar();
 
-        _promptInput = new TextInputNode(frameProvider: RenderFrameProvider)
+        _promptInput = new TextInputNode()
             .WithPlaceholder("Enter your question...")
             .WithForeground(Color.Cyan)
             .WithHistory();

--- a/demos/Termina.Demo.Wizard/Pages/SetupWizardPage.cs
+++ b/demos/Termina.Demo.Wizard/Pages/SetupWizardPage.cs
@@ -124,7 +124,7 @@ public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
 
     private ILayoutNode BuildAuthStep()
     {
-        var usernameInput = new TextInputNode(frameProvider: RenderFrameProvider)
+        var usernameInput = new TextInputNode()
             .WithPlaceholder("Enter username...");
 
         usernameInput.Submitted.Subscribe(text =>

--- a/demos/Termina.Demo/Pages/TodoListPage.cs
+++ b/demos/Termina.Demo/Pages/TodoListPage.cs
@@ -99,7 +99,7 @@ public class TodoListPage : ReactivePage<TodoListViewModel>
     public override ILayoutNode BuildLayout()
     {
         // Create layout nodes as part of the layout tree lifecycle
-        _textInput = new TextInputNode(frameProvider: RenderFrameProvider)
+        _textInput = new TextInputNode()
             .WithPlaceholder("Enter task description...");
 
         _priorityList = Layouts.SelectionList("High", "Medium", "Low")

--- a/docs/advanced/custom-components.md
+++ b/docs/advanced/custom-components.md
@@ -242,7 +242,7 @@ public class LiveValueNode : LayoutNode
         HeightConstraint = new SizeConstraint.Fixed(1);
     }
 
-    public LiveValueNode BindTo(IObservable<string> source, Action requestRedraw)
+    public LiveValueNode BindTo(Observable<string> source, Action requestRedraw)
     {
         _subscription?.Dispose();
         _subscription = source.Subscribe(value =>
@@ -277,6 +277,84 @@ public class LiveValueNode : LayoutNode
 }
 ```
 
+## Runtime Context
+
+App-owned layout nodes receive a `LayoutRuntimeContext` before activation. If you inherit from `LayoutNode`, access it through the protected `RuntimeContext` property.
+
+The context contains:
+
+- `RenderFrameProvider` for R3 render-loop delivery
+- `TimeProvider` configured on the owning application
+- `RequestRedraw` for manual redraw requests
+
+Use it for timers, background observable delivery, and custom invalidation. Constructors should configure the node; runtime work should start in `OnActivate()` after context is available.
+
+```csharp
+public sealed class BlinkingStatusNode : LayoutNode, IInvalidatingNode
+{
+    private readonly Subject<Unit> _invalidated = new();
+    private IDisposable? _timer;
+    private bool _visible = true;
+
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
+
+    public override void OnActivate()
+    {
+        var context = RuntimeContext
+            ?? throw new InvalidOperationException("Node has not been attached to a Termina layout tree.");
+
+        _timer ??= Observable.Interval(TimeSpan.FromMilliseconds(500), context.TimeProvider)
+            .ObserveOn(context.RenderFrameProvider)
+            .Subscribe(_ =>
+            {
+                _visible = !_visible;
+                _invalidated.OnNext(Unit.Default);
+            });
+
+        base.OnActivate();
+    }
+
+    public override void OnDeactivate()
+    {
+        _timer?.Dispose();
+        _timer = null;
+        base.OnDeactivate();
+    }
+
+    public override Size Measure(Size available) => new(Math.Min(6, available.Width), 1);
+
+    public override void Render(IRenderContext context, Rect bounds)
+    {
+        if (_visible)
+            context.WriteAt(bounds.X, bounds.Y, "ONLINE"[..Math.Min(bounds.Width, 6)]);
+    }
+
+    public override void Dispose()
+    {
+        _timer?.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
+        base.Dispose();
+    }
+}
+```
+
+If your node implements `ILayoutNode` directly instead of inheriting from `LayoutNode`, implement `ILayoutRuntimeContextAware` to receive the same context.
+
+If your `LayoutNode` subclass owns child nodes outside `ContainerNode`, propagate context when the child is assigned:
+
+```csharp
+public override void SetRuntimeContext(LayoutRuntimeContext context)
+{
+    base.SetRuntimeContext(context);
+
+    if (_content != null)
+        ApplyRuntimeContextToChild(_content);
+}
+```
+
+`ContainerNode` handles this automatically for children added through `AddChild` and `AddChildren`.
+
 ## Component Lifecycle
 
 When using `NavigationBehavior.PreserveState`, layout nodes are preserved across navigations and go through activation/deactivation cycles instead of being disposed. This prevents race conditions with in-flight events and allows components to maintain state.
@@ -286,28 +364,26 @@ When using `NavigationBehavior.PreserveState`, layout nodes are preserved across
 Lifecycle dispatch goes through the `IActivatableNode` interface. `LayoutNode` implements it, so subclasses simply override `OnActivate()` and `OnDeactivate()`. Components that implement the layout interfaces directly — without extending `LayoutNode` — should implement `IActivatableNode` themselves to participate (this is what `FilePickerNode` and `SelectionListNode` do).
 
 ```csharp
-public class AnimatedNode : LayoutNode
+public class AnimatedNode : LayoutNode, IInvalidatingNode
 {
-    private readonly TimeProvider _timeProvider;
-    private readonly FrameProvider _frameProvider;
+    private readonly Subject<Unit> _invalidated = new();
     private IDisposable? _timer;
     private int _frame;
 
-    public AnimatedNode(FrameProvider frameProvider, TimeProvider? timeProvider = null)
-    {
-        _frameProvider = frameProvider;
-        _timeProvider = timeProvider ?? TimeProvider.System;
-    }
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
     public override void OnActivate()
     {
+        var context = RuntimeContext
+            ?? throw new InvalidOperationException("Node has not been attached to a Termina layout tree.");
+
         // Resume animation when page becomes active
-        _timer ??= Observable.Interval(TimeSpan.FromMilliseconds(100), _timeProvider)
-            .ObserveOn(_frameProvider)
+        _timer ??= Observable.Interval(TimeSpan.FromMilliseconds(100), context.TimeProvider)
+            .ObserveOn(context.RenderFrameProvider)
             .Subscribe(_ =>
             {
                 _frame++;
-                // Trigger UI update
+                _invalidated.OnNext(Unit.Default);
             });
         base.OnActivate();
     }
@@ -324,6 +400,8 @@ public class AnimatedNode : LayoutNode
     {
         // Final cleanup when component is destroyed
         _timer?.Dispose();
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
         base.Dispose();
     }
 }

--- a/docs/components/graph-node.md
+++ b/docs/components/graph-node.md
@@ -79,10 +79,10 @@ The constructor accepts an interval for periodic self-invalidation. Set `interva
 
 ```csharp
 // Timer-driven refresh (default 500ms), invalidated on the Termina loop
-new GraphNode(intervalMs: 500, frameProvider: RenderFrameProvider)
+new GraphNode(intervalMs: 500)
 
 // Data-driven only — no timer overhead
-new GraphNode(intervalMs: 0, frameProvider: RenderFrameProvider)
+new GraphNode(intervalMs: 0)
 ```
 
 ## Testable Timing

--- a/docs/components/graph-node.md
+++ b/docs/components/graph-node.md
@@ -87,26 +87,14 @@ new GraphNode(intervalMs: 0)
 
 ## Testable Timing
 
-Pass a `TimeProvider` for deterministic tests:
-
-```csharp
-var timeProvider = new FakeTimeProvider();
-var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
-
-graph.SetData([50, 100]);
-timeProvider.Advance(TimeSpan.FromMilliseconds(100));
-// graph has now self-invalidated
-```
+`GraphNode` receives timing through `LayoutRuntimeContext`. In app code this happens automatically when the graph is attached to a page layout tree. For component-level tests, set a test runtime context before activation.
 
 ## API Reference
 
 ### Constructor
 
 ```csharp
-public GraphNode(
-    int intervalMs = 500,
-    TimeProvider? timeProvider = null,
-    FrameProvider? frameProvider = null)
+public GraphNode(int intervalMs = 500)
 ```
 
 ### Methods

--- a/docs/components/modal-node.md
+++ b/docs/components/modal-node.md
@@ -171,7 +171,7 @@ public class MyPage : ReactivePage<MyViewModel>
     protected override void OnBound()
     {
         // Create text input
-        _textInput = new TextInputNode(frameProvider: RenderFrameProvider)
+        _textInput = new TextInputNode()
             .WithPlaceholder("Enter task description...");
 
         _textInput.Submitted

--- a/docs/components/spinner-node.md
+++ b/docs/components/spinner-node.md
@@ -35,10 +35,10 @@ Control the animation interval:
 new SpinnerNode(SpinnerStyle.Dots)
 
 // Slower animation
-new SpinnerNode(SpinnerStyle.Dots, intervalMs: 150, frameProvider: RenderFrameProvider)
+new SpinnerNode(SpinnerStyle.Dots, intervalMs: 150)
 
 // Faster animation
-new SpinnerNode(SpinnerStyle.Dots, intervalMs: 50, frameProvider: RenderFrameProvider)
+new SpinnerNode(SpinnerStyle.Dots, intervalMs: 50)
 ```
 
 ## Styling
@@ -52,7 +52,7 @@ new SpinnerNode(SpinnerStyle.Dots)
 
 ## Start/Stop Animation
 
-Spinners auto-start by default but can be controlled:
+Spinners start when the containing page layout is activated and can be controlled manually:
 
 ```csharp
 var spinner = new SpinnerNode().WithLabel("Working...");
@@ -76,7 +76,7 @@ ViewModel.IsLoadingChanged
     .AsLayout(RenderFrameProvider)
 ```
 
-Pass `frameProvider: RenderFrameProvider` when using spinners in pages so timer-driven invalidation is delivered on the Termina render loop.
+Spinners attached to a page layout tree receive runtime context automatically, so timer-driven invalidation is delivered on the Termina render loop. Keep `AsLayout(RenderFrameProvider)` when the observable source itself may publish off-loop.
 
 ## API Reference
 
@@ -97,7 +97,7 @@ public SpinnerNode(
 | `Label` | `string?` | `null` | Text after spinner |
 | `SpinnerColor` | `Color?` | `null` | Spinner color |
 | `LabelColor` | `Color?` | `null` | Label color |
-| `IsAnimating` | `bool` | `true` | Animation running |
+| `IsAnimating` | `bool` | `false until activation` | Animation running |
 
 ### Methods
 

--- a/docs/components/spinner-node.md
+++ b/docs/components/spinner-node.md
@@ -85,9 +85,7 @@ Spinners attached to a page layout tree receive runtime context automatically, s
 ```csharp
 public SpinnerNode(
     SpinnerStyle style = SpinnerStyle.Dots,
-    int intervalMs = 80,
-    TimeProvider? timeProvider = null,
-    FrameProvider? frameProvider = null)
+    int intervalMs = 80)
 ```
 
 ### Properties

--- a/docs/components/text-area-node.md
+++ b/docs/components/text-area-node.md
@@ -188,7 +188,7 @@ public TextAreaNode(
     FrameProvider? frameProvider = null)
 ```
 
-Pass `frameProvider: RenderFrameProvider` in pages so cursor-blink invalidation is delivered on the Termina render loop.
+Text areas attached to a page layout tree receive runtime context automatically, so cursor-blink invalidation is delivered on the Termina render loop. Pass explicit providers only for tests or nodes owned outside a Termina page tree.
 
 ### Properties
 

--- a/docs/components/text-area-node.md
+++ b/docs/components/text-area-node.md
@@ -182,13 +182,10 @@ new TextAreaNode()
 ### Constructor
 
 ```csharp
-public TextAreaNode(
-    int cursorBlinkMs = 530,
-    TimeProvider? timeProvider = null,
-    FrameProvider? frameProvider = null)
+public TextAreaNode(int cursorBlinkMs = 530)
 ```
 
-Text areas attached to a page layout tree receive runtime context automatically, so cursor-blink invalidation is delivered on the Termina render loop. Pass explicit providers only for tests or nodes owned outside a Termina page tree.
+Text areas attached to a page layout tree receive runtime context automatically, so cursor-blink invalidation is delivered on the Termina render loop. For deterministic component tests, set a `LayoutRuntimeContext` before focusing the node.
 
 ### Properties
 

--- a/docs/components/text-input-node.md
+++ b/docs/components/text-input-node.md
@@ -120,7 +120,7 @@ public class MyPage : ReactivePage<MyViewModel>
 
     protected override void OnBound()
     {
-        _textInput = new TextInputNode(frameProvider: RenderFrameProvider)
+        _textInput = new TextInputNode()
             .WithPlaceholder("Enter command...");
         _modal = Layouts.Modal().WithContent(_textInput);
 
@@ -148,7 +148,7 @@ public class MyPage : ReactivePage<MyViewModel>
 
     protected override void OnBound()
     {
-        _promptInput = new TextInputNode(frameProvider: RenderFrameProvider)
+        _promptInput = new TextInputNode()
             .WithPlaceholder("Enter command...");
 
         // Route input from ViewModel to the text input
@@ -248,7 +248,7 @@ public TextInputNode(
     FrameProvider? frameProvider = null)
 ```
 
-Pass `frameProvider: RenderFrameProvider` in pages so cursor-blink invalidation is delivered on the Termina render loop.
+Inputs attached to a page layout tree receive runtime context automatically, so cursor-blink invalidation is delivered on the Termina render loop. Pass explicit providers only for tests or nodes owned outside a Termina page tree.
 
 ### Properties
 

--- a/docs/components/text-input-node.md
+++ b/docs/components/text-input-node.md
@@ -242,13 +242,10 @@ public sealed class CustomInputNode : LayoutNode, IFocusable, IPasteReceiver
 ### Constructor
 
 ```csharp
-public TextInputNode(
-    int cursorBlinkMs = 530,
-    TimeProvider? timeProvider = null,
-    FrameProvider? frameProvider = null)
+public TextInputNode(int cursorBlinkMs = 530)
 ```
 
-Inputs attached to a page layout tree receive runtime context automatically, so cursor-blink invalidation is delivered on the Termina render loop. Pass explicit providers only for tests or nodes owned outside a Termina page tree.
+Inputs attached to a page layout tree receive runtime context automatically, so cursor-blink invalidation is delivered on the Termina render loop. For deterministic component tests, set a `LayoutRuntimeContext` before focusing the node.
 
 ### Properties
 

--- a/docs/concepts/observables.md
+++ b/docs/concepts/observables.md
@@ -158,7 +158,7 @@ See [Render Loop Threading](/concepts/render-loop-threading) for the full guidan
 ```csharp
 ViewModel.IsLoading
     .Select<bool, ILayoutNode>(loading => loading
-        ? new SpinnerNode(frameProvider: RenderFrameProvider)
+        ? new SpinnerNode()
         : new TextNode("Ready"))
     .AsLayout(RenderFrameProvider)
 ```

--- a/docs/concepts/render-loop-threading.md
+++ b/docs/concepts/render-loop-threading.md
@@ -70,16 +70,18 @@ Use `ObserveOn(RenderFrameProvider)`, `Post`, or `InvokeAsync` instead.
 
 ## Built-In Components
 
-Termina-owned reactive and animated components can marshal through the frame provider when supplied:
+Built-in animated and input components receive the app runtime context automatically when they are part of a page layout tree. Their internal timers use the app `TimeProvider` and deliver invalidation through the app `RenderFrameProvider`:
 
 ```csharp
-new SpinnerNode(frameProvider: RenderFrameProvider)
-new GraphNode(frameProvider: RenderFrameProvider)
-new TextInputNode(frameProvider: RenderFrameProvider)
-new TextAreaNode(frameProvider: RenderFrameProvider)
+new SpinnerNode()
+new GraphNode()
+new TextInputNode()
+new TextAreaNode()
 ```
 
-Existing constructors still work. Passing the frame provider is recommended for components whose timers or observable sources should deliver invalidation on the Termina loop.
+Explicit `timeProvider` and `frameProvider` constructor arguments remain available for tests and externally-owned nodes. App pages usually do not need them.
+
+Custom components can use the protected `LayoutNode.RuntimeContext` property after the node is attached to the layout tree. See [Custom Components](/advanced/custom-components#runtime-context).
 
 ## Default ObservableSystem
 
@@ -96,5 +98,6 @@ Prefer explicit `RenderFrameProvider` arguments in libraries and tests to avoid 
 1. Find subscriptions to daemon, SignalR, channel, timer, or probe output streams.
 2. Add `.ObserveOn(RenderFrameProvider)` before subscribers that mutate UI state.
 3. Replace off-loop final state writes after `await` with `InvokeAsync`.
-4. Do not use custom `IInputSource` implementations as a loop-dispatch workaround.
-5. Keep `TimeProvider` for elapsed-time behavior; use `FrameProvider` for loop-affined delivery.
+4. Keep `AsLayout(RenderFrameProvider)` for layout bindings that may receive off-loop emissions.
+5. Do not use custom `IInputSource` implementations as a loop-dispatch workaround.
+6. Keep `TimeProvider` for elapsed-time behavior; use `FrameProvider` for loop-affined delivery.

--- a/docs/concepts/render-loop-threading.md
+++ b/docs/concepts/render-loop-threading.md
@@ -79,7 +79,7 @@ new TextInputNode()
 new TextAreaNode()
 ```
 
-Explicit `timeProvider` and `frameProvider` constructor arguments remain available for tests and externally-owned nodes. App pages usually do not need them.
+Runtime services are supplied through `LayoutRuntimeContext`, not component constructors. In app code this happens automatically when nodes are attached to a page layout tree.
 
 Custom components can use the protected `LayoutNode.RuntimeContext` property after the node is attached to the layout tree. See [Custom Components](/advanced/custom-components#runtime-context).
 

--- a/docs/guide/upgrade-render-loop-threading.md
+++ b/docs/guide/upgrade-render-loop-threading.md
@@ -126,7 +126,7 @@ new TextInputNode()
 new TextAreaNode()
 ```
 
-Existing `timeProvider` and `frameProvider` constructor arguments still work. Use them for deterministic tests or nodes owned outside a Termina page tree. App pages usually do not need them.
+Runtime services are supplied through `LayoutRuntimeContext`, not component constructors. In app code this happens automatically when nodes are attached to a page layout tree. For deterministic component tests, set a test context before activation.
 
 ## RequestRedraw Is Not Enough
 
@@ -150,7 +150,7 @@ Post(() => StatusMessage.Value = "Done");
 1. Search for `Observable.Interval`, daemon callbacks, SignalR subscriptions, channel readers, and `Task.Run` callbacks.
 2. Add `.ObserveOn(RenderFrameProvider)` before subscribers that mutate UI state.
 3. Replace UI writes after `await` with `InvokeAsync`.
-4. Remove redundant `frameProvider: RenderFrameProvider` arguments from built-in animated or input nodes in app pages.
+4. Remove `timeProvider` and `frameProvider` arguments from built-in animated or input nodes.
 5. Keep `AsLayout(RenderFrameProvider)` for layout bindings that may receive off-loop emissions.
 
 See [Render Loop Threading](/concepts/render-loop-threading) for conceptual background.

--- a/docs/guide/upgrade-render-loop-threading.md
+++ b/docs/guide/upgrade-render-loop-threading.md
@@ -12,7 +12,7 @@ This is an additive change. Existing applications continue to compile, but appli
 | Observable drives a layout node | `.AsLayout(RenderFrameProvider)` |
 | One-shot async result updates UI state | `await InvokeAsync(...)` |
 | Fire-and-forget async callback updates UI state | `Post(...)` |
-| Built-in animated/input nodes use timers | pass `frameProvider: RenderFrameProvider` |
+| Built-in animated/input nodes use timers | automatic runtime context |
 
 ## What Changed
 
@@ -117,16 +117,16 @@ await foreach (var token in response.TokenStream.WithCancellation(cancellationTo
 
 ## Built-In Components
 
-Pass `RenderFrameProvider` to built-in nodes that have their own timers:
+Built-in nodes that have their own timers now receive runtime context automatically when they are attached to a page layout tree:
 
 ```csharp
-new SpinnerNode(frameProvider: RenderFrameProvider)
-new GraphNode(frameProvider: RenderFrameProvider)
-new TextInputNode(frameProvider: RenderFrameProvider)
-new TextAreaNode(frameProvider: RenderFrameProvider)
+new SpinnerNode()
+new GraphNode()
+new TextInputNode()
+new TextAreaNode()
 ```
 
-Existing constructors still work. The frame provider is recommended for app UI so timer-driven invalidation is serialized with rendering.
+Existing `timeProvider` and `frameProvider` constructor arguments still work. Use them for deterministic tests or nodes owned outside a Termina page tree. App pages usually do not need them.
 
 ## RequestRedraw Is Not Enough
 
@@ -150,7 +150,7 @@ Post(() => StatusMessage.Value = "Done");
 1. Search for `Observable.Interval`, daemon callbacks, SignalR subscriptions, channel readers, and `Task.Run` callbacks.
 2. Add `.ObserveOn(RenderFrameProvider)` before subscribers that mutate UI state.
 3. Replace UI writes after `await` with `InvokeAsync`.
-4. Pass `frameProvider: RenderFrameProvider` to animated or input nodes in app pages.
-5. Use `AsLayout(RenderFrameProvider)` for layout bindings that may receive off-loop emissions.
+4. Remove redundant `frameProvider: RenderFrameProvider` arguments from built-in animated or input nodes in app pages.
+5. Keep `AsLayout(RenderFrameProvider)` for layout bindings that may receive off-loop emissions.
 
 See [Render Loop Threading](/concepts/render-loop-threading) for conceptual background.

--- a/docs/tutorials/streaming-chat.md
+++ b/docs/tutorials/streaming-chat.md
@@ -116,7 +116,7 @@ The Page renders the chat interface.
 
 **Page Owns Layout Nodes**
 
-The Page creates and owns interactive layout nodes. Pass `RenderFrameProvider` to timer-backed nodes like `TextInputNode` so cursor blink invalidation is delivered on the Termina loop:
+The Page creates and owns interactive layout nodes. Timer-backed nodes like `TextInputNode` receive runtime context automatically once attached to the layout tree, so cursor blink invalidation is delivered on the Termina loop:
 
 ```csharp
 private StreamingTextNode _chatHistory = null!;
@@ -125,7 +125,7 @@ private TextInputNode _promptInput = null!;
 protected override void OnBound()
 {
     _chatHistory = StreamingTextNode.Create().WithPrefix("  ", Color.Gray);
-    _promptInput = new TextInputNode(frameProvider: RenderFrameProvider)
+    _promptInput = new TextInputNode()
         .WithPlaceholder("Enter your question...");
 
     // Subscribe to ViewModel's output streams

--- a/docs/tutorials/wizard-app.md
+++ b/docs/tutorials/wizard-app.md
@@ -88,8 +88,8 @@ public class SetupWizardPage : ReactivePage<SetupWizardViewModel>
 
     private ILayoutNode BuildAuthStep()
     {
-        var username = new TextInputNode(frameProvider: RenderFrameProvider).WithPlaceholder("Username");
-        var password = new TextInputNode(frameProvider: RenderFrameProvider).WithPlaceholder("Password");
+        var username = new TextInputNode().WithPlaceholder("Username");
+        var password = new TextInputNode().WithPlaceholder("Password");
 
         username.Submitted.Subscribe(text =>
             ViewModel.Username.Value = text);

--- a/src/Termina/Layout/ConditionalNode.cs
+++ b/src/Termina/Layout/ConditionalNode.cs
@@ -47,6 +47,14 @@ public sealed class ConditionalNode : LayoutNode, IInvalidatingNode
     private ILayoutNode ActiveNode => _condition ? _thenNode : _elseNode;
 
     /// <inheritdoc />
+    public override void SetRuntimeContext(LayoutRuntimeContext context)
+    {
+        base.SetRuntimeContext(context);
+        ApplyRuntimeContextToChild(_thenNode);
+        ApplyRuntimeContextToChild(_elseNode);
+    }
+
+    /// <inheritdoc />
     internal override IEnumerable<ILayoutNode> GetChildNodes() => [ActiveNode];
 
     /// <inheritdoc />

--- a/src/Termina/Layout/CopyableTextNode.cs
+++ b/src/Termina/Layout/CopyableTextNode.cs
@@ -15,7 +15,6 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
     private readonly IClipboardService _clipboardService;
     private readonly IToastService? _toastService;
     private readonly Subject<Unit> _invalidated = new();
-    private readonly TimeProvider _timeProvider;
     private IDisposable? _inlineIndicatorSubscription;
     private IReadOnlyList<CopyKeyBinding> _copyBindings =
     [
@@ -28,11 +27,10 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
     private bool _hasFocus;
     private bool _disposed;
 
-    public CopyableTextNode(IClipboardService clipboardService, string content, IToastService? toastService = null, TimeProvider? timeProvider = null)
+    public CopyableTextNode(IClipboardService clipboardService, string content, IToastService? toastService = null)
     {
         _clipboardService = clipboardService;
         _toastService = toastService;
-        _timeProvider = timeProvider ?? TimeProvider.System;
         Content = content ?? string.Empty;
         WidthConstraint = new SizeConstraint.Fill();
         HeightConstraint = SizeConstraint.AutoSize();
@@ -294,9 +292,11 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         {
             _showInlineIndicator = true;
             _inlineIndicatorSubscription?.Dispose();
-            _inlineIndicatorSubscription = Observable
-                .Interval(FeedbackDuration, _timeProvider)
-                .Take(1)
+            var ticks = Observable.Interval(FeedbackDuration, GetTimeProvider()).Take(1);
+            if (GetFrameProvider() is { } frameProvider)
+                ticks = ticks.ObserveOn(frameProvider);
+
+            _inlineIndicatorSubscription = ticks
                 .Subscribe(_ =>
                 {
                     _showInlineIndicator = false;
@@ -305,6 +305,10 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
             Invalidate();
         }
     }
+
+    private TimeProvider GetTimeProvider() => RuntimeContext?.TimeProvider ?? TimeProvider.System;
+
+    private FrameProvider? GetFrameProvider() => RuntimeContext?.RenderFrameProvider;
 
     private bool MoveCursor(int delta, ConsoleModifiers modifiers)
     {

--- a/src/Termina/Layout/DynamicLayoutNode.cs
+++ b/src/Termina/Layout/DynamicLayoutNode.cs
@@ -72,6 +72,7 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
         }
 
         _currentChild = newChild;
+        ApplyRuntimeContextToChild(newChild);
         SubscribeToChildInvalidation(newChild);
 
         // Activate new child if we're currently active

--- a/src/Termina/Layout/FilePickerNode.cs
+++ b/src/Termina/Layout/FilePickerNode.cs
@@ -11,7 +11,7 @@ namespace Termina.Layout;
 /// <summary>
 /// An interactive file/folder picker with breadcrumb navigation, scrolling, and fuzzy filtering.
 /// </summary>
-public sealed class FilePickerNode : IFocusable, IInvalidatingNode, IActivatableNode
+public sealed class FilePickerNode : IFocusable, IInvalidatingNode, IActivatableNode, ILayoutRuntimeContextAware
 {
     private readonly Subject<Unit> _invalidated = new();
     private readonly Subject<IReadOnlyList<string>> _selectionConfirmed = new();
@@ -35,6 +35,7 @@ public sealed class FilePickerNode : IFocusable, IInvalidatingNode, IActivatable
     // Filter state
     private bool _isFiltering;
     private TextInputNode? _filterInput;
+    private LayoutRuntimeContext? _runtimeContext;
     private IDisposable? _filterInvalidationSub;
     private readonly TimeProvider? _timeProvider;
 
@@ -78,6 +79,16 @@ public sealed class FilePickerNode : IFocusable, IInvalidatingNode, IActivatable
     /// The initial lazy load does not emit.
     /// </summary>
     public Observable<string> DirectoryChanged => _directoryChanged.AsObservable();
+
+    /// <inheritdoc />
+    public void SetRuntimeContext(LayoutRuntimeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        _runtimeContext = context;
+        if (_filterInput is not null)
+            LayoutRuntimeContextInjector.Apply(_filterInput, context);
+    }
 
     public SizeConstraint WidthConstraint => SizeConstraint.FillRemaining();
 
@@ -486,6 +497,9 @@ public sealed class FilePickerNode : IFocusable, IInvalidatingNode, IActivatable
         {
             _filterInput = new TextInputNode(timeProvider: _timeProvider)
                 .WithPlaceholder("Type to filter...");
+            if (_runtimeContext is not null)
+                LayoutRuntimeContextInjector.Apply(_filterInput, _runtimeContext);
+
             // Bridge the embedded input's invalidations (cursor blink) to ours
             _filterInvalidationSub = _filterInput.Invalidated.Subscribe(_ => Invalidate());
         }

--- a/src/Termina/Layout/FilePickerNode.cs
+++ b/src/Termina/Layout/FilePickerNode.cs
@@ -37,7 +37,6 @@ public sealed class FilePickerNode : IFocusable, IInvalidatingNode, IActivatable
     private TextInputNode? _filterInput;
     private LayoutRuntimeContext? _runtimeContext;
     private IDisposable? _filterInvalidationSub;
-    private readonly TimeProvider? _timeProvider;
 
     // Configuration
     private FilePickerMode _mode = FilePickerMode.Files;
@@ -56,10 +55,9 @@ public sealed class FilePickerNode : IFocusable, IInvalidatingNode, IActivatable
     private const string FilterPrefix = "/ ";
     private const string BreadcrumbPrefix = ">> ";
 
-    public FilePickerNode(string? startPath = null, TimeProvider? timeProvider = null)
+    public FilePickerNode(string? startPath = null)
     {
         _currentPath = startPath ?? Environment.CurrentDirectory;
-        _timeProvider = timeProvider;
     }
 
     public Observable<Unit> Invalidated => _invalidated.AsObservable();
@@ -495,7 +493,7 @@ public sealed class FilePickerNode : IFocusable, IInvalidatingNode, IActivatable
         _isFiltering = true;
         if (_filterInput == null)
         {
-            _filterInput = new TextInputNode(timeProvider: _timeProvider)
+            _filterInput = new TextInputNode()
                 .WithPlaceholder("Type to filter...");
             if (_runtimeContext is not null)
                 LayoutRuntimeContextInjector.Apply(_filterInput, _runtimeContext);

--- a/src/Termina/Layout/GraphNode.cs
+++ b/src/Termina/Layout/GraphNode.cs
@@ -25,8 +25,6 @@ public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     ];
 
     private readonly Subject<Unit> _invalidated = new();
-    private readonly TimeProvider? _timeProvider;
-    private readonly FrameProvider? _frameProvider;
     private readonly int _intervalMs;
     private IDisposable? _timerSubscription;
     private double[] _data = [];
@@ -38,11 +36,9 @@ public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     public Observable<Unit> Invalidated => _invalidated.AsObservable();
     public bool IsAnimating { get; private set; }
 
-    public GraphNode(int intervalMs = 500, TimeProvider? timeProvider = null, FrameProvider? frameProvider = null)
+    public GraphNode(int intervalMs = 500)
     {
         _intervalMs = intervalMs;
-        _timeProvider = timeProvider;
-        _frameProvider = frameProvider;
     }
 
     /// <summary>
@@ -74,7 +70,7 @@ public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
 
     public override void SetRuntimeContext(LayoutRuntimeContext context)
     {
-        var restart = IsAnimating && (_timeProvider is null || _frameProvider is null);
+        var restart = IsAnimating;
         if (restart)
             Stop();
 
@@ -84,9 +80,9 @@ public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             Start();
     }
 
-    private TimeProvider GetTimeProvider() => _timeProvider ?? RuntimeContext?.TimeProvider ?? TimeProvider.System;
+    private TimeProvider GetTimeProvider() => RuntimeContext?.TimeProvider ?? TimeProvider.System;
 
-    private FrameProvider? GetFrameProvider() => _frameProvider ?? RuntimeContext?.RenderFrameProvider;
+    private FrameProvider? GetFrameProvider() => RuntimeContext?.RenderFrameProvider;
 
     public void Stop()
     {

--- a/src/Termina/Layout/GraphNode.cs
+++ b/src/Termina/Layout/GraphNode.cs
@@ -25,7 +25,7 @@ public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     ];
 
     private readonly Subject<Unit> _invalidated = new();
-    private readonly TimeProvider _timeProvider;
+    private readonly TimeProvider? _timeProvider;
     private readonly FrameProvider? _frameProvider;
     private readonly int _intervalMs;
     private IDisposable? _timerSubscription;
@@ -41,9 +41,8 @@ public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     public GraphNode(int intervalMs = 500, TimeProvider? timeProvider = null, FrameProvider? frameProvider = null)
     {
         _intervalMs = intervalMs;
-        _timeProvider = timeProvider ?? TimeProvider.System;
+        _timeProvider = timeProvider;
         _frameProvider = frameProvider;
-        Start();
     }
 
     /// <summary>
@@ -64,14 +63,30 @@ public sealed class GraphNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             return;
         }
 
-        var ticks = Observable.Interval(TimeSpan.FromMilliseconds(_intervalMs), _timeProvider);
-        if (_frameProvider is not null)
-            ticks = ticks.ObserveOn(_frameProvider);
+        var ticks = Observable.Interval(TimeSpan.FromMilliseconds(_intervalMs), GetTimeProvider());
+        if (GetFrameProvider() is { } frameProvider)
+            ticks = ticks.ObserveOn(frameProvider);
 
         _timerSubscription ??= ticks
             .Subscribe(_ => { _invalidated.OnNext(Unit.Default); });
         IsAnimating = true;
     }
+
+    public override void SetRuntimeContext(LayoutRuntimeContext context)
+    {
+        var restart = IsAnimating && (_timeProvider is null || _frameProvider is null);
+        if (restart)
+            Stop();
+
+        base.SetRuntimeContext(context);
+
+        if (restart)
+            Start();
+    }
+
+    private TimeProvider GetTimeProvider() => _timeProvider ?? RuntimeContext?.TimeProvider ?? TimeProvider.System;
+
+    private FrameProvider? GetFrameProvider() => _frameProvider ?? RuntimeContext?.RenderFrameProvider;
 
     public void Stop()
     {

--- a/src/Termina/Layout/KeyedDynamicLayoutNode.cs
+++ b/src/Termina/Layout/KeyedDynamicLayoutNode.cs
@@ -88,6 +88,7 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
         }
 
         _currentChild = newChild;
+        ApplyRuntimeContextToChild(newChild);
         SubscribeToChildInvalidation(newChild);
 
         // Activate new child if we're currently active

--- a/src/Termina/Layout/LayoutNode.cs
+++ b/src/Termina/Layout/LayoutNode.cs
@@ -9,10 +9,16 @@ namespace Termina.Layout;
 /// <summary>
 /// Base class for layout nodes providing common functionality.
 /// </summary>
-public abstract class LayoutNode : ILayoutNode, IActivatableNode
+public abstract class LayoutNode : ILayoutNode, IActivatableNode, ILayoutRuntimeContextAware
 {
     private SizeConstraint _widthConstraint = new SizeConstraint.Auto();
     private SizeConstraint _heightConstraint = new SizeConstraint.Auto();
+
+    /// <summary>
+    /// Runtime services supplied by the owning Termina application.
+    /// Available after the layout tree is built and before activation.
+    /// </summary>
+    protected LayoutRuntimeContext? RuntimeContext { get; private set; }
 
     /// <inheritdoc />
     public SizeConstraint WidthConstraint
@@ -38,6 +44,22 @@ public abstract class LayoutNode : ILayoutNode, IActivatableNode
     public virtual void Dispose()
     {
         GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc />
+    public virtual void SetRuntimeContext(LayoutRuntimeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        RuntimeContext = context;
+    }
+
+    /// <summary>
+    /// Applies this node's runtime context to a child created after the initial layout tree walk.
+    /// </summary>
+    protected void ApplyRuntimeContextToChild(ILayoutNode child)
+    {
+        if (RuntimeContext is { } context)
+            LayoutRuntimeContextInjector.Apply(child, context);
     }
 
     /// <summary>
@@ -176,6 +198,7 @@ public abstract class ContainerNode : LayoutNode, IContainerNode, IInvalidatingN
     /// </summary>
     protected void AddChild(ILayoutNode child)
     {
+        ApplyRuntimeContextToChild(child);
         _children.Add(child);
         SubscribeToChildInvalidation(child);
     }
@@ -187,6 +210,7 @@ public abstract class ContainerNode : LayoutNode, IContainerNode, IInvalidatingN
     {
         foreach (var child in children)
         {
+            ApplyRuntimeContextToChild(child);
             _children.Add(child);
             SubscribeToChildInvalidation(child);
         }

--- a/src/Termina/Layout/LayoutRuntimeContext.cs
+++ b/src/Termina/Layout/LayoutRuntimeContext.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+
+namespace Termina.Layout;
+
+/// <summary>
+/// Runtime services supplied by the owning Termina application to layout nodes.
+/// </summary>
+public sealed class LayoutRuntimeContext
+{
+    /// <summary>
+    /// Creates a new layout runtime context.
+    /// </summary>
+    public LayoutRuntimeContext(
+        FrameProvider renderFrameProvider,
+        TimeProvider timeProvider,
+        Action requestRedraw)
+    {
+        ArgumentNullException.ThrowIfNull(renderFrameProvider);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(requestRedraw);
+
+        RenderFrameProvider = renderFrameProvider;
+        TimeProvider = timeProvider;
+        RequestRedraw = requestRedraw;
+    }
+
+    /// <summary>
+    /// R3 frame provider bound to the owning Termina application render loop.
+    /// </summary>
+    public FrameProvider RenderFrameProvider { get; }
+
+    /// <summary>
+    /// Time provider configured for the owning Termina application.
+    /// </summary>
+    public TimeProvider TimeProvider { get; }
+
+    /// <summary>
+    /// Requests a redraw from the owning Termina application.
+    /// </summary>
+    public Action RequestRedraw { get; }
+}
+
+/// <summary>
+/// Implemented by layout nodes that receive runtime services from the owning Termina application.
+/// </summary>
+public interface ILayoutRuntimeContextAware
+{
+    /// <summary>
+    /// Supplies runtime services before the node is activated.
+    /// </summary>
+    void SetRuntimeContext(LayoutRuntimeContext context);
+}
+
+internal static class LayoutRuntimeContextInjector
+{
+    public static void Apply(ILayoutNode root, LayoutRuntimeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var visited = new HashSet<ILayoutNode>();
+        var stack = new Stack<ILayoutNode>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            if (!visited.Add(current))
+                continue;
+
+            if (current is ILayoutRuntimeContextAware aware)
+                aware.SetRuntimeContext(context);
+
+            foreach (var child in GetChildNodes(current))
+                stack.Push(child);
+        }
+    }
+
+    internal static IEnumerable<ILayoutNode> GetChildNodes(ILayoutNode node) => node switch
+    {
+        LayoutNode layoutNode => layoutNode.GetChildNodes(),
+        IContainerNode containerNode => containerNode.Children,
+        _ => []
+    };
+}

--- a/src/Termina/Layout/ReactiveLayoutNode.cs
+++ b/src/Termina/Layout/ReactiveLayoutNode.cs
@@ -40,6 +40,7 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
                     oldChild.OnDeactivate();
                 }
                 _currentChild = node;
+                ApplyRuntimeContextToChild(node);
                 SubscribeToChildInvalidation(node);
 
                 // Activate the new child if we're currently active
@@ -112,6 +113,7 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
                         oldChild.OnDeactivate();
                     }
                     _currentChild = node;
+                    ApplyRuntimeContextToChild(node);
                     SubscribeToChildInvalidation(node);
 
                     // Activate the new child if we're currently active
@@ -199,6 +201,7 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
                     oldChild.OnDeactivate();
                 }
                 _currentChild = _transform(value);
+                ApplyRuntimeContextToChild(_currentChild);
                 SubscribeToChildInvalidation(_currentChild);
 
                 // Activate the new child if we're currently active
@@ -269,6 +272,7 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
                         oldChild.OnDeactivate();
                     }
                     _currentChild = _transform(value);
+                    ApplyRuntimeContextToChild(_currentChild);
                     SubscribeToChildInvalidation(_currentChild);
 
                     // Activate the new child if we're currently active

--- a/src/Termina/Layout/SelectionListNode.cs
+++ b/src/Termina/Layout/SelectionListNode.cs
@@ -29,7 +29,7 @@ namespace Termina.Layout;
 /// Optionally supports an "Other" option for custom text input.
 /// </para>
 /// </remarks>
-public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode, IActivatableNode
+public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode, IActivatableNode, ILayoutRuntimeContextAware
 {
     private readonly Subject<Unit> _invalidated = new();
     private readonly Subject<IReadOnlyList<T>> _selectionConfirmed = new();
@@ -42,6 +42,7 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode, IActiv
     private int _visibleRows = 10;
     private bool _isEditingOther;
     private TextInputNode? _otherInput;
+    private LayoutRuntimeContext? _runtimeContext;
     private string? _otherLabel;
     private Action<string>? _otherCallback;
     private bool _hasFocus;
@@ -118,6 +119,16 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode, IActiv
     /// Observable that emits when Escape is pressed.
     /// </summary>
     public Observable<Unit> Cancelled => _cancelled.AsObservable();
+
+    /// <inheritdoc />
+    public void SetRuntimeContext(LayoutRuntimeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        _runtimeContext = context;
+        if (_otherInput is not null)
+            LayoutRuntimeContextInjector.Apply(_otherInput, context);
+    }
 
     /// <inheritdoc />
     public SizeConstraint WidthConstraint => SizeConstraint.FillRemaining();
@@ -464,6 +475,8 @@ public sealed class SelectionListNode<T> : IFocusable, IInvalidatingNode, IActiv
     {
         _otherInput ??= new TextInputNode()
             .WithPlaceholder("Enter custom value...");
+        if (_runtimeContext is not null)
+            LayoutRuntimeContextInjector.Apply(_otherInput, _runtimeContext);
 
         _otherInput.Clear();
         _isEditingOther = true;

--- a/src/Termina/Layout/SpinnerNode.cs
+++ b/src/Termina/Layout/SpinnerNode.cs
@@ -59,8 +59,6 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         [SpinnerStyle.Circle] = ["◐", "◓", "◑", "◒"]
     };
 
-    private readonly TimeProvider? _timeProvider;
-    private readonly FrameProvider? _frameProvider;
     private readonly int _intervalMs;
     private readonly string[] _frames;
     private readonly Subject<Unit> _invalidated = new();
@@ -88,14 +86,10 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// <inheritdoc />
     public bool IsAnimating { get; private set; }
 
-    public SpinnerNode(SpinnerStyle style = SpinnerStyle.Dots, int intervalMs = 80,
-        TimeProvider? timeProvider = null,
-        FrameProvider? frameProvider = null)
+    public SpinnerNode(SpinnerStyle style = SpinnerStyle.Dots, int intervalMs = 80)
     {
         _frames = Frames[style];
         _intervalMs = intervalMs;
-        _timeProvider = timeProvider;
-        _frameProvider = frameProvider;
 
         HeightConstraint = new SizeConstraint.Fixed(1);
         WidthConstraint = new SizeConstraint.Auto();
@@ -150,7 +144,7 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     /// <inheritdoc />
     public override void SetRuntimeContext(LayoutRuntimeContext context)
     {
-        var restart = IsAnimating && (_timeProvider is null || _frameProvider is null);
+        var restart = IsAnimating;
         if (restart)
             Stop();
 
@@ -160,9 +154,9 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
             Start();
     }
 
-    private TimeProvider GetTimeProvider() => _timeProvider ?? RuntimeContext?.TimeProvider ?? TimeProvider.System;
+    private TimeProvider GetTimeProvider() => RuntimeContext?.TimeProvider ?? TimeProvider.System;
 
-    private FrameProvider? GetFrameProvider() => _frameProvider ?? RuntimeContext?.RenderFrameProvider;
+    private FrameProvider? GetFrameProvider() => RuntimeContext?.RenderFrameProvider;
 
     /// <inheritdoc />
     public void Stop()

--- a/src/Termina/Layout/SpinnerNode.cs
+++ b/src/Termina/Layout/SpinnerNode.cs
@@ -59,7 +59,7 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         [SpinnerStyle.Circle] = ["◐", "◓", "◑", "◒"]
     };
 
-    private readonly TimeProvider _timeProvider;
+    private readonly TimeProvider? _timeProvider;
     private readonly FrameProvider? _frameProvider;
     private readonly int _intervalMs;
     private readonly string[] _frames;
@@ -94,14 +94,11 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
     {
         _frames = Frames[style];
         _intervalMs = intervalMs;
-        _timeProvider = timeProvider ?? TimeProvider.System;
+        _timeProvider = timeProvider;
         _frameProvider = frameProvider;
 
         HeightConstraint = new SizeConstraint.Fixed(1);
         WidthConstraint = new SizeConstraint.Auto();
-
-        // Auto-start
-        Start();
     }
 
     /// <summary>
@@ -137,9 +134,9 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
         if (!IsAnimating)
         {
             IsAnimating = true;
-            var ticks = Observable.Interval(TimeSpan.FromMilliseconds(_intervalMs), _timeProvider);
-            if (_frameProvider is not null)
-                ticks = ticks.ObserveOn(_frameProvider);
+            var ticks = Observable.Interval(TimeSpan.FromMilliseconds(_intervalMs), GetTimeProvider());
+            if (GetFrameProvider() is { } frameProvider)
+                ticks = ticks.ObserveOn(frameProvider);
 
             _timerSubscription ??= ticks
                 .Subscribe(_ =>
@@ -149,6 +146,23 @@ public sealed class SpinnerNode : LayoutNode, IAnimatedNode, IInvalidatingNode
                 });
         }
     }
+
+    /// <inheritdoc />
+    public override void SetRuntimeContext(LayoutRuntimeContext context)
+    {
+        var restart = IsAnimating && (_timeProvider is null || _frameProvider is null);
+        if (restart)
+            Stop();
+
+        base.SetRuntimeContext(context);
+
+        if (restart)
+            Start();
+    }
+
+    private TimeProvider GetTimeProvider() => _timeProvider ?? RuntimeContext?.TimeProvider ?? TimeProvider.System;
+
+    private FrameProvider? GetFrameProvider() => _frameProvider ?? RuntimeContext?.RenderFrameProvider;
 
     /// <inheritdoc />
     public void Stop()

--- a/src/Termina/Layout/TextAreaNode.cs
+++ b/src/Termina/Layout/TextAreaNode.cs
@@ -3,7 +3,6 @@
 
 using Termina.Rendering;
 using Termina.Terminal;
-using R3;
 
 namespace Termina.Layout;
 
@@ -26,11 +25,8 @@ public sealed class TextAreaNode : TextInputBaseNode
 
     private record struct WrappedLine(int TextStartIndex, int Length);
 
-    public TextAreaNode(
-        int cursorBlinkMs = 530,
-        TimeProvider? timeProvider = null,
-        FrameProvider? frameProvider = null)
-        : base(cursorBlinkMs, timeProvider, frameProvider)
+    public TextAreaNode(int cursorBlinkMs = 530)
+        : base(cursorBlinkMs)
     {
         HeightConstraint = new SizeConstraint.Auto { Min = 1, Max = 10 };
         WidthConstraint = new SizeConstraint.Fill();

--- a/src/Termina/Layout/TextInputBaseNode.cs
+++ b/src/Termina/Layout/TextInputBaseNode.cs
@@ -22,8 +22,6 @@ namespace Termina.Layout;
 /// </remarks>
 public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidatingNode, IFocusable, IPasteReceiver
 {
-    protected readonly TimeProvider? _timeProvider;
-    protected readonly FrameProvider? _frameProvider;
     protected readonly int _cursorBlinkMs;
     protected IDisposable? _cursorTimerSubscription;
     protected readonly Subject<Unit> _invalidated = new();
@@ -170,14 +168,9 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
         }
     }
 
-    protected TextInputBaseNode(
-        int cursorBlinkMs = 530,
-        TimeProvider? timeProvider = null,
-        FrameProvider? frameProvider = null)
+    protected TextInputBaseNode(int cursorBlinkMs = 530)
     {
         _cursorBlinkMs = cursorBlinkMs;
-        _timeProvider = timeProvider;
-        _frameProvider = frameProvider;
     }
 
     /// <inheritdoc />
@@ -222,7 +215,7 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
     /// <inheritdoc />
     public override void SetRuntimeContext(LayoutRuntimeContext context)
     {
-        var restart = IsAnimating && (_timeProvider is null || _frameProvider is null);
+        var restart = IsAnimating;
         if (restart)
             Stop();
 
@@ -232,9 +225,9 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
             Start();
     }
 
-    private TimeProvider GetTimeProvider() => _timeProvider ?? RuntimeContext?.TimeProvider ?? TimeProvider.System;
+    private TimeProvider GetTimeProvider() => RuntimeContext?.TimeProvider ?? TimeProvider.System;
 
-    private FrameProvider? GetFrameProvider() => _frameProvider ?? RuntimeContext?.RenderFrameProvider;
+    private FrameProvider? GetFrameProvider() => RuntimeContext?.RenderFrameProvider;
 
     /// <inheritdoc />
     public void Stop()

--- a/src/Termina/Layout/TextInputBaseNode.cs
+++ b/src/Termina/Layout/TextInputBaseNode.cs
@@ -22,7 +22,7 @@ namespace Termina.Layout;
 /// </remarks>
 public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidatingNode, IFocusable, IPasteReceiver
 {
-    protected readonly TimeProvider _timeProvider;
+    protected readonly TimeProvider? _timeProvider;
     protected readonly FrameProvider? _frameProvider;
     protected readonly int _cursorBlinkMs;
     protected IDisposable? _cursorTimerSubscription;
@@ -176,7 +176,7 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
         FrameProvider? frameProvider = null)
     {
         _cursorBlinkMs = cursorBlinkMs;
-        _timeProvider = timeProvider ?? TimeProvider.System;
+        _timeProvider = timeProvider;
         _frameProvider = frameProvider;
     }
 
@@ -206,9 +206,9 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
         {
             IsAnimating = true;
             _cursorVisible = true;
-            var ticks = Observable.Interval(TimeSpan.FromMilliseconds(_cursorBlinkMs), _timeProvider);
-            if (_frameProvider is not null)
-                ticks = ticks.ObserveOn(_frameProvider);
+            var ticks = Observable.Interval(TimeSpan.FromMilliseconds(_cursorBlinkMs), GetTimeProvider());
+            if (GetFrameProvider() is { } frameProvider)
+                ticks = ticks.ObserveOn(frameProvider);
 
             _cursorTimerSubscription ??= ticks
                 .Subscribe(_ =>
@@ -218,6 +218,23 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
                 });
         }
     }
+
+    /// <inheritdoc />
+    public override void SetRuntimeContext(LayoutRuntimeContext context)
+    {
+        var restart = IsAnimating && (_timeProvider is null || _frameProvider is null);
+        if (restart)
+            Stop();
+
+        base.SetRuntimeContext(context);
+
+        if (restart && _hasFocus)
+            Start();
+    }
+
+    private TimeProvider GetTimeProvider() => _timeProvider ?? RuntimeContext?.TimeProvider ?? TimeProvider.System;
+
+    private FrameProvider? GetFrameProvider() => _frameProvider ?? RuntimeContext?.RenderFrameProvider;
 
     /// <inheritdoc />
     public void Stop()

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -3,7 +3,6 @@
 
 using Termina.Rendering;
 using Termina.Terminal;
-using R3;
 
 namespace Termina.Layout;
 
@@ -15,11 +14,8 @@ public sealed class TextInputNode : TextInputBaseNode
 {
     private int _scrollOffset;
 
-    public TextInputNode(
-        int cursorBlinkMs = 530,
-        TimeProvider? timeProvider = null,
-        FrameProvider? frameProvider = null)
-        : base(cursorBlinkMs, timeProvider, frameProvider)
+    public TextInputNode(int cursorBlinkMs = 530)
+        : base(cursorBlinkMs)
     {
         HeightConstraint = new SizeConstraint.Fixed(1);
         WidthConstraint = new SizeConstraint.Fill();

--- a/src/Termina/Layout/WizardNode.cs
+++ b/src/Termina/Layout/WizardNode.cs
@@ -480,6 +480,7 @@ public sealed class WizardNode<TStep> : LayoutNode, IFocusable, IInvalidatingNod
                     return new EmptyNode();
                 return _steps[stepIndex].ContentFactory();
             });
+        ApplyRuntimeContextToChild(_contentNode);
 
         // Propagate content invalidation (e.g., SelectionListNode highlight changes)
         // up through the wizard so the page triggers a redraw

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -316,6 +316,8 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
                 ?? throw new InvalidOperationException(
                     $"BuildLayout() returned null for page {GetType().FullName}.");
 
+            ApplyRuntimeContext(newRoot);
+
             var newNodes = CollectLayoutNodes(newRoot);
 
             // Tear down the old framework wiring before we touch the previous
@@ -405,6 +407,8 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
                     $"BuildLayout() returned null for page {GetType().FullName}.");
         }
 
+        ApplyRuntimeContext(_layoutRoot);
+
         // Subscribe to layout invalidation events to trigger redraws. Lives in
         // _layoutSubscriptions so InvalidateLayout can replace it without
         // touching user-held entries in _subscriptions.
@@ -445,6 +449,15 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
         }
 
         return visited;
+    }
+
+    private void ApplyRuntimeContext(ILayoutNode root)
+    {
+        var context = new LayoutRuntimeContext(
+            ViewModel.RenderFrameProvider,
+            ViewModel.TimeProvider,
+            ViewModel.RequestRedraw);
+        LayoutRuntimeContextInjector.Apply(root, context);
     }
 
     private static void DisconnectAbandonedNodes(ILayoutNode? root, HashSet<ILayoutNode> retainedNodes)

--- a/src/Termina/Reactive/ReactiveViewModel.cs
+++ b/src/Termina/Reactive/ReactiveViewModel.cs
@@ -126,6 +126,11 @@ public abstract class ReactiveViewModel : IDisposable
     public FrameProvider RenderFrameProvider { get; private set; } = ObservableSystem.DefaultFrameProvider;
 
     /// <summary>
+    /// Time provider configured for the owning Termina application.
+    /// </summary>
+    public TimeProvider TimeProvider { get; private set; } = TimeProvider.System;
+
+    /// <summary>
     /// Enqueue work to run on the owning Termina application's render loop.
     /// </summary>
     public void Post(Action action) => _post(action);
@@ -193,6 +198,7 @@ public abstract class ReactiveViewModel : IDisposable
         Action requestRedraw,
         Observable<IInputEvent> input,
         FrameProvider? renderFrameProvider = null,
+        TimeProvider? timeProvider = null,
         Action<Action>? post = null,
         Func<Action, CancellationToken, Task>? invokeAsync = null)
     {
@@ -202,6 +208,7 @@ public abstract class ReactiveViewModel : IDisposable
         RequestRedraw = requestRedraw;
         Input = input;
         RenderFrameProvider = renderFrameProvider ?? ObservableSystem.DefaultFrameProvider;
+        TimeProvider = timeProvider ?? TimeProvider.System;
         _post = post ?? (_ => { });
         _invokeAsync = invokeAsync ?? ((action, _) =>
         {

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -307,6 +307,7 @@ public sealed class TerminaApplication
                 RequestRedraw,
                 Input,
                 RenderFrameProvider,
+                _runtimeOptions.TimeProvider,
                 Post,
                 InvokeAsync);
 

--- a/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
+++ b/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
@@ -145,9 +145,12 @@ public class CopyableTextNodeTests
     {
         var clipboard = new TestClipboardService();
         var timeProvider = new FakeTimeProvider();
-        var node = new CopyableTextNode(clipboard, "hello", timeProvider: timeProvider)
+        var node = new CopyableTextNode(clipboard, "hello")
             .WithFeedbackMode(CopyFeedbackMode.InlineIndicator)
             .WithInlineIndicator("OK");
+        LayoutRuntimeContextInjector.Apply(
+            node,
+            new LayoutRuntimeContext(new TestFrameProvider(), timeProvider, () => { }));
         var terminal = new VirtualTerminal(10, 3);
         var context = new RegionRenderContext(terminal, 0, 0, 10, 3);
 
@@ -195,6 +198,15 @@ public class CopyableTextNodeTests
         {
             LastToast = new ToastMessage(message, options?.Position ?? ToastPosition.BottomRight);
             _subject.OnNext(LastToast);
+        }
+    }
+
+    private sealed class TestFrameProvider : FrameProvider
+    {
+        public override long GetFrameCount() => 0;
+
+        public override void Register(IFrameRunnerWorkItem callback)
+        {
         }
     }
 }

--- a/tests/Termina.Tests/Layout/GraphNodeTests.cs
+++ b/tests/Termina.Tests/Layout/GraphNodeTests.cs
@@ -88,6 +88,7 @@ public class GraphNodeTests
     {
         var timeProvider = new FakeTimeProvider();
         var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
+        graph.OnActivate();
 
         Assert.True(graph.IsAnimating);
 

--- a/tests/Termina.Tests/Layout/GraphNodeTests.cs
+++ b/tests/Termina.Tests/Layout/GraphNodeTests.cs
@@ -86,8 +86,7 @@ public class GraphNodeTests
     [Fact]
     public void OnDeactivate_StopsAnimation()
     {
-        var timeProvider = new FakeTimeProvider();
-        var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
+        var graph = new GraphNode(intervalMs: 100);
         graph.OnActivate();
 
         Assert.True(graph.IsAnimating);
@@ -100,8 +99,7 @@ public class GraphNodeTests
     [Fact]
     public void OnActivate_ResumesAnimation()
     {
-        var timeProvider = new FakeTimeProvider();
-        var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
+        var graph = new GraphNode(intervalMs: 100);
 
         graph.OnDeactivate();
         Assert.False(graph.IsAnimating);
@@ -113,8 +111,7 @@ public class GraphNodeTests
     [Fact]
     public void Dispose_CompletesInvalidated()
     {
-        var timeProvider = new FakeTimeProvider();
-        var graph = new GraphNode(intervalMs: 100, timeProvider: timeProvider);
+        var graph = new GraphNode(intervalMs: 100);
 
         var completed = false;
         graph.Invalidated.Subscribe(
@@ -187,12 +184,9 @@ public class GraphNodeTests
     [Fact]
     public void IntervalZero_DisablesInternalTimer()
     {
-        var time = new FakeTimeProvider();
-        var graph = new GraphNode(intervalMs: 0, timeProvider: time);
+        var graph = new GraphNode(intervalMs: 0);
         var fired = 0;
         graph.Invalidated.Subscribe(_ => fired++);
-
-        time.Advance(TimeSpan.FromSeconds(10));
 
         Assert.Equal(0, fired);
         Assert.False(graph.IsAnimating);

--- a/tests/Termina.Tests/Layout/LayoutNodeLifecycleTests.cs
+++ b/tests/Termina.Tests/Layout/LayoutNodeLifecycleTests.cs
@@ -66,8 +66,9 @@ public class LayoutNodeLifecycleTests
     {
         // Arrange
         using var node = new SpinnerNode();
+        node.OnActivate();
 
-        // Assert - SpinnerNode auto-starts in constructor
+        // Assert - SpinnerNode starts on activation
         Assert.True(node.IsAnimating);
 
         // Act
@@ -235,8 +236,9 @@ public class LayoutNodeLifecycleTests
         // Arrange
         var spinner = new SpinnerNode();
         var modal = new ModalNode().WithContent(spinner);
+        modal.OnActivate();
 
-        Assert.True(spinner.IsAnimating); // Auto-started
+        Assert.True(spinner.IsAnimating);
 
         // Act
         modal.OnDeactivate();
@@ -300,6 +302,7 @@ public class LayoutNodeLifecycleTests
         var container = Layouts.Vertical()
             .WithChild(spinner1)
             .WithChild(spinner2);
+        container.OnActivate();
 
         Assert.True(spinner1.IsAnimating);
         Assert.True(spinner2.IsAnimating);

--- a/tests/Termina.Tests/Layout/LayoutRuntimeContextTests.cs
+++ b/tests/Termina.Tests/Layout/LayoutRuntimeContextTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Time.Testing;
+using R3;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+
+namespace Termina.Tests.Layout;
+
+public class LayoutRuntimeContextTests
+{
+    [Fact]
+    public void Apply_SuppliesContextBeforeActivation()
+    {
+        var context = CreateContext();
+        var node = new RecordingNode();
+
+        LayoutRuntimeContextInjector.Apply(node, context);
+        node.OnActivate();
+
+        Assert.Same(context, node.Context);
+        Assert.True(node.HadContextOnActivate);
+    }
+
+    [Fact]
+    public void Apply_PropagatesContextToNestedChildren()
+    {
+        var context = CreateContext();
+        var child = new RecordingNode();
+        using var root = Layouts.Vertical()
+            .WithChild(Layouts.Horizontal().WithChild(child));
+
+        LayoutRuntimeContextInjector.Apply(root, context);
+
+        Assert.Same(context, child.Context);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_AppliesContextToFactoryCreatedChild()
+    {
+        var context = CreateContext();
+        var child = new RecordingNode();
+        using var node = new DynamicLayoutNode(() => child);
+
+        LayoutRuntimeContextInjector.Apply(node, context);
+        node.Measure(new Size(10, 10));
+
+        Assert.Same(context, child.Context);
+    }
+
+    [Fact]
+    public void ContainerNode_AppliesContextToChildAddedAfterContext()
+    {
+        var context = CreateContext();
+        var container = new TestContainerNode();
+        var child = new RecordingNode();
+
+        LayoutRuntimeContextInjector.Apply(container, context);
+        container.Add(child);
+
+        Assert.Same(context, child.Context);
+    }
+
+    [Fact]
+    public void SpinnerNode_UsesRuntimeContextFrameProviderWithoutConstructorArgument()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var frameRequests = 0;
+        using var frameProvider = new TerminaRenderFrameProvider(
+            () => frameRequests++,
+            timeProvider,
+            TimeSpan.FromMilliseconds(10));
+        var context = new LayoutRuntimeContext(frameProvider, timeProvider, () => { });
+        using var spinner = new SpinnerNode(intervalMs: 80);
+        var invalidations = 0;
+        using var subscription = spinner.Invalidated.Subscribe(_ => invalidations++);
+
+        LayoutRuntimeContextInjector.Apply(spinner, context);
+        spinner.OnActivate();
+        timeProvider.Advance(TimeSpan.FromMilliseconds(80));
+
+        Assert.Equal(0, invalidations);
+        Assert.Equal(1, frameRequests);
+
+        frameProvider.AdvanceFrame();
+
+        Assert.Equal(1, invalidations);
+    }
+
+    private static LayoutRuntimeContext CreateContext()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var frameProvider = new TestFrameProvider();
+        return new LayoutRuntimeContext(frameProvider, timeProvider, () => { });
+    }
+
+    private sealed class RecordingNode : LayoutNode
+    {
+        public LayoutRuntimeContext? Context => RuntimeContext;
+
+        public bool HadContextOnActivate { get; private set; }
+
+        public override void OnActivate()
+        {
+            HadContextOnActivate = RuntimeContext is not null;
+            base.OnActivate();
+        }
+
+        public override Size Measure(Size available) => Size.Zero;
+
+        public override void Render(IRenderContext context, Rect bounds)
+        {
+        }
+    }
+
+    private sealed class TestContainerNode : ContainerNode
+    {
+        public void Add(ILayoutNode child) => AddChild(child);
+
+        public override Size Measure(Size available) => Size.Zero;
+
+        public override void Render(IRenderContext context, Rect bounds)
+        {
+        }
+    }
+
+    private sealed class TestFrameProvider : FrameProvider
+    {
+        public override long GetFrameCount() => 0;
+
+        public override void Register(IFrameRunnerWorkItem callback)
+        {
+        }
+    }
+}

--- a/tests/Termina.Tests/Layout/TextAreaNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextAreaNodeTests.cs
@@ -768,7 +768,10 @@ public class TextAreaNodeTests : IDisposable
     public void CursorBlink_TogglesWithTimeProvider()
     {
         var timeProvider = new FakeTimeProvider();
-        using var node = new TextAreaNode(cursorBlinkMs: 100, timeProvider: timeProvider);
+        using var node = new TextAreaNode(cursorBlinkMs: 100);
+        LayoutRuntimeContextInjector.Apply(
+            node,
+            new LayoutRuntimeContext(new TestFrameProvider(), timeProvider, () => { }));
 
         node.OnFocused();
         Assert.True(node.IsAnimating);
@@ -779,6 +782,15 @@ public class TextAreaNodeTests : IDisposable
         // Node should have invalidated (cursor toggled)
         // We verify by checking IsAnimating is still true (timer running)
         Assert.True(node.IsAnimating);
+    }
+
+    private sealed class TestFrameProvider : FrameProvider
+    {
+        public override long GetFrameCount() => 0;
+
+        public override void Register(IFrameRunnerWorkItem callback)
+        {
+        }
     }
 
     #endregion

--- a/tests/Termina.Tests/Reactive/ReactivePageLifecycleTests.cs
+++ b/tests/Termina.Tests/Reactive/ReactivePageLifecycleTests.cs
@@ -305,7 +305,7 @@ public class ReactivePageLifecycleTests
             () => { },
             timeProvider,
             TimeSpan.FromMilliseconds(10));
-        var page = new TestPageWithSpinner(timeProvider);
+        var page = new TestPageWithSpinner();
 
         var redrawCount = 0;
 
@@ -381,18 +381,11 @@ public class ReactivePageLifecycleTests
 
     private class TestPageWithSpinner : ReactivePage<TestViewModel>
     {
-        private readonly TimeProvider? _timeProvider;
-
         public SpinnerNode Spinner { get; private set; } = null!;
-
-        public TestPageWithSpinner(TimeProvider? timeProvider = null)
-        {
-            _timeProvider = timeProvider;
-        }
 
         public override ILayoutNode BuildLayout()
         {
-            Spinner = new SpinnerNode(timeProvider: _timeProvider);
+            Spinner = new SpinnerNode();
             return Spinner;
         }
 

--- a/tests/Termina.Tests/Reactive/ReactivePageLifecycleTests.cs
+++ b/tests/Termina.Tests/Reactive/ReactivePageLifecycleTests.cs
@@ -301,13 +301,24 @@ public class ReactivePageLifecycleTests
     {
         // Arrange - page with an IInvalidatingNode root (SpinnerNode) using FakeTimeProvider
         var timeProvider = new FakeTimeProvider();
+        using var frameProvider = new TerminaRenderFrameProvider(
+            () => { },
+            timeProvider,
+            TimeSpan.FromMilliseconds(10));
         var page = new TestPageWithSpinner(timeProvider);
 
         var redrawCount = 0;
 
         // Wire up ViewModel with a redraw counter
         var vm = new TestViewModel();
-        vm.WireUp(_ => { }, (_, _) => { }, () => { }, () => redrawCount++, Observable.Empty<IInputEvent>());
+        vm.WireUp(
+            _ => { },
+            (_, _) => { },
+            () => { },
+            () => redrawCount++,
+            Observable.Empty<IInputEvent>(),
+            renderFrameProvider: frameProvider,
+            timeProvider: timeProvider);
         page.BindForTest(vm);
 
         // First visit - invalidation subscription created
@@ -317,6 +328,7 @@ public class ReactivePageLifecycleTests
         // Advance time to trigger invalidation via the spinner's interval timer
         redrawCount = 0;
         timeProvider.Advance(TimeSpan.FromMilliseconds(80));
+        frameProvider.AdvanceFrame();
         Assert.True(redrawCount > 0, "Invalidation subscription should work on first visit");
 
         // Navigate away - subscription disposed
@@ -329,6 +341,7 @@ public class ReactivePageLifecycleTests
 
         // Advance time again - must still reach RequestRedraw
         timeProvider.Advance(TimeSpan.FromMilliseconds(80));
+        frameProvider.AdvanceFrame();
 
         // Assert - RequestRedraw should have been called after navigation round-trip
         Assert.True(redrawCount > 0, "Invalidation subscription was not re-created after navigation round-trip");

--- a/tests/Termina.Tests/RenderFrameProviderTests.cs
+++ b/tests/Termina.Tests/RenderFrameProviderTests.cs
@@ -152,6 +152,7 @@ public class RenderFrameProviderTests
             intervalMs: 80,
             timeProvider: timeProvider,
             frameProvider: frameProvider);
+        spinner.OnActivate();
         var invalidations = 0;
         using var subscription = spinner.Invalidated.Subscribe(_ => invalidations++);
 

--- a/tests/Termina.Tests/RenderFrameProviderTests.cs
+++ b/tests/Termina.Tests/RenderFrameProviderTests.cs
@@ -148,10 +148,10 @@ public class RenderFrameProviderTests
             () => frameRequests++,
             timeProvider,
             TimeSpan.FromMilliseconds(10));
-        using var spinner = new SpinnerNode(
-            intervalMs: 80,
-            timeProvider: timeProvider,
-            frameProvider: frameProvider);
+        using var spinner = new SpinnerNode(intervalMs: 80);
+        LayoutRuntimeContextInjector.Apply(
+            spinner,
+            new LayoutRuntimeContext(frameProvider, timeProvider, () => { }));
         spinner.OnActivate();
         var invalidations = 0;
         using var subscription = spinner.Invalidated.Subscribe(_ => invalidations++);


### PR DESCRIPTION
## Summary
- add LayoutRuntimeContext and inject it into layout trees before activation
- move component timing onto runtime context instead of constructor provider arguments
- update demos, docs, and tests for the single runtime-services path

## Validation
- dotnet test tests/Termina.Tests/Termina.Tests.csproj
- dotnet build Termina.slnx -c Release --no-restore
- dotnet test tests/Termina.Tests/Termina.Tests.csproj -c Release --no-build
- npm run build