### PR TITLE
feat: add TERMINA003 analyzer for layout node child disposal

### DIFF
--- a/src/Termina.Generators/LayoutNodeChildDisposalAnalyzer.cs
+++ b/src/Termina.Generators/LayoutNodeChildDisposalAnalyzer.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Termina.Generators;
+
+/// <summary>
+/// Detects disposal of a layout node child during a content switch.
+///
+/// Termina layout nodes use an active/inactive lifecycle. <c>IActivatableNode.OnDeactivate()</c> pauses a
+/// child and keeps it alive. <c>Dispose()</c> destroys it, so it can no longer render or handle input. A
+/// container that swaps content should deactivate the old child, not dispose it. Disposal is only correct in
+/// the container's own <c>Dispose()</c> method (final teardown).
+///
+/// To keep the false-positive rate low, the analyzer only flags <c>Dispose()</c> on a field or property of
+/// layout node type, inside a type that derives from <c>LayoutNode</c>, and never inside that type's own
+/// <c>Dispose()</c> or <c>DisposeAsync()</c> method.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class LayoutNodeChildDisposalAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "TERMINA003";
+
+    private const string Category = "Termina.Lifecycle";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Do not dispose a layout node child when switching content",
+        messageFormat: "The layout node '{0}' is disposed outside this type's Dispose() method. Dispose() destroys the node, so it can no longer render or handle input. To switch content, call OnDeactivate() instead.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Termina layout nodes use an active/inactive lifecycle. OnDeactivate() pauses a child and keeps it alive. Dispose() destroys it. A container should deactivate a switched-out child, not dispose it. Dispose a child only in the container's own Dispose() method.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var terminaContext = new TerminaContext(compilationContext.Compilation);
+            if (!terminaContext.HasRequiredTypes)
+                return;
+
+            compilationContext.RegisterSyntaxNodeAction(
+                ctx => AnalyzeDisposeInvocation(ctx, terminaContext),
+                SyntaxKind.InvocationExpression);
+        });
+    }
+
+    private static void AnalyzeDisposeInvocation(SyntaxNodeAnalysisContext context, TerminaContext terminaContext)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+        if (!TryGetDisposeInvocation(invocation, context.SemanticModel, context.CancellationToken, out var disposeName, out var receiverExpression))
+            return;
+
+        // The receiver must be a field or property of layout node type (persisted content).
+        var receiverSymbol = context.SemanticModel.GetSymbolInfo(receiverExpression, context.CancellationToken).Symbol;
+        var receiverType = receiverSymbol switch
+        {
+            IFieldSymbol field => field.Type,
+            IPropertySymbol property => property.Type,
+            _ => null
+        };
+        if (receiverType is null || !terminaContext.ImplementsLayoutNode(receiverType))
+            return;
+
+        // The enclosing type must be a container that derives from LayoutNode.
+        var enclosingTypeSyntax = invocation.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (enclosingTypeSyntax is null)
+            return;
+
+        var enclosingType = context.SemanticModel.GetDeclaredSymbol(enclosingTypeSyntax, context.CancellationToken);
+        if (enclosingType is null || !terminaContext.DerivesFromLayoutNode(enclosingType))
+            return;
+
+        // Disposal is correct in the container's own teardown, so skip Dispose()/DisposeAsync().
+        if (IsInsideDisposeMethod(invocation))
+            return;
+
+        var diagnostic = Diagnostic.Create(Rule, disposeName.GetLocation(), receiverSymbol!.Name);
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    private static bool TryGetDisposeInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out SimpleNameSyntax disposeName,
+        out ExpressionSyntax receiverExpression)
+    {
+        disposeName = null!;
+        receiverExpression = null!;
+
+        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            disposeName = memberAccess.Name;
+            receiverExpression = memberAccess.Expression;
+        }
+        else if (invocation.Expression is MemberBindingExpressionSyntax memberBinding
+            && invocation.Parent is ConditionalAccessExpressionSyntax conditionalAccess)
+        {
+            disposeName = memberBinding.Name;
+            receiverExpression = conditionalAccess.Expression;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (disposeName.Identifier.ValueText != "Dispose")
+            return false;
+
+        var method = semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol as IMethodSymbol;
+        return method is { Name: "Dispose", Parameters.Length: 0 };
+    }
+
+    /// <summary>
+    /// True when the invocation is inside the nearest enclosing <c>Dispose()</c> or <c>DisposeAsync()</c>
+    /// method declaration. Disposal there is the container's final teardown, which is correct.
+    /// </summary>
+    private static bool IsInsideDisposeMethod(SyntaxNode node)
+    {
+        var method = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        return method is not null
+            && method.Identifier.ValueText is "Dispose" or "DisposeAsync";
+    }
+
+    private sealed class TerminaContext
+    {
+        private readonly INamedTypeSymbol? _iLayoutNode;
+        private readonly INamedTypeSymbol? _layoutNode;
+
+        public TerminaContext(Compilation compilation)
+        {
+            _iLayoutNode = compilation.GetTypeByMetadataName("Termina.Layout.ILayoutNode");
+            _layoutNode = compilation.GetTypeByMetadataName("Termina.Layout.LayoutNode");
+        }
+
+        public bool HasRequiredTypes => _iLayoutNode is not null && _layoutNode is not null;
+
+        public bool ImplementsLayoutNode(ITypeSymbol type)
+        {
+            if (_iLayoutNode is null)
+                return false;
+
+            if (SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, _iLayoutNode))
+                return true;
+
+            foreach (var iface in type.AllInterfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, _iLayoutNode))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public bool DerivesFromLayoutNode(INamedTypeSymbol type)
+        {
+            if (_layoutNode is null)
+                return false;
+
+            for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
+            {
+                if (SymbolEqualityComparer.Default.Equals(current, _layoutNode))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Termina.Generators/LayoutNodeChildDisposalAnalyzer.cs
+++ b/src/Termina.Generators/LayoutNodeChildDisposalAnalyzer.cs
@@ -15,11 +15,13 @@ namespace Termina.Generators;
 /// Termina layout nodes use an active/inactive lifecycle. <c>IActivatableNode.OnDeactivate()</c> pauses a
 /// child and keeps it alive. <c>Dispose()</c> destroys it, so it can no longer render or handle input. A
 /// container that swaps content should deactivate the old child, not dispose it. Disposal is only correct in
-/// the container's own <c>Dispose()</c> method (final teardown).
+/// the container's own teardown (final cleanup).
 ///
-/// To keep the false-positive rate low, the analyzer only flags <c>Dispose()</c> on a field or property of
-/// layout node type, inside a type that derives from <c>LayoutNode</c>, and never inside that type's own
-/// <c>Dispose()</c> or <c>DisposeAsync()</c> method.
+/// To keep the false-positive rate low, the analyzer only flags <c>Dispose()</c> on a field or property that
+/// this container holds — accessed on <c>this</c>/<c>base</c> — whose type implements <c>ILayoutNode</c>,
+/// inside a type that derives from <c>LayoutNode</c>. It never flags disposal inside the container's own
+/// teardown: a <c>Dispose()</c>/<c>DisposeAsync()</c> method, a <c>Dispose(bool)</c> method, or a finalizer.
+/// Locals, method parameters, collection elements, and members of other objects are out of scope.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class LayoutNodeChildDisposalAnalyzer : DiagnosticAnalyzer
@@ -35,7 +37,7 @@ public sealed class LayoutNodeChildDisposalAnalyzer : DiagnosticAnalyzer
         category: Category,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Termina layout nodes use an active/inactive lifecycle. OnDeactivate() pauses a child and keeps it alive. Dispose() destroys it. A container should deactivate a switched-out child, not dispose it. Dispose a child only in the container's own Dispose() method.");
+        description: "Termina layout nodes use an active/inactive lifecycle. OnDeactivate() pauses a child and keeps it alive. Dispose() destroys it. A container should deactivate a switched-out child, not dispose it. Dispose a child only in the container's own teardown (Dispose/DisposeAsync/Dispose(bool)/finalizer).");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -62,7 +64,11 @@ public sealed class LayoutNodeChildDisposalAnalyzer : DiagnosticAnalyzer
         if (!TryGetDisposeInvocation(invocation, context.SemanticModel, context.CancellationToken, out var disposeName, out var receiverExpression))
             return;
 
-        // The receiver must be a field or property of layout node type (persisted content).
+        // The receiver must be a member of this container (accessed on `this`/`base`), not a member of
+        // another object, a collection element, a local, or a parameter.
+        if (!IsThisRootedMember(receiverExpression))
+            return;
+
         var receiverSymbol = context.SemanticModel.GetSymbolInfo(receiverExpression, context.CancellationToken).Symbol;
         var receiverType = receiverSymbol switch
         {
@@ -82,8 +88,8 @@ public sealed class LayoutNodeChildDisposalAnalyzer : DiagnosticAnalyzer
         if (enclosingType is null || !terminaContext.DerivesFromLayoutNode(enclosingType))
             return;
 
-        // Disposal is correct in the container's own teardown, so skip Dispose()/DisposeAsync().
-        if (IsInsideDisposeMethod(invocation))
+        // Disposal is correct in the container's own teardown, so skip those members.
+        if (IsInsideTeardownMember(invocation))
             return;
 
         var diagnostic = Diagnostic.Create(Rule, disposeName.GetLocation(), receiverSymbol!.Name);
@@ -124,14 +130,39 @@ public sealed class LayoutNodeChildDisposalAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// True when the invocation is inside the nearest enclosing <c>Dispose()</c> or <c>DisposeAsync()</c>
-    /// method declaration. Disposal there is the container's final teardown, which is correct.
+    /// True when the receiver is a member of the current instance: an unqualified field or property, or one
+    /// qualified with <c>this</c> or <c>base</c>. Disposing a member of another object, a collection element,
+    /// a local, or a parameter is out of scope.
     /// </summary>
-    private static bool IsInsideDisposeMethod(SyntaxNode node)
+    private static bool IsThisRootedMember(ExpressionSyntax receiver) => receiver switch
     {
-        var method = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        return method is not null
-            && method.Identifier.ValueText is "Dispose" or "DisposeAsync";
+        IdentifierNameSyntax => true,
+        MemberAccessExpressionSyntax memberAccess => memberAccess.Expression is ThisExpressionSyntax or BaseExpressionSyntax,
+        _ => false
+    };
+
+    /// <summary>
+    /// True when the invocation sits inside the container's own teardown: a <c>Dispose()</c>,
+    /// <c>DisposeAsync()</c>, or <c>Dispose(bool)</c> method, or a finalizer. Disposal there is correct.
+    /// Lambdas and local functions are transparent; the search walks up to the containing member.
+    /// </summary>
+    private static bool IsInsideTeardownMember(SyntaxNode node)
+    {
+        foreach (var ancestor in node.Ancestors())
+        {
+            switch (ancestor)
+            {
+                case DestructorDeclarationSyntax:
+                    return true;
+                case MethodDeclarationSyntax method:
+                    return method.Identifier.ValueText is "Dispose" or "DisposeAsync";
+                case ConstructorDeclarationSyntax:
+                case AccessorDeclarationSyntax:
+                    return false;
+            }
+        }
+
+        return false;
     }
 
     private sealed class TerminaContext

--- a/src/Termina.Generators/LayoutNodeChildDisposalAnalyzer.cs
+++ b/src/Termina.Generators/LayoutNodeChildDisposalAnalyzer.cs
@@ -134,12 +134,34 @@ public sealed class LayoutNodeChildDisposalAnalyzer : DiagnosticAnalyzer
     /// qualified with <c>this</c> or <c>base</c>. Disposing a member of another object, a collection element,
     /// a local, or a parameter is out of scope.
     /// </summary>
-    private static bool IsThisRootedMember(ExpressionSyntax receiver) => receiver switch
+    private static bool IsThisRootedMember(ExpressionSyntax receiver) => Unwrap(receiver) switch
     {
         IdentifierNameSyntax => true,
         MemberAccessExpressionSyntax memberAccess => memberAccess.Expression is ThisExpressionSyntax or BaseExpressionSyntax,
         _ => false
     };
+
+    /// <summary>
+    /// Strips parentheses and the null-forgiving operator from a receiver, so that <c>(_child)</c> and
+    /// <c>_child!</c> classify the same as <c>_child</c>.
+    /// </summary>
+    private static ExpressionSyntax Unwrap(ExpressionSyntax expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    expression = parenthesized.Expression;
+                    break;
+                case PostfixUnaryExpressionSyntax postfix when postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                    expression = postfix.Operand;
+                    break;
+                default:
+                    return expression;
+            }
+        }
+    }
 
     /// <summary>
     /// True when the invocation sits inside the container's own teardown: a <c>Dispose()</c>,

