### PR TITLE
release: 0.14.0-beta.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,18 +10,34 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.12.1</VersionPrefix>
-    <PackageReleaseNotes>**New Features**:
+    <VersionPrefix>0.14.0-beta.1</VersionPrefix>
+    <PackageReleaseNotes>**Beta Release Notes**
 
-- **WithFooter and WithFooterColor API on ModalNode** ([#292](https://github.com/Aaronontheweb/termina/pull/292))
-  - New `WithFooter(string)` and `WithFooterColor(Color)` builder methods on `ModalNode` for adding a footer line to modal dialogs
-  - Footer renders on the bottom border line with automatic text truncation to fit modal width
-  - Optional color customization via `WithFooterColor` — falls back to reset terminal colors when not specified
-  - Demonstrated with a TodoListPage demo showcasing modals with actionable footers
+This is the first beta of Termina 0.14.0 — a major internal rework of the rendering lifecycle and layout service infrastructure.
 
-**Documentation**:
+**Render Loop Frame Provider (#306)**
 
-- Updated ModalNode component docs with WithFooter API reference and usage example ([#293](https://github.com/Aaronontheweb/termina/pull/293))
+Added `TerminaRenderFrameProvider` — a centralized rendering loop that drives frame updates for the application. This replaces ad-hoc rendering triggers with a single, configurable frame loop that applications can opt into via `TerminaRuntimeOptions`.
+
+- `TerminaRenderFrameProvider` — New service that manages the application render loop
+- `TerminaRuntimeOptions` — New configuration for render loop settings (frame interval, mode)
+- `ObservableLayoutExtensions` — New extension methods for reactive layout updates tied to frame intervals
+- Updated demo apps and tutorials to use the new frame provider pattern
+
+**Layout Runtime Context**
+
+Added `LayoutRuntimeContext` — an app-owned layout runtime service that centralizes layout services (timing, frame info, rendering coordination) for all layout nodes. This moves component timing infrastructure onto a single, consistent path.
+
+- `LayoutRuntimeContext` — New runtime context for app-owned layout nodes
+- Component timing — Moved from scattered implementations to centralized runtime context
+- Updated all demos, docs, and tests to use the single runtime-services path
+
+**Internal Improvements**
+
+- Refactored `ReactiveViewModel` and `ReactivePage` to work with the new rendering context
+- Updated `TextInputBaseNode`, `TextAreaNode`, `SpinnerNode`, and `WizardNode` to consume runtime context
+- Added comprehensive tests for `RenderFrameProvider` and `LayoutRuntimeContext`
+- Updated tutorials (streaming chat, wizard app) to reflect new patterns
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,58 +1,37 @@
-# Release Notes — Termina 0.13.0
+# Release Notes — Termina 0.14.0-beta.1
 
-**Release date:** 2026-06-17
+**Release date:** 2026-06-18
 
-## Features
+####
 
-### Gradient primitives, GraphNode, and ProgressBarNode (#298) — Jan (@st0o0)
+This is the first beta of Termina 0.14.0 — a major internal rework of the rendering lifecycle and layout service infrastructure.
 
-A major visual components update with gradient coloring support across the board.
+**Render Loop Frame Provider (#306)**
 
-- **`Color.Lerp`** — Linear RGB interpolation between two colors
-- **`Gradient`** — Immutable multi-stop gradient with color stop interpolation
-- **`GraphNode`** — Reactive, self-invalidating layout node for live scrolling graphs in four styles:
-  - `Blocks` — Filled block columns (▁▂▃▄▅▆▇█)
-  - `Outline` — Top edge only, sparkline feel
-  - `Braille` — Double vertical resolution using braille characters
-  - `Ascii` — ASCII fallback for terminals without Unicode
-  - All styles support gradient coloring by row height
-  - Configurable timer interval or data-driven updates
-- **`ProgressBarNode`** — Single-row progress bar with:
-  - Gradient fill across the bar width
-  - Configurable fill/empty characters and colors
-  - Optional formatted label (e.g., `"{0:P0}"` for percentage)
-- Full API docs and interactive gallery demo
+Added `TerminaRenderFrameProvider` — a centralized rendering loop that drives frame updates for the application. This replaces ad-hoc rendering triggers with a single, configurable frame loop that applications can opt into via `TerminaRuntimeOptions`.
 
-### Color and icon support for toast notifications (#296) — Jan (@st0o0)
+- `TerminaRenderFrameProvider` — New service that manages the application render loop
+- `TerminaRuntimeOptions` — New configuration for render loop settings (frame interval, mode)
+- `ObservableLayoutExtensions` — New extension methods for reactive layout updates tied to frame intervals
+- Updated demo apps and tutorials to use the new frame provider pattern
 
-Toast notifications can now be customized with colors, icons, and positions.
+**Layout Runtime Context**
 
-- **`ToastOptions.Color`** — Optional color override for toast border
-- **`ToastOptions.Icon`** — Optional icon string displayed in the toast
-- Built-in presets:
-  - **Success** — Green border, ✓ icon, Top Right
-  - **Error** — Red border, ✗ icon, Top Right
-  - **Warning** — Yellow border, ⚠ icon, Top Center
-  - **Info** — Cyan border, ℹ icon, Bottom Right
-  - **Custom** — Magenta border, 🚀 icon, Bottom Center
-  - **Default** — No overrides (unchanged behavior)
+Added `LayoutRuntimeContext` — an app-owned layout runtime service that centralizes layout services (timing, frame info, rendering coordination) for all layout nodes. This moves component timing infrastructure onto a single, consistent path.
 
-## Bug Fixes
+- `LayoutRuntimeContext` — New runtime context for app-owned layout nodes
+- Component timing — Moved from scattered implementations to centralized runtime context
+- Updated all demos, docs, and tests to use the single runtime-services path
 
-### Parse CSI Z (backtab) as Shift+Tab (#297) — Jan (@st0o0)
+**Internal Improvements**
 
-In legacy terminal mode, the CSI Z escape sequence (`ESC [ Z`) was silently dropped. It now correctly maps to `Shift+Tab`, restoring expected backward-tab behavior.
-
-### ScrollableContainerNode ignoring bounds.Y (#301)
-
-`ScrollableContainerNode` was ignoring `bounds.Y` during layout, causing it to overwrite content above the scrollable area. The layout calculation now correctly respects vertical bounds.
-
-## Docs
-
-- Embedded animated GIF demos for Toast and Graph/Progress components (#302)
+- Refactored `ReactiveViewModel` and `ReactivePage` to work with the new rendering context
+- Updated `TextInputBaseNode`, `TextAreaNode`, `SpinnerNode`, and `WizardNode` to consume runtime context
+- Added comprehensive tests for `RenderFrameProvider` and `LayoutRuntimeContext`
+- Updated tutorials (streaming chat, wizard app) to reflect new patterns
 
 ---
 
 ### Contributors
 
-Thanks to **Jan (@st0o0)** for these contributions!
+Aaron Stannard


### PR DESCRIPTION
# Release Notes — Termina 0.14.0-beta.1

**Release date:** 2026-06-18

####

This is the first beta of Termina 0.14.0 — a major internal rework of the rendering lifecycle and layout service infrastructure.

**Render Loop Frame Provider (#306)**

Added `TerminaRenderFrameProvider` — a centralized rendering loop that drives frame updates for the application. This replaces ad-hoc rendering triggers with a single, configurable frame loop that applications can opt into via `TerminaRuntimeOptions`.

- `TerminaRenderFrameProvider` — New service that manages the application render loop
- `TerminaRuntimeOptions` — New configuration for render loop settings (frame interval, mode)
- `ObservableLayoutExtensions` — New extension methods for reactive layout updates tied to frame intervals
- Updated demo apps and tutorials to use the new frame provider pattern

**Layout Runtime Context**

Added `LayoutRuntimeContext` — an app-owned layout runtime service that centralizes layout services (timing, frame info, rendering coordination) for all layout nodes. This moves component timing infrastructure onto a single, consistent path.

- `LayoutRuntimeContext` — New runtime context for app-owned layout nodes
- Component timing — Moved from scattered implementations to centralized runtime context
- Updated all demos, docs, and tests to use the single runtime-services path

**Internal Improvements**

- Refactored `ReactiveViewModel` and `ReactivePage` to work with the new rendering context
- Updated `TextInputBaseNode`, `TextAreaNode`, `SpinnerNode`, and `WizardNode` to consume runtime context
- Added comprehensive tests for `RenderFrameProvider` and `LayoutRuntimeContext`
- Updated tutorials (streaming chat, wizard app) to reflect new patterns

---

### Contributors

Aaron Stannard