### PR TITLE
fix(streaming): preserve space separator background color only when adjacent segments match

### DIFF
--- a/src/Termina/Components/Streaming/StyledWordWrapper.cs
+++ b/src/Termina/Components/Streaming/StyledWordWrapper.cs
@@ -98,8 +98,15 @@ public static class StyledWordWrapper
             }
             else if (currentWidth + 1 + wordWidth <= width)
             {
-                // Word fits with space separator
-                currentLine.Append(" ");
+                // Word fits with space separator. Only inherit background color if BOTH the preceding segment and incoming word segment share the exact same background color.
+                var prevStyle = currentLine.Segments.Count > 0 ? currentLine.Segments[^1].Style : TextStyle.Default;
+                var nextStyle = word.Segments.Count > 0 ? word.Segments[0].Style : TextStyle.Default;
+
+                var hasSameBg = prevStyle.HasBackground && nextStyle.HasBackground && prevStyle.Background.Equals(nextStyle.Background);
+                var spaceBg = hasSameBg ? nextStyle.Background : Color.Default;
+                var spaceStyle = new TextStyle(nextStyle.Foreground, spaceBg, nextStyle.Decoration);
+
+                currentLine.Append(new StyledSegment(" ", spaceStyle));
                 foreach (var segment in word.Segments)
                 {
                     currentLine.Append(segment);

--- a/tests/Termina.Tests/Components/Streaming/StyledWordWrapperTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/StyledWordWrapperTests.cs
@@ -158,6 +158,42 @@ public class StyledWordWrapperTests
         Assert.Equal("C", wrapped[2].ToPlainText());
     }
 
+    [Fact]
+    public void WrapLine_MultiWordSegmentWithBackground_PreservesBackgroundColorOnSeparatorSpace()
+    {
+        var line = new StyledLine();
+        var style = new TextStyle(Color.Black, Color.BrightMagenta, TextDecoration.Bold);
+        line.Append(new StyledSegment("[Highlighted Message]", style));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 30);
+
+        Assert.Single(wrapped);
+        Assert.Equal("[Highlighted Message]", wrapped[0].ToPlainText());
+
+        // All segments in the wrapped line (including the space separator segment between words) must inherit background color
+        foreach (var segment in wrapped[0].Segments)
+        {
+            Assert.Equal(Color.BrightMagenta, segment.Style.Background);
+        }
+    }
+
+    [Fact]
+    public void WrapLine_BackgroundWordAfterUnstyledWord_SpaceSeparatorDoesNotInheritBackground()
+    {
+        var line = new StyledLine();
+        line.Append(new StyledSegment("[YT]", new TextStyle(Color.Red))); // Unstyled background
+        line.Append(new StyledSegment(" ", TextStyle.Default));
+        line.Append(new StyledSegment("[GIFT SUB]", new TextStyle(Color.Black, Color.BrightGreen, TextDecoration.Bold)));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 30);
+
+        Assert.Single(wrapped);
+
+        // Find the space segment between [YT] and [GIFT SUB]
+        var spaceSegment = wrapped[0].Segments.First(s => s.Text == " ");
+        Assert.NotEqual(Color.BrightGreen, spaceSegment.Style.Background);
+    }
+
     private static StyledLine CreateLine(string text, Color color)
     {
         var line = new StyledLine();


### PR DESCRIPTION
## Changes

When `StyledWordWrapper.cs` processed styled lines containing multiple words, it inserted a space separator segment between words on the same line using the incoming word segment's full style (`nextStyle`). This caused visual artifacts when an unstyled word (or a word without a background color) was immediately followed by a word with a background color (e.g., an unstyled tag `[YT]` followed by a highlighted tag `[GIFT SUB]`). The space between the two words would erroneously inherit the background color of the second word (`[GIFT SUB]`). Conversely, multi-word text inside a single highlighted segment (e.g., `[Highlighted Message]`) needs the space separator to retain the background color so the highlight remains visually contiguous.

### Examples

<img width="378" height="217" alt="gifted sub example" src="https://github.com/user-attachments/assets/50246c7e-623a-4ea6-935e-4dc4dfbacb6c" />

<img width="246" height="66" alt="highlighted_message_example" src="https://github.com/user-attachments/assets/e32ae7c3-59f5-4b70-84d5-de4c359adb1e" />

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).

