### PR TITLE
fix(layout): reset horizontal scroll offset in TextInputNode on submit/clear

### DIFF
--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -260,7 +260,11 @@ public sealed class TextInputNode : TextInputBaseNode
     /// </summary>
     protected override void OnTextBufferChanged()
     {
-        // No-op for single-line — _scrollOffset is adjusted during Render
+        if (_text.Length == 0 || _cursorPosition == 0)
+        {
+            _scrollOffset = 0;
+        }
+        base.OnTextBufferChanged();
     }
 
     private static void WriteVisibleText(

--- a/src/Termina/Layout/TextInputNode.cs
+++ b/src/Termina/Layout/TextInputNode.cs
@@ -240,6 +240,10 @@ public sealed class TextInputNode : TextInputBaseNode
     /// </summary>
     protected override void OnTextBufferChanged()
     {
-        // No-op for single-line — _scrollOffset is adjusted during Render
+        if (_text.Length == 0 || _cursorPosition == 0)
+        {
+            _scrollOffset = 0;
+        }
+        base.OnTextBufferChanged();
     }
 }

--- a/tests/Termina.Tests/Layout/TextInputNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextInputNodeTests.cs
@@ -493,4 +493,34 @@ public class TextInputNodeTests : IDisposable
     {
         node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false));
     }
+
+    [Fact]
+    public void ScrollOffset_ResetsToZero_AfterSubmitOrClear()
+    {
+        var scrollOffsetField = typeof(TextInputNode).GetField("_scrollOffset", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(scrollOffsetField);
+        
+        TypeText(_node, "test");
+        scrollOffsetField.SetValue(_node, 10);
+        
+        _node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+        
+        var scrollOffsetAfterSubmit = (int)scrollOffsetField.GetValue(_node)!;
+        Assert.Equal(0, scrollOffsetAfterSubmit);
+    }
+
+    [Fact]
+    public void ScrollOffset_ResetsToZero_AfterClear()
+    {
+        var scrollOffsetField = typeof(TextInputNode).GetField("_scrollOffset", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(scrollOffsetField);
+        
+        TypeText(_node, "test");
+        scrollOffsetField.SetValue(_node, 10);
+        
+        _node.Clear();
+        
+        var scrollOffsetAfterClear = (int)scrollOffsetField.GetValue(_node)!;
+        Assert.Equal(0, scrollOffsetAfterClear);
+    }
 }

--- a/tests/Termina.Tests/Layout/TextInputNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextInputNodeTests.cs
@@ -468,4 +468,34 @@ public class TextInputNodeTests : IDisposable
     {
         node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false));
     }
+
+    [Fact]
+    public void ScrollOffset_ResetsToZero_AfterSubmitOrClear()
+    {
+        var scrollOffsetField = typeof(TextInputNode).GetField("_scrollOffset", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(scrollOffsetField);
+        
+        TypeText(_node, "test");
+        scrollOffsetField.SetValue(_node, 10);
+        
+        _node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+        
+        var scrollOffsetAfterSubmit = (int)scrollOffsetField.GetValue(_node)!;
+        Assert.Equal(0, scrollOffsetAfterSubmit);
+    }
+
+    [Fact]
+    public void ScrollOffset_ResetsToZero_AfterClear()
+    {
+        var scrollOffsetField = typeof(TextInputNode).GetField("_scrollOffset", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(scrollOffsetField);
+        
+        TypeText(_node, "test");
+        scrollOffsetField.SetValue(_node, 10);
+        
+        _node.Clear();
+        
+        var scrollOffsetAfterClear = (int)scrollOffsetField.GetValue(_node)!;
+        Assert.Equal(0, scrollOffsetAfterClear);
+    }
 }


### PR DESCRIPTION
## Changes

Resolves an issue where the first character typed into a `TextInputNode` is cut off (hidden/scrolled out of view) after a previously scrolled message is submitted or cleared.

### Root Cause Analysis

- `TextInputNode` manages a horizontal scroll index via a private field `_scrollOffset`.
- When input is submitted or cancelled, the base class `TextInputBaseNode` directly mutates `_text = ""` and `_cursorPosition = 0` bypassing the virtual `Clear()` method.
- Because `_scrollOffset` is managed entirely within the subclass, it is left in a stale, non-zero state.
- When the user types the first character of the next message, `_cursorPosition` jumps from 0 to 1 in the same input event tick.
- In the subsequent draw frame, `Render` sees `displayCursor = 1` and `_scrollOffset = 30`. It corrects `_scrollOffset` to `displayCursor`.
- Because `_scrollOffset` is now 1 and the text length is 1, the character at index 0 is scrolled off-screen and permanently clipped from view.

#### Proposed Changes

- `src/Termina/Layout/TextInputNode.cs`: Overrode `OnTextBufferChanged()` to reset `_scrollOffset` to 0 whenever the text buffer is empty or the cursor returns to position 0.

#### Testing

Added two unit tests in tests/Termina.Tests/Layout/TextInputNodeTests.cs:

- `ScrollOffset_ResetsToZero_AfterSubmitOrClear`: Verifies that `_scrollOffset` is reset to 0 upon Enter submission.
- `ScrollOffset_ResetsToZero_AfterClear`: Verifies that `_scrollOffset` is reset to 0 when calling `Clear()`.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).

I don't believe this is necessary.

* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).

I don't believe this is necessary.

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

* [ ] Design discussion issue #

I don't believe this is necessary.

* [ ] Changes in public API reviewed, if any.

I don't believe this is necessary.

* [ ] I have added website documentation for this feature.

