### PR TITLE
Wire analyzers into the Termina library and fix dispose-on-switch

### DIFF
--- a/src/Termina/Layout/PanelNode.cs
+++ b/src/Termina/Layout/PanelNode.cs
@@ -92,9 +92,12 @@ public sealed class PanelNode : LayoutNode, IInvalidatingNode
     /// </summary>
     public PanelNode WithContent(ILayoutNode content)
     {
-        // Dispose old content and subscription
+        // Dispose the old content's subscription, and deactivate the old content
+        // (active/inactive pattern) rather than dispose it — a swapped-out node may
+        // still be reused. Content is disposed only at teardown, in Dispose().
         _contentInvalidationSubscription?.Dispose();
-        _content.Dispose();
+        if (_content is IActivatableNode oldContent)
+            oldContent.OnDeactivate();
 
         // Set new content
         _content = content;

--- a/src/Termina/Layout/ScrollableContainerNode.cs
+++ b/src/Termina/Layout/ScrollableContainerNode.cs
@@ -101,9 +101,12 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     /// </summary>
     public ScrollableContainerNode WithContent(ILayoutNode content)
     {
-        // Dispose previous subscription and content
+        // Dispose the previous content's subscription, and deactivate the previous
+        // content (active/inactive pattern) rather than dispose it. Content is
+        // disposed only at teardown, in Dispose().
         _contentSubscription?.Dispose();
-        _content.Dispose();
+        if (_content is IActivatableNode oldContent)
+            oldContent.OnDeactivate();
         _content = content;
 
         // If content is invalidating, subscribe to the observable

--- a/src/Termina/Termina.csproj
+++ b/src/Termina/Termina.csproj
@@ -17,12 +17,31 @@
   </ItemGroup>
 
   <!--
-    Reference the source generator.
-    - The generator project handles its own packaging into analyzers/dotnet/cs
-    - No PrivateAssets means the dependency flows to NuGet consumers
+    Reference the analyzers/source generator.
+    - OutputItemType="Analyzer" runs TERMINA002/003/004 and the ReactivePropertyGenerator on
+      Termina's own compilation (self-analysis).
+    - ReferenceOutputAssembly="false" keeps the netstandard2.0 generator assembly out of Termina's
+      compile references and runtime dependencies (no TreatWarningsAsErrors fallout).
+    - The _BundleGeneratorAnalyzer target below packs the generator DLL into Termina's OWN package
+      under analyzers/dotnet/cs, so NuGet consumers receive the analyzers directly — no transitive
+      Termina.Generators package dependency required.
   -->
   <ItemGroup>
-    <ProjectReference Include="..\Termina.Generators\Termina.Generators.csproj"/>
+    <ProjectReference Include="..\Termina.Generators\Termina.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_BundleGeneratorAnalyzer</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="_BundleGeneratorAnalyzer" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(Analyzer)"
+                              Condition="'%(Filename)' == 'Termina.Generators'"
+                              PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/tests/Termina.Tests/Layout/ContentSwitchDeactivationTests.cs
+++ b/tests/Termina.Tests/Layout/ContentSwitchDeactivationTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Layout;
+using Termina.Rendering;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Regression tests for issue #70. A container must deactivate — not dispose — its old content on a content
+/// switch, and dispose content only at teardown. Destroying a node on a switch stops it rendering or handling
+/// input and risks ObjectDisposedException for in-flight R3 subscriptions. These pin the intended lifecycle
+/// for <see cref="PanelNode"/> and <see cref="ScrollableContainerNode"/>.
+/// </summary>
+public sealed class ContentSwitchDeactivationTests
+{
+    /// <summary>A layout node that records how many times it is deactivated and whether it is disposed.</summary>
+    private sealed class LifecycleSpy : LayoutNode
+    {
+        public int DeactivateCount { get; private set; }
+        public bool IsDisposed { get; private set; }
+
+        public override Size Measure(Size available) => new Size(0, 0);
+        public override void Render(IRenderContext context, Rect bounds) { }
+        public override void OnDeactivate() { DeactivateCount++; base.OnDeactivate(); }
+        public override void Dispose() { IsDisposed = true; base.Dispose(); }
+    }
+
+    [Fact]
+    public void PanelNode_WithContent_DeactivatesOldContent_DoesNotDispose()
+    {
+        var panel = new PanelNode();
+        var first = new LifecycleSpy();
+        var second = new LifecycleSpy();
+
+        panel.WithContent(first);
+        panel.WithContent(second);
+
+        // Swapping content must deactivate the old content, not destroy it.
+        Assert.Equal(1, first.DeactivateCount);
+        Assert.False(first.IsDisposed);
+
+        // Teardown disposes the current content.
+        panel.Dispose();
+        Assert.True(second.IsDisposed);
+    }
+
+    [Fact]
+    public void ScrollableContainerNode_WithContent_DeactivatesOldContent_DoesNotDispose()
+    {
+        var scroll = new ScrollableContainerNode();
+        var first = new LifecycleSpy();
+        var second = new LifecycleSpy();
+
+        scroll.WithContent(first);
+        scroll.WithContent(second);
+
+        Assert.Equal(1, first.DeactivateCount);
+        Assert.False(first.IsDisposed);
+
+        scroll.Dispose();
+        Assert.True(second.IsDisposed);
+    }
+}


### PR DESCRIPTION
## Summary

Make the Termina framework subject to its own analyzers, and fix the two lifecycle bugs that surfaced. Closes #344.

## Framework fixes (tests-first)

`PanelNode` and `ScrollableContainerNode` disposed the old, caller-provided content when `WithContent` swapped it, then disposed the current content again in `Dispose()`. That is the #70 pattern — destroying a node on a switch stops it rendering/handling input and risks `ObjectDisposedException` for in-flight R3 subscriptions. Both now **deactivate** the old content on a switch (`IActivatableNode.OnDeactivate()`) and dispose only at teardown.

`ContentSwitchDeactivationTests` was written **test-first**: it fails against the old dispose-on-switch code and passes after the change. It pins the intended lifecycle (swap deactivates, does not dispose; teardown disposes current).

## Self-analysis + consumer delivery

`src/Termina` now references `Termina.Generators` as an analyzer (`OutputItemType="Analyzer"`), so TERMINA002/003/004 and the source generator run on the framework itself. The generator DLL is bundled into Termina's own package under `analyzers/dotnet/cs`, so **NuGet consumers now receive the analyzers directly** — previously they did not (the transitive dependency excluded Analyzers assets by default).

## Scope / skepticism

These dispose-on-switch branches were effectively dead code today (all in-repo usage is one-time-builder), so these were latent footguns rather than live bugs. The change aligns the nodes with the framework's own model (`ReactiveLayoutNode` deactivates on switch; the analyzer's own message says to). Verified per-node before changing anything.

## Deliberately out of scope → #345

`GridNode.SetCell` has the same dispose-on-switch pattern, but its `Dispose()` is currently the only thing quieting a stale per-cell subscription (`_cellSubscriptions` is a flat list that only grows). A naive deactivate there would turn a masked leak into a live bug, so it needs a per-cell-subscription refactor. It is also not flagged by the analyzer (local-alias blind spot), so it does not block this wiring. Tracked in #345 as a separate test-backed change.

## Verification

- Self-analysis proven: a reintroduced TERMINA003 violation fails the `src/Termina` build.
- Consumer delivery proven: the packed Termina package contains `analyzers/dotnet/cs/Termina.Generators.dll`.
- Full solution builds with 0 warnings (self-analysis on). All 1586 tests pass.