--- a/tests/Termina.Tests/Analyzers/LayoutNodeChildDisposalAnalyzerTests.cs
+++ b/tests/Termina.Tests/Analyzers/LayoutNodeChildDisposalAnalyzerTests.cs
@@ -236,6 +236,23 @@ public sealed class LayoutNodeChildDisposalAnalyzerTests
             }
         }
         """,
+
+        // N12: dispose inside a lambda that is itself inside Dispose(). Still teardown.
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private ContentNode? _currentChild;
+            private FakeObservable _source = new FakeObservable();
+
+            public override void Dispose()
+            {
+                _source.Subscribe(v => _currentChild?.Dispose());
+                base.Dispose();
+            }
+        }
+        """,
     };
 
     // -------------------------------------------------------------------------------------------------
@@ -341,6 +358,88 @@ public sealed class LayoutNodeChildDisposalAnalyzerTests
             }
             """,
             "_currentChild"
+        },
+
+        // S6: null-forgiving receiver (idiomatic in a nullable-enabled repo).
+        {
+            """
+            using Termina.Layout;
+
+            public sealed class MyContainer : LayoutNode
+            {
+                private ContentNode? _currentChild;
+
+                public void Replace(ContentNode next)
+                {
+                    _currentChild!.{|#0:Dispose|}();
+                    _currentChild = next;
+                }
+            }
+            """,
+            "_currentChild"
+        },
+
+        // S7: parenthesized receiver.
+        {
+            """
+            using Termina.Layout;
+
+            public sealed class MyContainer : LayoutNode
+            {
+                private ContentNode _currentChild = new ContentNode();
+
+                public void Replace(ContentNode next)
+                {
+                    (_currentChild).{|#0:Dispose|}();
+                    _currentChild = next;
+                }
+            }
+            """,
+            "_currentChild"
+        },
+
+        // S8: dispose the old child inside a property setter that switches content (a #70 shape).
+        {
+            """
+            using Termina.Layout;
+
+            public sealed class MyContainer : LayoutNode
+            {
+                private ContentNode? _currentChild;
+
+                public ContentNode? Content
+                {
+                    set
+                    {
+                        _currentChild?.{|#0:Dispose|}();
+                        _currentChild = value;
+                    }
+                }
+            }
+            """,
+            "_currentChild"
+        },
+
+        // S9: dispose a base-qualified inherited field.
+        {
+            """
+            using Termina.Layout;
+
+            public abstract class BaseContainer : LayoutNode
+            {
+                protected ContentNode? Child;
+            }
+
+            public sealed class MyContainer : BaseContainer
+            {
+                public void SwitchTo(ContentNode next)
+                {
+                    base.Child?.{|#0:Dispose|}();
+                    Child = next;
+                }
+            }
+            """,
+            "Child"
         },
     };
 

--- a/tests/Termina.Tests/Analyzers/LayoutNodeChildDisposalAnalyzerTests.cs
+++ b/tests/Termina.Tests/Analyzers/LayoutNodeChildDisposalAnalyzerTests.cs
@@ -14,8 +14,8 @@ using Verify = TerminaVerifier<LayoutNodeChildDisposalAnalyzer>;
 /// Tests for <see cref="LayoutNodeChildDisposalAnalyzer"/> (TERMINA003).
 ///
 /// SuccessCases are the happy path (correct code, no diagnostic). FailureCases are the sad path (a container
-/// that disposes a layout node child outside its own Dispose() method). Each failure case marks the expected
-/// location with <c>{|#0:Dispose|}</c> markup and passes the field name as the expected message argument.
+/// that disposes a `this`-held layout node child outside its own teardown). Each failure case marks the
+/// expected location with <c>{|#0:Dispose|}</c> markup and passes the member name as the message argument.
 /// </summary>
 public sealed class LayoutNodeChildDisposalAnalyzerTests
 {
@@ -44,6 +44,11 @@ public sealed class LayoutNodeChildDisposalAnalyzerTests
             {
                 public void OnActivate() { }
                 public void OnDeactivate() { }
+            }
+
+            public sealed class Holder
+            {
+                public ContentNode? Child { get; set; }
             }
 
             public sealed class FakeObservable
@@ -149,11 +154,93 @@ public sealed class LayoutNodeChildDisposalAnalyzerTests
             }
         }
         """,
+
+        // N7: dispose the child inside a finalizer (teardown, not a content switch).
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private ContentNode? _currentChild;
+
+            ~MyContainer()
+            {
+                _currentChild?.Dispose();
+            }
+        }
+        """,
+
+        // N8: dispose the child inside a Dispose(bool) method (the classic dispose pattern).
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private ContentNode? _currentChild;
+
+            public override void Dispose()
+            {
+                Dispose(true);
+                base.Dispose();
+            }
+
+            private void Dispose(bool disposing)
+            {
+                if (disposing)
+                    _currentChild?.Dispose();
+            }
+        }
+        """,
+
+        // N9: dispose a layout node that belongs to another instance, not this container.
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private ContentNode? _currentChild;
+
+            public void Detach(MyContainer other)
+            {
+                other._currentChild?.Dispose();
+            }
+        }
+        """,
+
+        // N10: dispose a layout node reached through another object (a holder's member).
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private Holder _holder = new Holder();
+
+            public void Clear()
+            {
+                _holder.Child?.Dispose();
+            }
+        }
+        """,
+
+        // N11: dispose a collection element, not a direct member. Out of scope.
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private System.Collections.Generic.List<ContentNode> _children = new();
+
+            public void Replace()
+            {
+                _children[0].Dispose();
+            }
+        }
+        """,
     };
 
     // -------------------------------------------------------------------------------------------------
-    // Sad path: a LayoutNode container disposes a layout node child outside its own Dispose(). One warning.
-    // Tuple: (source with {|#0:Dispose|} markup, disposed field name).
+    // Sad path: a LayoutNode container disposes a this-held layout node child outside its teardown.
+    // Tuple: (source with {|#0:Dispose|} markup, disposed member name).
     // -------------------------------------------------------------------------------------------------
     public static readonly TheoryData<string, string> FailureCases = new()
     {
@@ -235,6 +322,25 @@ public sealed class LayoutNodeChildDisposalAnalyzerTests
             }
             """,
             "Current"
+        },
+
+        // S5: the child is disposed through an explicit `this.` qualifier.
+        {
+            """
+            using Termina.Layout;
+
+            public sealed class MyContainer : LayoutNode
+            {
+                private ContentNode _currentChild = new ContentNode();
+
+                public void Replace(ContentNode next)
+                {
+                    this._currentChild.{|#0:Dispose|}();
+                    _currentChild = next;
+                }
+            }
+            """,
+            "_currentChild"
         },
     };
 

