### PR TITLE
release: Termina 0.14.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,18 +10,9 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.14.0-beta.3</VersionPrefix>
-    <PackageReleaseNotes>This is the third beta of Termina 0.14.0 — a focused render-loop stability release for deferred navigation.
-
-**Bug Fixes**
-
-- Suppressed stale pre-swap frames when deferred navigation is queued from an input handler (#314)
-
----
-
-### Contributors
-
-Aaron Stannard</PackageReleaseNotes>
+    <VersionPrefix>
+    </VersionPrefix>
+    <PackageReleaseNotes>0.14.0 June 23rd 2026</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,47 @@
+#### 0.14.0 June 23rd 2026 ####
+
+**New Features**:
+
+- **Gradient primitives, GraphNode, and ProgressBarNode** ([#298](https://github.com/Aaronontheweb/termina/pull/298))
+  - New gradient system for rich visual theming
+  - `GraphNode` for data visualization and flow diagrams
+  - `ProgressBarNode` for animated progress indicators
+
+- **Toast notifications with colors and icons** ([#296](https://github.com/Aaronontheweb/termina/pull/296))
+  - Enhanced `ToastNode` with configurable foreground/background colors
+  - Icon support for status differentiation
+
+- **Modal footers with configurable colors** ([#292](https://github.com/Aaronontheweb/termina/pull/292), [#293](https://github.com/Aaronontheweb/termina/pull/293))
+  - `ModalNode` now supports `WithFooter` and `WithFooterColor` for adding a styled footer section
+  - Footer renders below modal content with optional color theming
+  - Includes a Gallery demo showcasing the feature on TodoList modals
+
+- **Render loop frame provider** ([#306](https://github.com/Aaronontheweb/termina/pull/306))
+  - New `IRenderLoopFrameProvider` for deterministic frame timing control
+  - Enables precise animation and layout update scheduling
+
+**Bug Fixes**:
+
+- **Suppressed stale pre-swap frames on deferred navigation** ([#315](https://github.com/Aaronontheweb/termina/pull/315))
+  - Fixed visual artifacts when navigation is queued from an input handler during render swap
+
+- **Eliminated no-op resize full refresh** ([#312](https://github.com/Aaronontheweb/termina/pull/312))
+  - Resizes that don't change bounds no longer trigger expensive full layout refresh
+
+- **Corrected ScrollableContainerNode bounds.Y handling** ([#301](https://github.com/Aaronontheweb/termina/pull/301))
+  - `ScrollableContainerNode` now respects `bounds.Y` instead of overwriting layout above it
+  - Fixes layout stacking issues in scrollable containers
+
+- **Fixed CSI Z (backtab/Shift+Tab) parsing** ([#297](https://github.com/Aaronontheweb/termina/pull/297))
+  - CSI Z sequences now correctly map to Tab with Shift modifier instead of being misinterpreted
+
+**Dependency Updates**:
+
+- Updated `Akka.Hosting` from 1.5.68 to 1.5.69 ([#299](https://github.com/Aaronontheweb/termina/pull/299))
+- Updated `OpenTelemetry.Api` from 1.15.3 to 1.16.0 ([#291](https://github.com/Aaronontheweb/termina/pull/291))
+
+---
+
 # Release Notes — Termina 0.14.0-beta.3
 
 **Release date:** 2026-06-22


### PR DESCRIPTION
## Release Notes

### New Features

- **Gradient primitives, GraphNode, and ProgressBarNode** ([#298](https://github.com/Aaronontheweb/termina/pull/298))
  - New gradient system for rich visual theming
  - `GraphNode` for data visualization and flow diagrams
  - `ProgressBarNode` for animated progress indicators

- **Toast notifications with colors and icons** ([#296](https://github.com/Aaronontheweb/termina/pull/296))
  - Enhanced `ToastNode` with configurable foreground/background colors
  - Icon support for status differentiation

- **Modal footers with configurable colors** ([#292](https://github.com/Aaronontheweb/termina/pull/292), [#293](https://github.com/Aaronontheweb/termina/pull/293))
  - `ModalNode` now supports `WithFooter` and `WithFooterColor` for adding a styled footer section
  - Footer renders below modal content with optional color theming
  - Includes a Gallery demo showcasing the feature on TodoList modals

- **Render loop frame provider** ([#306](https://github.com/Aaronontheweb/termina/pull/306))
  - New `IRenderLoopFrameProvider` for deterministic frame timing control
  - Enables precise animation and layout update scheduling

### Bug Fixes

- **Suppressed stale pre-swap frames on deferred navigation** ([#315](https://github.com/Aaronontheweb/termina/pull/315))
  - Fixed visual artifacts when navigation is queued from an input handler during render swap

- **Eliminated no-op resize full refresh** ([#312](https://github.com/Aaronontheweb/termina/pull/312))
  - Resizes that don't change bounds no longer trigger expensive full layout refresh

- **Corrected ScrollableContainerNode bounds.Y handling** ([#301](https://github.com/Aaronontheweb/termina/pull/301))
  - `ScrollableContainerNode` now respects `bounds.Y` instead of overwriting layout above it
  - Fixes layout stacking issues in scrollable containers

- **Fixed CSI Z (backtab/Shift+Tab) parsing** ([#297](https://github.com/Aaronontheweb/termina/pull/297))
  - CSI Z sequences now correctly map to Tab with Shift modifier instead of being misinterpreted

### Dependency Updates

- Updated `Akka.Hosting` from 1.5.68 to 1.5.69 ([#299](https://github.com/Aaronontheweb/termina/pull/299))
- Updated `OpenTelemetry.Api` from 1.15.3 to 1.16.0 ([#291](https://github.com/Aaronontheweb/termina/pull/291))

---

Built with `build.ps1` — updated `VersionPrefix` to `0.14.0` and `PackageReleaseNotes` in `Directory.Build.props`.