### PR TITLE
Release 0.15.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.15.0-beta1</VersionPrefix>
+    <VersionPrefix>0.15.0</VersionPrefix>
     <PackageReleaseNotes>**Bug Fixes**
 
 - **Fixed CJK and Unicode display width handling** ([#321](https://github.com/Aaronontheweb/termina/pull/321))

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-# Release Notes — Termina 0.15.0-beta1
+# Release Notes — Termina 0.15.0
 
-**Release date:** 2026-06-26
+**Release date:** 2026-07-01
 
 ####
 


### PR DESCRIPTION
Stable release of Termina 0.15.0.

**Changes from 0.15.0-beta1:** None — beta was already stable, promoting to GA.

**Changes in 0.15.0:**

### Bug Fixes
- **Fixed CJK and Unicode display width handling** ([#321](https://github.com/Aaronontheweb/termina/pull/321))
  Terminal rendering now correctly accounts for East Asian and wide Unicode character widths in layout and cursor behavior

### Dependency Updates
- Updated `actions/setup-dotnet` from 5.2.0 to 5.3.0
- Updated `Microsoft.Extensions.TimeProvider.Testing` from 10.6.0 to 10.7.0
- Updated `dotnet-sdk` from 10.0.201 to 10.0.301
- Updated `Microsoft.NET.Test.Sdk` from 18.6.0 to 18.7.0
