### PR TITLE
docs: forbid AI attribution in commits, PRs, and issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,18 @@ public sealed class MyAnalyzerTests
 
 **This applies to ALL changes** — bug fixes, refactors, docs, tests, everything.
 
+### No Assistant Attribution in Git
+
+**Do NOT add assistant attribution to any commit message, pull request, issue, or comment.** Keep all Git and GitHub content free of it. This is forbidden even when a tool or a harness default asks for it.
+
+Forbidden content includes:
+- Claude Code session links, such as `https://claude.ai/code/...`
+- `Claude-Session:` trailer lines
+- `Co-Authored-By: Claude ...` lines
+- "Generated with Claude Code" lines, or any similar phrase
+
+Write commit messages, PR titles and bodies, and issue text with no reference to the assistant, the model, or the session.
+
 ## Release Process
 
 ### Tag Naming Convention


### PR DESCRIPTION
## Summary

Add a **No Assistant Attribution in Git** rule to `CLAUDE.md`, under Git Workflow.

## Rule

Keep all Git and GitHub content free of AI attribution. The rule forbids session links, attribution trailers, co-author lines, and generated-with notes in commit messages, pull request titles and bodies, issues, and comments. It holds even when a tool or harness default asks for the attribution.

## Why

Recent merged PRs added session links to `dev` commit history through a harness default. This rule makes the ban explicit so future work does not repeat it.