### PR TITLE
release: prepare 0.15.0-beta1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,9 +10,18 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>
-    </VersionPrefix>
-    <PackageReleaseNotes>0.14.0 June 23rd 2026</PackageReleaseNotes>
+    <VersionPrefix>0.15.0-beta1</VersionPrefix>
+    <PackageReleaseNotes>**Bug Fixes**
+
+- **Fixed CJK and Unicode display width handling** ([#321](https://github.com/Aaronontheweb/termina/pull/321))
+  - Terminal rendering now correctly accounts for East Asian and wide Unicode character widths in layout and cursor behavior
+
+**Dependency Updates**
+
+- Updated `actions/setup-dotnet` from 5.2.0 to 5.3.0 ([#270](https://github.com/Aaronontheweb/termina/pull/270))
+- Updated `Microsoft.Extensions.TimeProvider.Testing` from 10.6.0 to 10.7.0 ([#288](https://github.com/Aaronontheweb/termina/pull/288))
+- Updated `dotnet-sdk` from 10.0.201 to 10.0.301 ([#290](https://github.com/Aaronontheweb/termina/pull/290))
+- Updated `Microsoft.NET.Test.Sdk` from 18.6.0 to 18.7.0 ([#319](https://github.com/Aaronontheweb/termina/pull/319))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+# Release Notes — Termina 0.15.0-beta1
+
+**Release date:** 2026-06-26
+
+####
+
+**Bug Fixes**
+
+- **Fixed CJK and Unicode display width handling** ([#321](https://github.com/Aaronontheweb/termina/pull/321))
+  - Terminal rendering now correctly accounts for East Asian and wide Unicode character widths in layout and cursor behavior
+
+**Dependency Updates**
+
+- Updated `actions/setup-dotnet` from 5.2.0 to 5.3.0 ([#270](https://github.com/Aaronontheweb/termina/pull/270))
+- Updated `Microsoft.Extensions.TimeProvider.Testing` from 10.6.0 to 10.7.0 ([#288](https://github.com/Aaronontheweb/termina/pull/288))
+- Updated `dotnet-sdk` from 10.0.201 to 10.0.301 ([#290](https://github.com/Aaronontheweb/termina/pull/290))
+- Updated `Microsoft.NET.Test.Sdk` from 18.6.0 to 18.7.0 ([#319](https://github.com/Aaronontheweb/termina/pull/319))
+
+####
+
 #### 0.14.0 June 23rd 2026 ####
 
 **New Features**:


### PR DESCRIPTION
## Summary

- Prepare release notes for 0.15.0-beta1 in RELEASE_NOTES.md
- Bump VersionPrefix and PackageReleaseNotes for NuGet metadata

## Validation
- pwsh -File build.ps1
- dotnet build -c Release
- dotnet test -c Release
- dotnet pack -c Release -o ./output