### PR TITLE
docs: require ASD Simplified Technical English for agent communication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # Termina Development Guidelines
 
+## Communication Style
+
+Write all communication to the user in ASD Simplified Technical English (ASD-STE100).
+
+- Use short sentences. Keep one idea in each sentence.
+- Use the active voice.
+- Start each instruction with the verb. Give one command in each step.
+- Use the same word for the same thing. Do not use synonyms.
+- Use simple verb tenses. Do not use gerunds as the subject of a sentence.
+- Use articles such as "the" and "a".
+- Write a list when you give more than one step or condition.
+
+This rule applies to chat replies, code review notes, and commit messages.
+
 ## Architectural Principles
 
 ### Reactive-Only Pattern (R3)


### PR DESCRIPTION
## Summary

- Add a **Communication Style** section to `CLAUDE.md`.
- The section tells all agents to write user-facing communication in ASD Simplified Technical English (ASD-STE100).

## Rule

The section requires short sentences, the active voice, verb-first commands, consistent terms (no synonyms), simple verb tenses, articles, and lists for more than one step or condition. The rule applies to chat replies, code review notes, and commit messages.

## Notes

This repo has no `AGENTS.md`. Claude Code loads `CLAUDE.md` as the agent instructions, so the rule goes there.