--- a/tests/Termina.Tests/Analyzers/LayoutNodeChildDisposalAnalyzerTests.cs
+++ b/tests/Termina.Tests/Analyzers/LayoutNodeChildDisposalAnalyzerTests.cs
@@ -1,0 +1,255 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Termina.Generators;
+using Termina.Tests.Utility;
+
+namespace Termina.Tests.Analyzers;
+
+using Verify = TerminaVerifier<LayoutNodeChildDisposalAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="LayoutNodeChildDisposalAnalyzer"/> (TERMINA003).
+///
+/// SuccessCases are the happy path (correct code, no diagnostic). FailureCases are the sad path (a container
+/// that disposes a layout node child outside its own Dispose() method). Each failure case marks the expected
+/// location with <c>{|#0:Dispose|}</c> markup and passes the field name as the expected message argument.
+/// </summary>
+public sealed class LayoutNodeChildDisposalAnalyzerTests
+{
+    private const string TerminaFrameworkSource = """
+        namespace Termina.Layout
+        {
+            public interface ILayoutNode : System.IDisposable { }
+
+            public interface IActivatableNode : ILayoutNode
+            {
+                void OnActivate();
+                void OnDeactivate();
+            }
+
+            public abstract class LayoutNode : ILayoutNode
+            {
+                public virtual void Dispose() { }
+            }
+
+            public sealed class TextNode : LayoutNode
+            {
+                public TextNode(string text) { }
+            }
+
+            public sealed class ContentNode : LayoutNode, IActivatableNode
+            {
+                public void OnActivate() { }
+                public void OnDeactivate() { }
+            }
+
+            public sealed class FakeObservable
+            {
+                public System.IDisposable Subscribe(System.Action<object> onNext) => null!;
+            }
+        }
+        """;
+
+    // -------------------------------------------------------------------------------------------------
+    // Happy path: correct code that keeps children alive, or disposes only during teardown. No warning.
+    // -------------------------------------------------------------------------------------------------
+    public static readonly TheoryData<string> SuccessCases = new()
+    {
+        // N1: dispose the child inside the container's own Dispose() override (final teardown).
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private ContentNode? _currentChild;
+
+            public override void Dispose()
+            {
+                _currentChild?.Dispose();
+                base.Dispose();
+            }
+        }
+        """,
+
+        // N2: dispose the child inside DisposeAsync() (also final teardown).
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private ContentNode? _currentChild;
+
+            public System.Threading.Tasks.ValueTask DisposeAsync()
+            {
+                _currentChild?.Dispose();
+                return default;
+            }
+        }
+        """,
+
+        // N3: deactivate the old child on a switch. There is no Dispose() call.
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private ContentNode? _currentChild;
+
+            public void SwitchTo(ContentNode next)
+            {
+                _currentChild?.OnDeactivate();
+                _currentChild = next;
+            }
+        }
+        """,
+
+        // N4: dispose a non-layout IDisposable (a subscription). Not an ILayoutNode.
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            private System.IDisposable? _subscription;
+
+            public void Refresh()
+            {
+                _subscription?.Dispose();
+            }
+        }
+        """,
+
+        // N5: the enclosing type is not a LayoutNode (for example a page). Out of scope.
+        """
+        using Termina.Layout;
+
+        public sealed class MyPage
+        {
+            private ContentNode? _child;
+
+            public void Close()
+            {
+                _child?.Dispose();
+            }
+        }
+        """,
+
+        // N6: dispose a local layout node, not a field or property. Out of scope.
+        """
+        using Termina.Layout;
+
+        public sealed class MyContainer : LayoutNode
+        {
+            public void Rebuild()
+            {
+                var temp = new ContentNode();
+                temp.Dispose();
+            }
+        }
+        """,
+    };
+
+    // -------------------------------------------------------------------------------------------------
+    // Sad path: a LayoutNode container disposes a layout node child outside its own Dispose(). One warning.
+    // Tuple: (source with {|#0:Dispose|} markup, disposed field name).
+    // -------------------------------------------------------------------------------------------------
+    public static readonly TheoryData<string, string> FailureCases = new()
+    {
+        // S1: dispose the child in a content-switch method.
+        {
+            """
+            using Termina.Layout;
+
+            public sealed class MyContainer : LayoutNode
+            {
+                private ContentNode? _currentChild;
+
+                public void SwitchTo(ContentNode next)
+                {
+                    _currentChild?.{|#0:Dispose|}();
+                    _currentChild = next;
+                }
+            }
+            """,
+            "_currentChild"
+        },
+
+        // S2: dispose the child inside a Subscribe(...) handler (the shape of #70).
+        {
+            """
+            using Termina.Layout;
+
+            public sealed class MyContainer : LayoutNode
+            {
+                private ILayoutNode? _currentChild;
+                private FakeObservable _source = new FakeObservable();
+
+                public MyContainer()
+                {
+                    _source.Subscribe(v =>
+                    {
+                        _currentChild?.{|#0:Dispose|}();
+                        _currentChild = new TextNode("next");
+                    });
+                }
+            }
+            """,
+            "_currentChild"
+        },
+
+        // S3: dispose the old child, then assign the new one, via a plain (non-conditional) call.
+        {
+            """
+            using Termina.Layout;
+
+            public sealed class MyContainer : LayoutNode
+            {
+                private ContentNode _currentChild = new ContentNode();
+
+                public void Replace(ContentNode next)
+                {
+                    _currentChild.{|#0:Dispose|}();
+                    _currentChild = next;
+                }
+            }
+            """,
+            "_currentChild"
+        },
+
+        // S4: dispose a layout node exposed as a property.
+        {
+            """
+            using Termina.Layout;
+
+            public sealed class MyContainer : LayoutNode
+            {
+                private ContentNode? Current { get; set; }
+
+                public void Clear()
+                {
+                    Current?.{|#0:Dispose|}();
+                    Current = null;
+                }
+            }
+            """,
+            "Current"
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(SuccessCases))]
+    public Task SuccessCase(string testCode)
+        => Verify.VerifyAnalyzer([TerminaFrameworkSource, testCode]);
+
+    [Theory]
+    [MemberData(nameof(FailureCases))]
+    public Task FailureCase(string testCode, string memberName)
+        => Verify.VerifyAnalyzer(
+            [TerminaFrameworkSource, testCode],
+            Verify.Diagnostic(LayoutNodeChildDisposalAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments(memberName)
+                .WithSeverity(DiagnosticSeverity.Warning));
+}