I don't believe this is necessary.

* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).

I don't believe this is necessary.

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #

I don't believe this is necessary.

* [ ] Changes in public API reviewed, if any.

I don't believe this is necessary.

* [ ] I have added website documentation for this feature.

I don't believe this is necessary.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

#### 1. Rendering Benchmarks (RenderingBenchmarks)

    BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8894/25H2/2025Update/HudsonValley2)
    Intel Core i7-14700 2.10GHz, 1 CPU, 28 logical and 20 physical cores
    .NET SDK 10.0.400-preview.0.26322.102

    | Method           | Scenario                 |             Mean |          Error |         StdDev |           Median |     Allocated |
    |------------------|--------------------------|-----------------:|---------------:|---------------:|-----------------:|--------------:|
    | **MeasureOnly**  | **ComplexGrid_3x3**      |    **29.001 μs** |  **1.6479 μs** |   **4.807 μs** |    **28.300 μs** |  **15.24 KB** |
    | MeasureAndRender | ComplexGrid_3x3          |       260.721 μs |      5.4549 μs |      15.912 μs |       260.950 μs |      86.85 KB |
    | FullRenderCycle  | ComplexGrid_3x3          |       424.932 μs |     12.7776 μs |      37.675 μs |       418.400 μs |     135.47 KB |
    | **MeasureOnly**  | **Horiz(...)Items [23]** |    **10.636 μs** |  **0.6188 μs** |   **1.795 μs** |     **9.900 μs** |   **3.36 KB** |
    | MeasureAndRender | Horiz(...)Items [23]     |        63.091 μs |      1.2624 μs |       3.049 μs |        62.100 μs |       8.16 KB |
    | FullRenderCycle  | Horiz(...)Items [23]     |       134.125 μs |      2.6338 μs |       5.199 μs |       132.500 μs |      10.14 KB |
    | **MeasureOnly**  | **LargeText**            | **1,069.747 μs** | **75.8293 μs** | **213.878 μs** | **1,127.050 μs** | **346.34 KB** |
    | MeasureAndRender | LargeText                |     2,372.061 μs |    217.9519 μs |     639.215 μs |     2,672.600 μs |      786.8 KB |
    | FullRenderCycle  | LargeText                |     2,273.714 μs |    288.4619 μs |     841.457 μs |     2,756.700 μs |     919.55 KB |
    | **MeasureOnly**  | **NestedPanels_3Deep**   |     **9.364 μs** |  **0.6900 μs** |   **2.013 μs** |     **8.400 μs** |   **3.27 KB** |
    | MeasureAndRender | NestedPanels_3Deep       |       279.589 μs |      5.5304 μs |      15.325 μs |       273.900 μs |     103.96 KB |
    | FullRenderCycle  | NestedPanels_3Deep       |       429.497 μs |      8.5527 μs |      21.769 μs |       422.800 μs |     178.84 KB |
    | **MeasureOnly**  | **Panel_WithBorder**     |     **6.930 μs** |  **0.5834 μs** |   **1.711 μs** |     **6.300 μs** |   **1.74 KB** |
    | MeasureAndRender | Panel_WithBorder         |       133.237 μs |      2.6592 μs |       6.720 μs |       131.800 μs |      38.68 KB |
    | FullRenderCycle  | Panel_WithBorder         |       277.908 μs |      5.5163 μs |      14.041 μs |       277.900 μs |      68.66 KB |
    | **MeasureOnly**  | **Selec(...)Items [21]** |    **53.581 μs** |  **2.3956 μs** |   **6.912 μs** |    **53.800 μs** |  **27.51 KB** |
    | MeasureAndRender | Selec(...)Items [21]     |       144.539 μs |      2.8690 μs |       6.762 μs |       142.850 μs |      52.63 KB |
    | FullRenderCycle  | Selec(...)Items [21]     |       253.445 μs |      5.0188 μs |      13.739 μs |       249.100 μs |      58.63 KB |
    | **MeasureOnly**  | **SimpleText**           |     **7.223 μs** |  **0.4219 μs** |   **1.224 μs** |     **7.300 μs** |   **1.37 KB** |
    | MeasureAndRender | SimpleText               |        63.189 μs |      1.8403 μs |       5.280 μs |        62.200 μs |        4.1 KB |
    | FullRenderCycle  | SimpleText               |       134.830 μs |      2.7548 μs |       7.770 μs |       134.150 μs |       5.96 KB |
    | **MeasureOnly**  | **Verti(...)Items [22]** |    **28.679 μs** |  **1.2746 μs** |   **3.678 μs** |    **29.100 μs** |  **11.04 KB** |
    | MeasureAndRender | Verti(...)Items [22]     |       133.197 μs |      3.2621 μs |       9.567 μs |       130.700 μs |      36.13 KB |
    | FullRenderCycle  | Verti(...)Items [22]     |       230.992 μs |      4.5959 μs |      11.274 μs |       229.200 μs |      40.69 KB |

