### PR TITLE
Release 0.14.0-beta.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,15 +11,17 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <VersionPrefix>0.14.0-beta.2</VersionPrefix>
-    <PackageReleaseNotes>**Beta Release Notes**
-
-This is the second beta of Termina 0.14.0 — a minor incremental release building on the rendering lifecycle and layout infrastructure from beta.1.
+    <PackageReleaseNotes>This is the second beta of Termina 0.14.0 — a minor incremental release on top of the rendering lifecycle and layout infrastructure from beta.1.
 
 **Bug Fixes**
 
 - Suppressed unnecessary full-screen refreshes triggered by no-op terminal resize events (#312)
 
----</PackageReleaseNotes>
+---
+
+### Contributors
+
+Aaron Stannard</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,34 +10,14 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.14.0-beta.1</VersionPrefix>
+    <VersionPrefix>0.14.0-beta.2</VersionPrefix>
     <PackageReleaseNotes>**Beta Release Notes**
 
-This is the first beta of Termina 0.14.0 — a major internal rework of the rendering lifecycle and layout service infrastructure.
+This is the second beta of Termina 0.14.0 — a minor incremental release building on the rendering lifecycle and layout infrastructure from beta.1.
 
-**Render Loop Frame Provider (#306)**
+**Bug Fixes**
 
-Added `TerminaRenderFrameProvider` — a centralized rendering loop that drives frame updates for the application. This replaces ad-hoc rendering triggers with a single, configurable frame loop that applications can opt into via `TerminaRuntimeOptions`.
-
-- `TerminaRenderFrameProvider` — New service that manages the application render loop
-- `TerminaRuntimeOptions` — New configuration for render loop settings (frame interval, mode)
-- `ObservableLayoutExtensions` — New extension methods for reactive layout updates tied to frame intervals
-- Updated demo apps and tutorials to use the new frame provider pattern
-
-**Layout Runtime Context**
-
-Added `LayoutRuntimeContext` — an app-owned layout runtime service that centralizes layout services (timing, frame info, rendering coordination) for all layout nodes. This moves component timing infrastructure onto a single, consistent path.
-
-- `LayoutRuntimeContext` — New runtime context for app-owned layout nodes
-- Component timing — Moved from scattered implementations to centralized runtime context
-- Updated all demos, docs, and tests to use the single runtime-services path
-
-**Internal Improvements**
-
-- Refactored `ReactiveViewModel` and `ReactivePage` to work with the new rendering context
-- Updated `TextInputBaseNode`, `TextAreaNode`, `SpinnerNode`, and `WizardNode` to consume runtime context
-- Added comprehensive tests for `RenderFrameProvider` and `LayoutRuntimeContext`
-- Updated tutorials (streaming chat, wizard app) to reflect new patterns
+- Suppressed unnecessary full-screen refreshes triggered by no-op terminal resize events (#312)
 
 ---</PackageReleaseNotes>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,34 +1,14 @@
-# Release Notes — Termina 0.14.0-beta.1
+# Release Notes — Termina 0.14.0-beta.2
 
-**Release date:** 2026-06-18
+**Release date:** 2026-06-19
 
 ####
 
-This is the first beta of Termina 0.14.0 — a major internal rework of the rendering lifecycle and layout service infrastructure.
+This is the second beta of Termina 0.14.0 — a minor incremental release building on the rendering lifecycle and layout infrastructure from beta.1.
 
-**Render Loop Frame Provider (#306)**
+#### Bug Fixes
 
-Added `TerminaRenderFrameProvider` — a centralized rendering loop that drives frame updates for the application. This replaces ad-hoc rendering triggers with a single, configurable frame loop that applications can opt into via `TerminaRuntimeOptions`.
-
-- `TerminaRenderFrameProvider` — New service that manages the application render loop
-- `TerminaRuntimeOptions` — New configuration for render loop settings (frame interval, mode)
-- `ObservableLayoutExtensions` — New extension methods for reactive layout updates tied to frame intervals
-- Updated demo apps and tutorials to use the new frame provider pattern
-
-**Layout Runtime Context**
-
-Added `LayoutRuntimeContext` — an app-owned layout runtime service that centralizes layout services (timing, frame info, rendering coordination) for all layout nodes. This moves component timing infrastructure onto a single, consistent path.
-
-- `LayoutRuntimeContext` — New runtime context for app-owned layout nodes
-- Component timing — Moved from scattered implementations to centralized runtime context
-- Updated all demos, docs, and tests to use the single runtime-services path
-
-**Internal Improvements**
-
-- Refactored `ReactiveViewModel` and `ReactivePage` to work with the new rendering context
-- Updated `TextInputBaseNode`, `TextAreaNode`, `SpinnerNode`, and `WizardNode` to consume runtime context
-- Added comprehensive tests for `RenderFrameProvider` and `LayoutRuntimeContext`
-- Updated tutorials (streaming chat, wizard app) to reflect new patterns
+- Suppressed unnecessary full-screen refreshes triggered by no-op terminal resize events (#312)
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,12 @@
 # Release Notes — Termina 0.14.0-beta.2
 
-**Release date:** 2026-06-19
+**Release date:** 2026-06-20
 
 ####
 
-This is the second beta of Termina 0.14.0 — a minor incremental release building on the rendering lifecycle and layout infrastructure from beta.1.
+This is the second beta of Termina 0.14.0 — a minor incremental release on top of the rendering lifecycle and layout infrastructure from beta.1.
 
-#### Bug Fixes
+**Bug Fixes**
 
 - Suppressed unnecessary full-screen refreshes triggered by no-op terminal resize events (#312)
 

--- a/scripts/getReleaseNotes.ps1
+++ b/scripts/getReleaseNotes.ps1
@@ -7,9 +7,6 @@ function Get-ReleaseNotes {
     # Read markdown file content
     $content = Get-Content -Path $MarkdownFile -Raw
 
-    # Split content based on headers
-    $sections = $content -split "####"
-
     # Output object to store result
     $outputObject = [PSCustomObject]@{
         Version       = $null
@@ -17,22 +14,26 @@ function Get-ReleaseNotes {
         ReleaseNotes  = $null
     }
 
-    # Check if we have at least 3 sections (1. Before the header, 2. Header, 3. Release notes)
-    if ($sections.Count -ge 3) {
-        $header = $sections[1].Trim()
-        $releaseNotes = $sections[2].Trim()
+    # Split on #### delimiter: section 0 = header, section 1 = release body
+    $sections = $content -split "####"
+    
+    if ($sections.Count -ge 2) {
+        $headerSection = $sections[0].Trim()
+        $releaseNotes = $sections[1].Trim()
 
-        # Extract version and date from the header
-        $headerParts = $header -split " ", 2
-        if ($headerParts.Count -eq 2) {
-            $outputObject.Version = $headerParts[0]
-            $outputObject.Date = $headerParts[1]
+        # Extract version from "# Release Notes — Termina 0.14.0-beta.2"
+        if ($headerSection -match "^# Release Notes — Termina\s+(.+)") {
+            $outputObject.Version = $matches[1]
+        }
+        
+        # Extract date from "**Release date:** 2026-06-20"
+        if ($headerSection -match "\*\*Release date:\*\*\s+(\d{4}-\d{2}-\d{2})") {
+            $outputObject.Date = $matches[1]
         }
 
         $outputObject.ReleaseNotes = $releaseNotes
     }
 
-    # Return the output object
     return $outputObject
 }
 


### PR DESCRIPTION
## Release 0.14.0-beta.2 (2026-06-19)

### Bug Fixes
- Suppressed unnecessary full-screen refreshes triggered by no-op terminal resize events (#312)

---
- [x] Version bumped to 0.14.0-beta.2
- [x] Release notes updated