### PR TITLE
Fix stale navigation seam renders and prep beta3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,12 +10,12 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.14.0-beta.2</VersionPrefix>
-    <PackageReleaseNotes>This is the second beta of Termina 0.14.0 — a minor incremental release on top of the rendering lifecycle and layout infrastructure from beta.1.
+    <VersionPrefix>0.14.0-beta.3</VersionPrefix>
+    <PackageReleaseNotes>This is the third beta of Termina 0.14.0 — a focused render-loop stability release for deferred navigation.
 
 **Bug Fixes**
 
-- Suppressed unnecessary full-screen refreshes triggered by no-op terminal resize events (#312)
+- Suppressed stale pre-swap frames when deferred navigation is queued from an input handler (#314)
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,14 @@
-# Release Notes — Termina 0.14.0-beta.2
+# Release Notes — Termina 0.14.0-beta.3
 
-**Release date:** 2026-06-20
+**Release date:** 2026-06-22
 
 ####
 
-This is the second beta of Termina 0.14.0 — a minor incremental release on top of the rendering lifecycle and layout infrastructure from beta.1.
+This is the third beta of Termina 0.14.0 — a focused render-loop stability release for deferred navigation.
 
 **Bug Fixes**
 
-- Suppressed unnecessary full-screen refreshes triggered by no-op terminal resize events (#312)
+- Suppressed stale pre-swap frames when deferred navigation is queued from an input handler (#314)
 
 ---
 

--- a/build.ps1
+++ b/build.ps1
@@ -6,7 +6,7 @@
 ######################################################################
 $releaseNotes = Get-ReleaseNotes -MarkdownFile (Join-Path -Path $PSScriptRoot -ChildPath "RELEASE_NOTES.md")
 
-# inject release notes into Directory.Buil
+# Inject release notes into Directory.Build.props.
 UpdateVersionAndReleaseNotes -ReleaseNotesResult $releaseNotes -XmlFilePath (Join-Path -Path $PSScriptRoot -ChildPath "Directory.Build.props")
 
-Write-Output "Added release notes $releaseNotes"
+Write-Output "Added release notes for $($releaseNotes.Version)"

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -67,6 +67,7 @@ public sealed class TerminaApplication
     private bool _rawInputActive;
     private bool _kittyKeyboardPushed;
     private bool _wheelScrollEnabledByApp;
+    private int _pendingNavigationRequests;
 
     /// <summary>
     /// Creates a new Termina application.
@@ -488,13 +489,20 @@ public sealed class TerminaApplication
     // model (the render loop calls BuildLayout() before OnBound() has run).
     private void RequestNavigation(string path)
     {
-        _eventChannel.Writer.TryWrite(new NavigationRequested(path));
+        EnqueueNavigationRequest(new NavigationRequested(path));
     }
 
     private void RequestNavigation(string routeTemplate, object? routeValues)
     {
-        _eventChannel.Writer.TryWrite(
+        EnqueueNavigationRequest(
             new NavigationRequested(RouteMatcher.BuildPath(routeTemplate, routeValues)));
+    }
+
+    private void EnqueueNavigationRequest(NavigationRequested request)
+    {
+        Interlocked.Increment(ref _pendingNavigationRequests);
+        if (!_eventChannel.Writer.TryWrite(request))
+            Interlocked.Decrement(ref _pendingNavigationRequests);
     }
 
     private void RequestRenderFrame()
@@ -585,16 +593,14 @@ public sealed class TerminaApplication
 
             // Initial render
             TerminaTrace.Render.Debug(this, "Starting initial render");
-            RenderCurrentPage();
+            if (!HasPendingNavigationRequests())
+                RenderCurrentPage();
             TerminaTrace.Render.Debug(this, "Initial render complete");
 
             // Single-threaded event loop - all input sources merge here
             await foreach (var evt in _eventChannel.Reader.ReadAllAsync(linkedToken))
             {
-                ProcessEvent(evt);
-
-                // Re-render after event processing
-                RenderCurrentPage();
+                ProcessEventAndMaybeRender(evt);
             }
         }
         catch (OperationCanceledException)
@@ -703,6 +709,7 @@ public sealed class TerminaApplication
 
             case NavigationRequested navReq:
                 TerminaTrace.Page.Debug(this, "NavigationRequested: {0}", navReq.PageKey);
+                Interlocked.Decrement(ref _pendingNavigationRequests);
                 NavigateTo(navReq.PageKey);
                 return;
 
@@ -801,6 +808,21 @@ public sealed class TerminaApplication
             _inputSubject.OnNext(inputEvent);
         }
     }
+
+    private void ProcessEventAndMaybeRender(object evt)
+    {
+        ProcessEvent(evt);
+
+        // If this event enqueued a navigation, do not render the page that is
+        // one event-loop turn away from being replaced.
+        if (HasPendingNavigationRequests())
+            return;
+
+        RenderCurrentPage();
+    }
+
+    private bool HasPendingNavigationRequests() =>
+        Volatile.Read(ref _pendingNavigationRequests) > 0;
 
     private static void ExecuteLoopWork(Action action)
     {

--- a/tests/Termina.Tests/NavigationThreadSafetyTests.cs
+++ b/tests/Termina.Tests/NavigationThreadSafetyTests.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Threading.Channels;
+using R3;
+using Termina.Input;
 using Termina.Layout;
 using Termina.Navigation;
 using Termina.Reactive;
@@ -66,6 +68,69 @@ public class NavigationThreadSafetyTests
         Assert.Equal("/dest", app.CurrentPath);
     }
 
+    [Fact]
+    public void ProcessEventAndMaybeRender_SkipsRender_WhenInputQueuesNavigation()
+    {
+        var terminal = new VirtualTerminal();
+        var app = new TerminaApplication(terminal);
+        app.RegisterRoute<InputNavigatingPage, InputNavigatingViewModel>("/start");
+        app.RegisterRoute<PlainPage, IdleViewModel>("/dest");
+        app.NavigateTo("/start");
+        InvokeRenderCurrentPage(app);
+        var outputCountBeforeInput = terminal.RawOutput.Count;
+
+        InvokeProcessEventAndMaybeRender(
+            app,
+            new KeyPressed(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false)));
+
+        Assert.Equal("/start", app.CurrentPath);
+        Assert.Equal(outputCountBeforeInput, terminal.RawOutput.Count);
+
+        var navRequest = ReadQueuedNavigation(app);
+        Assert.Equal("/dest", navRequest.PageKey);
+
+        InvokeProcessEventAndMaybeRender(app, navRequest);
+
+        Assert.Equal("/dest", app.CurrentPath);
+        Assert.True(terminal.RawOutput.Count > outputCountBeforeInput);
+        Assert.Contains("plain", terminal.ToString());
+    }
+
+    [Fact]
+    public void ProcessEventAndMaybeRender_SkipsIntermediateRender_WhenNavigationQueuesNavigation()
+    {
+        var terminal = new VirtualTerminal();
+        var app = new TerminaApplication(terminal);
+        app.RegisterRoute<InputNavigatingToMiddlePage, InputNavigatingToMiddleViewModel>("/start");
+        app.RegisterRoute<RedirectingPage, RedirectingViewModel>("/middle");
+        app.RegisterRoute<FinalPage, IdleViewModel>("/final");
+        app.NavigateTo("/start");
+        InvokeRenderCurrentPage(app);
+        var outputCountBeforeInput = terminal.RawOutput.Count;
+
+        InvokeProcessEventAndMaybeRender(
+            app,
+            new KeyPressed(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false)));
+        Assert.Equal(outputCountBeforeInput, terminal.RawOutput.Count);
+
+        var middleNavRequest = ReadQueuedNavigation(app);
+        Assert.Equal("/middle", middleNavRequest.PageKey);
+
+        InvokeProcessEventAndMaybeRender(app, middleNavRequest);
+
+        Assert.Equal("/middle", app.CurrentPath);
+        Assert.Equal(outputCountBeforeInput, terminal.RawOutput.Count);
+
+        var finalNavRequest = ReadQueuedNavigation(app);
+        Assert.Equal("/final", finalNavRequest.PageKey);
+
+        InvokeProcessEventAndMaybeRender(app, finalNavRequest);
+
+        Assert.Equal("/final", app.CurrentPath);
+        Assert.True(terminal.RawOutput.Count > outputCountBeforeInput);
+        Assert.Contains("final", terminal.ToString());
+    }
+
     private static NavigationRequested ReadQueuedNavigation(TerminaApplication app)
     {
         var field = typeof(TerminaApplication).GetField(
@@ -91,6 +156,22 @@ public class NavigationThreadSafetyTests
         method!.Invoke(app, [evt]);
     }
 
+    private static void InvokeProcessEventAndMaybeRender(TerminaApplication app, object evt)
+    {
+        var method = typeof(TerminaApplication).GetMethod(
+            "ProcessEventAndMaybeRender", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        method!.Invoke(app, [evt]);
+    }
+
+    private static void InvokeRenderCurrentPage(TerminaApplication app)
+    {
+        var method = typeof(TerminaApplication).GetMethod(
+            "RenderCurrentPage", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        method!.Invoke(app, []);
+    }
+
     private sealed class NavigatingViewModel : ReactiveViewModel
     {
         public override void OnActivated()
@@ -104,9 +185,68 @@ public class NavigationThreadSafetyTests
     {
     }
 
+    private sealed class InputNavigatingViewModel : ReactiveViewModel
+    {
+        public override void OnActivated()
+        {
+            base.OnActivated();
+            Input.OfType<IInputEvent, KeyPressed>()
+                .Subscribe(key =>
+                {
+                    if (key.KeyInfo.Key == ConsoleKey.Enter)
+                        Navigate("/dest");
+                })
+                .DisposeWith(Subscriptions);
+        }
+    }
+
+    private sealed class InputNavigatingToMiddleViewModel : ReactiveViewModel
+    {
+        public override void OnActivated()
+        {
+            base.OnActivated();
+            Input.OfType<IInputEvent, KeyPressed>()
+                .Subscribe(key =>
+                {
+                    if (key.KeyInfo.Key == ConsoleKey.Enter)
+                        Navigate("/middle");
+                })
+                .DisposeWith(Subscriptions);
+        }
+    }
+
+    private sealed class RedirectingViewModel : ReactiveViewModel
+    {
+        public override void OnActivated()
+        {
+            base.OnActivated();
+            Navigate("/final");
+        }
+    }
+
     private sealed class NavigatingPage : ReactivePage<NavigatingViewModel>
     {
         public override ILayoutNode BuildLayout() => new TextNode("A");
+    }
+
+    private sealed class InputNavigatingPage : ReactivePage<InputNavigatingViewModel>
+    {
+        public override ILayoutNode BuildLayout() => new TextNode("start");
+    }
+
+    private sealed class InputNavigatingToMiddlePage : ReactivePage<InputNavigatingToMiddleViewModel>
+    {
+        public override ILayoutNode BuildLayout() => new TextNode("start");
+    }
+
+    private sealed class RedirectingPage : ReactivePage<RedirectingViewModel>
+    {
+        public override ILayoutNode BuildLayout() => new TextNode("middle");
+    }
+
+    private sealed class FinalPage : ReactivePage<IdleViewModel>
+    {
+        public override ILayoutNode BuildLayout() => new TextNode("final");
     }
 
     private sealed class PageNavigatingPage : ReactivePage<IdleViewModel>


### PR DESCRIPTION
## Summary
- Suppress render-loop frames while deferred navigation requests are pending, including startup redirects.
- Add regression coverage for input-triggered navigation seams and chained deferred navigation.
- Prepare 0.14.0-beta.3 release notes and package metadata via build.ps1.

## Verification
- dotnet test tests/Termina.Tests/Termina.Tests.csproj -c Release --filter NavigationThreadSafetyTests
- dotnet test -c Release
- dotnet pack -c Release -o /tmp/opencode/termina-beta3-pack

Fixes #314