#### 2. Tracing Disabled Benchmarks (TracingDisabledBenchmarks)

    | Method             | Categories |      Mean |     Error |    StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
    |--------------------|------------|----------:|----------:|----------:|------:|--------:|----------:|------------:|
    | Disabled_NoArgs    | NoArgs     | 0.2411 ns | 0.0161 ns | 0.0151 ns |  1.00 |    0.08 |         - |          NA |
    | Disabled_OneArg    | OneArg     | 0.5486 ns | 0.0172 ns | 0.0161 ns |     ? |       ? |         - |           ? |
    | Disabled_ThreeArgs | ThreeArgs  | 0.4235 ns | 0.0075 ns | 0.0063 ns |     ? |       ? |         - |           ? |
    | Disabled_TwoArgs   | TwoArgs    | 0.4398 ns | 0.0209 ns | 0.0196 ns |     ? |       ? |         - |           ? |
    ──────

#### 3. Tracing Enabled Formatting Benchmarks (TracingEnabledFormattingBenchmarks)

    | Method               | Categories |     Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
    |----------------------|------------|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
    | Formatting_NoArgs    | NoArgs     | 20.62 ns | 0.306 ns | 0.271 ns |  1.00 |    0.02 |      - |         - |          NA |
    | Formatting_OneArg    | OneArg     | 41.95 ns | 0.869 ns | 1.301 ns |     ? |       ? | 0.0046 |      80 B |           ? |
    | Formatting_ThreeArgs | ThreeArgs  | 77.93 ns | 1.572 ns | 2.627 ns |     ? |       ? | 0.0074 |     128 B |           ? |
    | Formatting_TwoArgs   | TwoArgs    | 54.83 ns | 1.125 ns | 2.607 ns |     ? |       ? | 0.0055 |      96 B |           ? |
    ──────

#### 4. Tracing Enabled Null Listener Benchmarks (TracingEnabledNullListenerBenchmarks)

    | Method                 | Categories |     Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
    |------------------------|------------|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
    | NullListener_NoArgs    | NoArgs     | 18.87 ns | 0.123 ns | 0.103 ns |  1.00 |    0.01 |      - |         - |          NA |
    | NullListener_OneArg    | OneArg     | 21.22 ns | 0.450 ns | 0.421 ns |     ? |       ? | 0.0014 |      24 B |           ? |
    | NullListener_ThreeArgs | ThreeArgs  | 22.28 ns | 0.468 ns | 0.520 ns |     ? |       ? | 0.0028 |      48 B |           ? |
    | NullListener_TwoArgs   | TwoArgs    | 20.70 ns | 0.102 ns | 0.080 ns |     ? |       ? | 0.0014 |      24 B |           ? |