### PR DESCRIPTION
## Summary

Add `LayoutNodeChildDisposalAnalyzer` (**TERMINA003**). It warns when code disposes a layout node child during a content switch, when it should call `OnDeactivate()` instead. Implements the spec on issue #73.

Closes #73.

## Why

Termina layout nodes use an active/inactive lifecycle. `OnDeactivate()` pauses a child and keeps it alive. `Dispose()` destroys it, so the child can no longer render or handle input. Issue #70 was exactly this bug: `ReactiveLayoutNode` disposed its child on a content switch, and the child went dead.

## Detection

Warn when all of these are true:
- The call is `Dispose()` (no arguments) on a **field or property** whose type implements `ILayoutNode`.
- The **enclosing type derives from `LayoutNode`** (a container).
- The call is **not** inside the enclosing type's `Dispose()` or `DisposeAsync()` method.

Handles `_node.Dispose()` and `_node?.Dispose()`. Uses semantic symbol analysis and caches type lookups in `CompilationStart`.

## Why the false-positive rate stays low

The framework disposes children only in `Dispose()` (for example `ReactiveLayoutNode.Dispose()` disposes `_currentChild`). That teardown case is excluded, so the analyzer stays quiet on correct code. The full solution and all demos build with **no new warnings**.

## Diagnostic

