### PR TITLE
fix: GridNode per-cell subscription tracking + deactivate on swap

### DIFF
--- a/src/Termina/Layout/GridNode.cs
+++ b/src/Termina/Layout/GridNode.cs
@@ -51,7 +51,9 @@ public sealed class GridNode : LayoutNode, IFocusable, IInvalidatingNode
     private readonly Subject<Unit> _invalidated = new();
     private readonly Subject<(int Row, int Col)> _focusedCellChanged = new();
     private readonly Subject<(int Row, int Col, ILayoutNode? Cell)> _cellActivated = new();
-    private readonly List<IDisposable> _cellSubscriptions = new();
+    // Invalidation subscription per content node, so a cell swap can dispose exactly the displaced
+    // node's subscription. Keyed by content because the subscription belongs to the node, not the cell.
+    private readonly Dictionary<ILayoutNode, IDisposable> _cellSubscriptions = new();
 
     private ILayoutNode?[,] _cells;
     private (int ColSpan, int RowSpan)[,] _spans;
@@ -106,8 +108,8 @@ public sealed class GridNode : LayoutNode, IFocusable, IInvalidatingNode
     /// <inheritdoc />
     internal override void DisconnectChildInvalidationSubscriptions()
     {
-        foreach (var sub in _cellSubscriptions)
-            sub.Dispose();
+        foreach (var subscription in _cellSubscriptions.Values)
+            subscription.Dispose();
 
         _cellSubscriptions.Clear();
     }
@@ -270,35 +272,31 @@ public sealed class GridNode : LayoutNode, IFocusable, IInvalidatingNode
         EnsureRows(row + rowSpan);
         EnsureColumns(col + colSpan);
 
-        // Dispose old content subscription if exists
-        var oldContent = _cells[row, col];
-        if (oldContent != null)
-        {
-            // Find and remove subscription - simplified approach
-            oldContent.Dispose();
-        }
+        // Remove whatever is currently in the target cell: deactivate its content (do not dispose — a
+        // swapped-out node may be reused) and dispose that cell's own invalidation subscription.
+        DisplaceCell(row, col);
 
         _cells[row, col] = content;
         _spans[row, col] = (colSpan, rowSpan);
 
-        // Mark spanned cells as occupied (null content, 0 span indicates part of another cell)
+        // Mark spanned cells as occupied (null content, 0 span indicates part of another cell).
         for (var r = row; r < row + rowSpan; r++)
         {
             for (var c = col; c < col + colSpan; c++)
             {
                 if (r != row || c != col)
                 {
-                    _cells[r, c] = null;
+                    DisplaceCell(r, c);
                     _spans[r, c] = (0, 0); // 0,0 indicates this is part of a span
                 }
             }
         }
 
-        // Subscribe to content invalidation
+        // Subscribe to the new content's invalidation, tracked by content so a later swap can remove it.
         if (content is IInvalidatingNode invalidating)
         {
-            var sub = invalidating.Invalidated.Subscribe(_ => _invalidated.OnNext(Unit.Default));
-            _cellSubscriptions.Add(sub);
+            _cellSubscriptions[content] =
+                invalidating.Invalidated.Subscribe(_ => _invalidated.OnNext(Unit.Default));
         }
 
         return this;
@@ -340,6 +338,26 @@ public sealed class GridNode : LayoutNode, IFocusable, IInvalidatingNode
     }
 
     #endregion
+
+    /// <summary>
+    /// Removes the content currently occupying a cell: disposes that cell's invalidation subscription and
+    /// deactivates the content (active/inactive pattern), then clears the cell. The content is not disposed
+    /// here — a swapped-out node may still be reused; disposal happens only in <see cref="Dispose"/>.
+    /// </summary>
+    private void DisplaceCell(int row, int col)
+    {
+        var content = _cells[row, col];
+        if (content is null)
+            return;
+
+        if (_cellSubscriptions.Remove(content, out var subscription))
+            subscription.Dispose();
+
+        if (content is IActivatableNode activatable)
+            activatable.OnDeactivate();
+
+        _cells[row, col] = null;
+    }
 
     #region Grid Resizing
 
@@ -916,8 +934,8 @@ public sealed class GridNode : LayoutNode, IFocusable, IInvalidatingNode
         if (_disposed) return;
         _disposed = true;
 
-        foreach (var sub in _cellSubscriptions)
-            sub.Dispose();
+        foreach (var subscription in _cellSubscriptions.Values)
+            subscription.Dispose();
         _cellSubscriptions.Clear();
 
         _invalidated.OnCompleted();