I don't believe this is necessary.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Run Environment:

    BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8875/25H2/2025Update/HudsonValley2)
    Intel Core i7-14700 2.10GHz, 1 CPU, 28 logical and 20 physical cores
    .NET SDK 10.0.302
      [Host]     : .NET 10.0.10 (10.0.10, 10.0.1026.32716), X64 RyuJIT x86-64-v3

  #### Layout Rendering Benchmarks

   Method                      | Scenario                    |                        Mean |                      Error |                     StdDev |                     Median |                  Allocated
  -----------------------------|-----------------------------|-----------------------------|----------------------------|----------------------------|----------------------------|----------------------------
   MeasureOnly                 | ComplexGrid_3x3             |                   23.323 μs |                  1.4403 μs |                   4.201 μs |                  23.300 μs |                    11904 B
   MeasureAndRender            | ComplexGrid_3x3             |                  105.233 μs |                  3.8382 μs |                  11.196 μs |                 104.200 μs |                    20360 B
   FullRenderCycle             | ComplexGrid_3x3             |                  241.603 μs |                  7.1960 μs |                  19.940 μs |                 241.000 μs |                    58336 B
   MeasureOnly                 | Horiz(...)Items [23]        |                    9.074 μs |                  0.8673 μs |                   2.530 μs |                   8.750 μs |                     1936 B
   MeasureAndRender            | Horiz(...)Items [23]        |                   54.796 μs |                  2.2413 μs |                   6.502 μs |                  52.700 μs |                     2760 B
   FullRenderCycle             | Horiz(...)Items [23]        |                  137.036 μs |                  4.2200 μs |                  12.310 μs |                 136.100 μs |                     4568 B
   MeasureOnly                 | LargeText                   |                   22.849 μs |                  1.4555 μs |                   4.246 μs |                  22.500 μs |                    10016 B
   MeasureAndRender            | LargeText                   |                  102.037 μs |                  2.9438 μs |                   8.587 μs |                 101.400 μs |                    17920 B
   FullRenderCycle             | LargeText                   |                  252.549 μs |                  8.6512 μs |                  24.822 μs |                 252.000 μs |                   120672 B
   MeasureOnly                 | NestedPanels_3Deep          |                    6.684 μs |                  0.6885 μs |                   2.008 μs |                   6.600 μs |                     1904 B
   MeasureAndRender            | NestedPanels_3Deep          |                   83.926 μs |                  3.0700 μs |                   8.808 μs |                  81.900 μs |                     7560 B
   FullRenderCycle             | NestedPanels_3Deep          |                  245.573 μs |                  6.9327 μs |                  20.332 μs |                 241.200 μs |                    66032 B
   MeasureOnly                 | Panel_WithBorder            |                    4.763 μs |                  0.4325 μs |                   1.255 μs |                   4.700 μs |                      816 B
   MeasureAndRender            | Panel_WithBorder            |                   59.989 μs |                  1.9801 μs |                   5.744 μs |                  59.200 μs |                     2992 B
   FullRenderCycle             | Panel_WithBorder            |                  202.191 μs |                  5.0676 μs |                  14.621 μs |                 201.000 μs |                    26880 B
   MeasureOnly                 | Selec(...)Items [21]        |                   34.279 μs |                  2.2424 μs |                   6.541 μs |                  34.600 μs |                    18264 B
   MeasureAndRender            | Selec(...)Items [21]        |                   94.835 μs |                  3.7539 μs |                  11.010 μs |                  94.550 μs |                    20584 B
   FullRenderCycle             | Selec(...)Items [21]        |                  193.486 μs |                  4.7211 μs |                  13.920 μs |                 190.750 μs |                    25752 B
   MeasureOnly                 | SimpleText                  |                    4.333 μs |                  0.4767 μs |                   1.391 μs |                   4.450 μs |                      448 B
   MeasureAndRender            | SimpleText                  |                   48.018 μs |                  1.8077 μs |                   5.244 μs |                  48.000 μs |                      736 B
   FullRenderCycle             | SimpleText                  |                  122.472 μs |                  3.2964 μs |                   9.511 μs |                 119.650 μs |                     2448 B
   MeasureOnly                 | Verti(...)Items [22]        |                   19.206 μs |                  1.7947 μs |                   5.235 μs |                  19.300 μs |                     5712 B
   MeasureAndRender            | Verti(...)Items [22]        |                   74.891 μs |                  2.8903 μs |                   8.477 μs |                  73.300 μs |                    10696 B
   FullRenderCycle             | Verti(...)Items [22]        |                  178.351 μs |                  4.2038 μs |                  12.263 μs |                 176.400 μs |                    14640 B

  #### Tracing Overhead Benchmarks

   Method                 | Categories         |              Mean |             Error |            StdDev |             Ratio |           RatioSD |              Gen0 |         Allocated |       Alloc Ratio
  ------------------------|--------------------|-------------------|-------------------|-------------------|-------------------|-------------------|-------------------|-------------------|-------------------
   NullListener_NoArgs    | NoArgs             |          19.96 ns |          0.333 ns |          0.312 ns |              1.00 |              0.02 |                 - |                 - |                NA
   NullListener_OneArg    | OneArg             |          21.94 ns |          0.371 ns |          0.347 ns |                 ? |                 ? |            0.0014 |              24 B |                 ?
   NullListener_ThreeArgs | ThreeArgs          |          24.24 ns |          0.419 ns |          0.371 ns |                 ? |                 ? |            0.0028 |              48 B |                 ?
   NullListener_TwoArgs   | TwoArgs            |          22.21 ns |          0.287 ns |          0.269 ns |                 ? |                 ? |            0.0014 |              24 B |                 ?