- Id: `TERMINA003` (this rule owns the id, per #73).
- Severity: Warning. `TreatWarningsAsErrors` makes it a build error for first-party code.
- Category: `Termina.Lifecycle`.

## Scope and non-goals

- Targets fields and properties of layout node type inside `LayoutNode`-derived containers.
- Does not flag locals, parameters, or non-`LayoutNode` types (pages, app teardown).
- Accepts some false negatives to keep the false-positive rate low.

## Tests

Success/failure `TheoryData` format (the codified convention):
- Happy path (6): teardown in `Dispose()`, teardown in `DisposeAsync()`, `OnDeactivate()` on switch, a non-layout `IDisposable`, a non-`LayoutNode` type, a local variable.
- Sad path (4): switch method, `Subscribe(...)` handler, plain call, property.

All 1573 tests in `Termina.Tests` pass.

## Adversarial review fixes

An adversarial review found false positives beyond the documented non-goals. Fixed in this branch:
- **Finalizer / `Dispose(bool)`:** disposal there is teardown, not a switch. `IsInsideTeardownMember` now recognizes destructors and `Dispose(bool)`, and walks up through lambdas and local functions to the containing member.
- **Foreign receiver:** the rule intends "a child this container holds," but it did not check the receiver. It now requires a field or property accessed on `this`/`base`. This drops false positives for disposing another object's member, a collection element, a local, or a parameter — and removes the meaningless `'this[]'` message for indexer receivers.

Tests expanded to 16 cases (11 happy, 5 sad), including finalizer, `Dispose(bool)`, foreign instance, holder member, collection element, and an explicit `this.` qualifier. The review found no crashes.


### Second review pass

A re-review confirmed the fixes above and found that the `this`-rooted gate had silenced two idiomatic content-switch shapes: `_child!.Dispose()` (null-forgiving) and `(_child).Dispose()` (parenthesized). `IsThisRootedMember` now unwraps parentheses and the null-forgiving operator, so both warn again. Tests are at 21 cases (added null-forgiving, parenthesized, property-setter, base-qualified failures, and a lambda-inside-`Dispose()` success). No crashes were found in either pass.