--- a/tests/Termina.Tests/Layout/GridNodeCellSwitchTests.cs
+++ b/tests/Termina.Tests/Layout/GridNodeCellSwitchTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using R3;
+using Termina.Layout;
+using Termina.Rendering;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Regression tests for <see cref="GridNode.SetCell"/> content switching (see #345 / #70).
+///
+/// Re-setting a cell must deactivate the old content (not dispose it), and must tear down that cell's
+/// invalidation subscription so a swapped-out cell no longer bumps the grid — without leaking or growing
+/// subscriptions. Content is disposed only at teardown. The per-cell subscription array must also survive a
+/// grid resize.
+/// </summary>
+public sealed class GridNodeCellSwitchTests
+{
+    /// <summary>A layout node that records deactivation/disposal and can raise invalidations on demand.</summary>
+    private sealed class InvalidatingSpy : LayoutNode, IInvalidatingNode
+    {
+        private readonly Subject<Unit> _invalidated = new();
+
+        public Observable<Unit> Invalidated => _invalidated;
+        public int DeactivateCount { get; private set; }
+        public bool IsDisposed { get; private set; }
+
+        public void RaiseInvalidated() => _invalidated.OnNext(Unit.Default);
+
+        public override Size Measure(Size available) => new Size(0, 0);
+        public override void Render(IRenderContext context, Rect bounds) { }
+        public override void OnDeactivate() { DeactivateCount++; base.OnDeactivate(); }
+
+        public override void Dispose()
+        {
+            IsDisposed = true;
+            _invalidated.OnCompleted();
+            _invalidated.Dispose();
+            base.Dispose();
+        }
+    }
+
+    [Fact]
+    public void SetCell_ReplacingContent_DeactivatesOldContent_DoesNotDispose()
+    {
+        var grid = new GridNode(1, 1);
+        var first = new InvalidatingSpy();
+        var second = new InvalidatingSpy();
+
+        grid.SetCell(0, 0, first);
+        grid.SetCell(0, 0, second);
+
+        // Swapping a cell must deactivate the old content, not destroy it.
+        Assert.Equal(1, first.DeactivateCount);
+        Assert.False(first.IsDisposed);
+
+        // Teardown disposes the current cell content.
+        grid.Dispose();
+        Assert.True(second.IsDisposed);
+    }
+
+    [Fact]
+    public void SetCell_ReplacingContent_TearsDownOldCellSubscription()
+    {
+        var grid = new GridNode(1, 1);
+        var first = new InvalidatingSpy();
+        var second = new InvalidatingSpy();
+
+        grid.SetCell(0, 0, first);
+        grid.SetCell(0, 0, second);
+
+        var gridInvalidations = 0;
+        using var _ = grid.Invalidated.Subscribe(__ => gridInvalidations++);
+
+        // The old, swapped-out cell survives (deactivated, not disposed)...
+        Assert.False(first.IsDisposed);
+
+        // ...but its invalidation subscription is gone, so it no longer bumps the grid.
+        first.RaiseInvalidated();
+        Assert.Equal(0, gridInvalidations);
+
+        // The current cell still forwards its invalidations.
+        second.RaiseInvalidated();
+        Assert.Equal(1, gridInvalidations);
+    }
+
+    [Fact]
+    public void SetCell_TriggeringResize_PreservesExistingCellSubscription()
+    {
+        var grid = new GridNode(1, 1);
+        var existing = new InvalidatingSpy();
+
+        grid.SetCell(0, 0, existing);
+        // Setting a far cell grows the grid; the existing cell's subscription must survive the resize.
+        grid.SetCell(2, 2, new InvalidatingSpy());
+
+        var gridInvalidations = 0;
+        using var _ = grid.Invalidated.Subscribe(__ => gridInvalidations++);
+
+        existing.RaiseInvalidated();
+        Assert.Equal(1, gridInvalidations);
+    }
+}


### PR DESCRIPTION
## Summary

Fix the two coupled bugs in `GridNode.SetCell` found while wiring self-analysis (#345). Closes #345.

## The bugs

- **Subscription leak.** `_cellSubscriptions` was a flat `List<IDisposable>` that `SetCell` only ever **appended** to — it never removed the swapped-out cell's subscription. Re-setting a cell grew the list unbounded and left the old cell's `Invalidated -> _invalidated` forwarding live. The inline comment even called it a "simplified approach."
- **Dispose-on-switch (#70).** `SetCell` disposed the old cell content on a swap, which was the *only* thing quieting that stale subscription. So a naive deactivate would have turned a masked leak into a live bug.

## The fix

- Replace the flat list with a **`Dictionary<ILayoutNode, IDisposable>` keyed by content**. A subscription belongs to its node, not to a grid position, so this needs **no resize plumbing** — it keeps the original design's simplicity (no per-dimension bookkeeping) and just adds the one thing it was missing: removing a single entry on displacement.
- New `DisplaceCell(row, col)` helper: remove and dispose *that node's* subscription, and **deactivate** (not dispose) the old content. Content is disposed only at teardown, in `Dispose()`. Spanned-over cells are displaced the same way (previously their content/subscriptions were dropped without cleanup).

## Tests (written test-first)

`GridNodeCellSwitchTests` — red before the fix, green after:
- A re-set cell is **deactivated, not disposed**.
- The swapped-out cell's invalidation **no longer bumps the grid** (subscription torn down), and the old content survives.
- An existing cell's subscription **survives a grid resize**.

## Verification
- `GridNode` tests: 38 pass. Full suite: 1589 pass.
- Full solution builds clean with **self-analysis on** — the refactor no longer disposes cell content on a switch, so it stays within TERMINA003.