### PR TITLE
fix: guard DynamicLayoutNode/KeyedDynamicLayoutNode against re-entrant Invalidate

### DIFF
--- a/src/Termina/Layout/DynamicLayoutNode.cs
+++ b/src/Termina/Layout/DynamicLayoutNode.cs
@@ -23,6 +23,11 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
     private ILayoutNode _currentChild;
     private bool _isActive;
     private bool _needsEvaluation = true;
+    private bool _isEvaluating;
+    private bool _reevaluationRequested;
+
+    // Bounds the settle loop when a factory invalidates its own node on every pass (never converges).
+    internal const int MaxReevaluationPasses = 8;
 
     /// <inheritdoc />
     public Observable<Unit> Invalidated => _invalidated;
@@ -45,19 +50,68 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
     public void Invalidate()
     {
         _needsEvaluation = true;
+
+        // A re-entrant call from inside the factory: request another pass of the current settle loop
+        // instead of recursing, and do not notify the parent mid-evaluation.
+        if (_isEvaluating)
+        {
+            _reevaluationRequested = true;
+            return;
+        }
+
         EvaluateFactory();
         _invalidated.OnNext(Unit.Default);
     }
 
     /// <summary>
     /// Evaluate the factory and update the child if it changed (by reference).
-    /// No-op when clean (not invalidated).
+    /// No-op when clean (not invalidated). Re-runs the factory until it stops requesting re-evaluation
+    /// (convergence), bounded by <see cref="MaxReevaluationPasses"/>, so a factory that invalidates its
+    /// own node self-heals instead of blanking the content or recursing without end (#159).
     /// </summary>
     private void EvaluateFactory()
     {
         if (!_needsEvaluation)
             return;
 
+        // Re-entrant evaluation (the factory invalidated during a Measure/Render pass): defer, do not recurse.
+        if (_isEvaluating)
+        {
+            _reevaluationRequested = true;
+            return;
+        }
+
+        _isEvaluating = true;
+        try
+        {
+            var passes = 0;
+            do
+            {
+                _reevaluationRequested = false;
+                EvaluateFactoryOnce();
+            }
+            while (_reevaluationRequested && ++passes < MaxReevaluationPasses);
+
+            if (_reevaluationRequested)
+            {
+                // The factory invalidated its own node on every pass and never converged. Keep the last
+                // child rather than hang, and surface the mistake in debug builds.
+                System.Diagnostics.Debug.WriteLine(
+                    $"DynamicLayoutNode factory did not converge after {MaxReevaluationPasses} passes; " +
+                    "it invalidates its own node on every evaluation. Move the side effect out of the factory.");
+            }
+        }
+        finally
+        {
+            _isEvaluating = false;
+        }
+    }
+
+    /// <summary>
+    /// Evaluate the factory once and swap the child if it changed (by reference).
+    /// </summary>
+    private void EvaluateFactoryOnce()
+    {
         _needsEvaluation = false;
         var newChild = _factory();
 

--- a/src/Termina/Layout/KeyedDynamicLayoutNode.cs
+++ b/src/Termina/Layout/KeyedDynamicLayoutNode.cs
@@ -28,6 +28,12 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     private TKey? _currentKey;
     private bool _isActive;
     private bool _needsEvaluation = true;
+    private bool _isEvaluating;
+    private bool _reevaluationRequested;
+
+    // Bounds the settle loop when the key selector or content factory invalidates its own node on every
+    // pass (never converges).
+    internal const int MaxReevaluationPasses = 8;
 
     /// <inheritdoc />
     public Observable<Unit> Invalidated => _invalidated;
@@ -52,19 +58,69 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     public void Invalidate()
     {
         _needsEvaluation = true;
+
+        // A re-entrant call from inside the key selector or content factory: request another pass of the
+        // current settle loop instead of recursing, and do not notify the parent mid-evaluation.
+        if (_isEvaluating)
+        {
+            _reevaluationRequested = true;
+            return;
+        }
+
         EvaluateFactory();
         _invalidated.OnNext(Unit.Default);
     }
 
     /// <summary>
     /// Evaluate the key selector, look up or create content, and swap child if changed.
-    /// No-op when clean (not invalidated).
+    /// No-op when clean (not invalidated). Re-runs until the selector/factory stops requesting
+    /// re-evaluation (convergence), bounded by <see cref="MaxReevaluationPasses"/>, so a selector or
+    /// factory that invalidates its own node self-heals instead of recursing without end (#159).
     /// </summary>
     private void EvaluateFactory()
     {
         if (!_needsEvaluation)
             return;
 
+        // Re-entrant evaluation (invalidated during a Measure/Render pass): defer, do not recurse.
+        if (_isEvaluating)
+        {
+            _reevaluationRequested = true;
+            return;
+        }
+
+        _isEvaluating = true;
+        try
+        {
+            var passes = 0;
+            do
+            {
+                _reevaluationRequested = false;
+                EvaluateFactoryOnce();
+            }
+            while (_reevaluationRequested && ++passes < MaxReevaluationPasses);
+
+            if (_reevaluationRequested)
+            {
+                // The selector/factory invalidated its own node on every pass and never converged. Keep the
+                // last child rather than hang, and surface the mistake in debug builds.
+                System.Diagnostics.Debug.WriteLine(
+                    $"KeyedDynamicLayoutNode did not converge after {MaxReevaluationPasses} passes; the key " +
+                    "selector or content factory invalidates its own node on every evaluation. Move the side " +
+                    "effect out of the selector/factory.");
+            }
+        }
+        finally
+        {
+            _isEvaluating = false;
+        }
+    }
+
+    /// <summary>
+    /// Evaluate the key selector once, look up or create content, and swap the child if it changed.
+    /// </summary>
+    private void EvaluateFactoryOnce()
+    {
         _needsEvaluation = false;
         var key = _keySelector();
 

--- a/tests/Termina.Tests/Layout/ReentrantInvalidateTests.cs
+++ b/tests/Termina.Tests/Layout/ReentrantInvalidateTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Layout;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Tests for the re-entrant Invalidate() guard on DynamicLayoutNode and KeyedDynamicLayoutNode (#159).
+///
+/// A factory that invalidates its own node during evaluation used to blank the content (DynamicLayoutNode)
+/// or recurse without end (StackOverflow). The guard defers the re-run: it re-evaluates once the current
+/// evaluation finishes, and repeats until the factory stops asking (convergence). A factory that never
+/// converges is bounded by a fixed cap. The guard flag resets in a finally block, so a throwing factory
+/// does not freeze the node.
+/// </summary>
+public sealed class ReentrantInvalidateTests
+{
+    // ---- DynamicLayoutNode -----------------------------------------------------------------------------
+
+    [Fact]
+    public void DynamicLayoutNode_Invalidate_ReEvaluatesFactoryEachCall()
+    {
+        var a = new TextNode("a");
+        var b = new TextNode("b");
+        var calls = 0;
+        var node = new DynamicLayoutNode(() => ++calls == 1 ? a : b);
+
+        node.Invalidate();
+        Assert.Same(a, node.GetChildNodes().First());
+
+        node.Invalidate();
+        Assert.Same(b, node.GetChildNodes().First());
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_ReentrantInvalidate_ConvergesToFinalContent()
+    {
+        DynamicLayoutNode node = null!;
+        var calls = 0;
+        var transient = new TextNode("transient");
+        var settled = new TextNode("settled");
+
+        node = new DynamicLayoutNode(() =>
+        {
+            calls++;
+            if (calls == 1)
+            {
+                // Simulate an auto-advance side effect that invalidates this same node mid-evaluation.
+                node.Invalidate();
+                return transient;
+            }
+
+            return settled;
+        });
+
+        node.Invalidate();
+
+        // The node must settle on the final content, not the transient value produced during re-entrancy.
+        Assert.Same(settled, node.GetChildNodes().First());
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_FactoryThrows_GuardResets()
+    {
+        DynamicLayoutNode node = null!;
+        var shouldThrow = true;
+        var recovered = new TextNode("recovered");
+
+        node = new DynamicLayoutNode(() =>
+        {
+            if (shouldThrow)
+                throw new InvalidOperationException("boom");
+            return recovered;
+        });
+
+        Assert.Throws<InvalidOperationException>(() => node.Invalidate());
+
+        // The guard must have reset in a finally block; a later evaluation must still work.
+        shouldThrow = false;
+        node.Invalidate();
+        Assert.Same(recovered, node.GetChildNodes().First());
+    }
+
+    [Fact]
+    public void DynamicLayoutNode_ReentrantInvalidate_EveryPass_StopsAtCap()
+    {
+        DynamicLayoutNode node = null!;
+        var calls = 0;
+
+        node = new DynamicLayoutNode(() =>
+        {
+            calls++;
+            node.Invalidate(); // never converges — asks to re-run on every pass
+            return new TextNode("pass" + calls);
+        });
+
+        node.Invalidate();
+
+        // Bounded: no StackOverflow, no hang. The factory runs at most the cap number of times.
+        Assert.Equal(DynamicLayoutNode.MaxReevaluationPasses, calls);
+    }
+
+    // ---- KeyedDynamicLayoutNode ------------------------------------------------------------------------
+
+    [Fact]
+    public void KeyedDynamicLayoutNode_Invalidate_ReEvaluatesOnKeyChange()
+    {
+        var key = 0;
+        var created = new Dictionary<int, ILayoutNode>();
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => key,
+            k => created[k] = new TextNode("k" + k));
+
+        node.Invalidate();
+        Assert.Same(created[0], node.GetChildNodes().First());
+
+        key = 1;
+        node.Invalidate();
+        Assert.Same(created[1], node.GetChildNodes().First());
+    }
+
+    [Fact]
+    public void KeyedDynamicLayoutNode_ReentrantInvalidate_ConvergesToFinalKey()
+    {
+        KeyedDynamicLayoutNode<int> node = null!;
+        var key = 0;
+        var keyCalls = 0;
+        var created = new Dictionary<int, ILayoutNode>();
+
+        node = new KeyedDynamicLayoutNode<int>(
+            () =>
+            {
+                keyCalls++;
+                if (keyCalls == 1)
+                {
+                    key = 1;
+                    node.Invalidate();
+                }
+
+                return key;
+            },
+            k => created[k] = new TextNode("k" + k));
+
+        node.Invalidate();
+
+        Assert.Same(created[1], node.GetChildNodes().First());
+    }
+
+    [Fact]
+    public void KeyedDynamicLayoutNode_KeySelectorThrows_GuardResets()
+    {
+        KeyedDynamicLayoutNode<int> node = null!;
+        var shouldThrow = true;
+        var recovered = new TextNode("recovered");
+
+        node = new KeyedDynamicLayoutNode<int>(
+            () => shouldThrow ? throw new InvalidOperationException("boom") : 5,
+            _ => recovered);
+
+        Assert.Throws<InvalidOperationException>(() => node.Invalidate());
+
+        shouldThrow = false;
+        node.Invalidate();
+        Assert.Same(recovered, node.GetChildNodes().First());
+    }
+
+    [Fact]
+    public void KeyedDynamicLayoutNode_ReentrantInvalidate_EveryPass_StopsAtCap()
+    {
+        KeyedDynamicLayoutNode<int> node = null!;
+        var keyCalls = 0;
+
+        node = new KeyedDynamicLayoutNode<int>(
+            () =>
+            {
+                keyCalls++;
+                node.Invalidate(); // never converges
+                return keyCalls;
+            },
+            k => new TextNode("k" + k));
+
+        node.Invalidate();
+
+        Assert.Equal(KeyedDynamicLayoutNode<int>.MaxReevaluationPasses, keyCalls);
+    }
+}


### PR DESCRIPTION
## Summary

Fix the re-entrant `Invalidate()` bug. Closes #159.

A factory that invalidated its own node during evaluation produced a **silent blank screen** (`DynamicLayoutNode`), or, in the non-converging case, recursed without end into a **`StackOverflow`**. Because `EvaluateFactory()` runs inside `Measure()`/`Render()`, the re-entrancy happens inside the render loop.

## The fix (defer + settle, on both node types)

- A re-entrant `Invalidate()` during evaluation sets a "run again" flag instead of recursing, and does not notify the parent mid-evaluation.
- `EvaluateFactory()` runs a **settle loop**: it re-evaluates until the factory stops asking to re-run (convergence), bounded by `MaxReevaluationPasses` (8).
- The guard flag resets in a **`finally`** block, so a throwing factory does not freeze the node.
- A factory that **never converges** keeps its last child (no hang, no `StackOverflow`) and logs in DEBUG builds.

For the #159 case the node settles after one extra pass and shows the **correct content** instead of a blank.

## What does not change

- **Correct code is unaffected.** Only a factory that invalidates its own node behaves differently — and its two current outcomes (blank / `StackOverflow`) become "renders correctly."
- **Normal invalidation** still evaluates eagerly, so the eager-evaluation-for-focus contract is preserved.

## Note on the two node types

`DynamicLayoutNode` showed the blank directly. `KeyedDynamicLayoutNode`'s cache already made the blank case less likely, so for it the guard mainly prevents the `StackOverflow` and keeps behavior consistent across the two.

## Tests (written test-first)

`ReentrantInvalidateTests`, for both node types:
- **Converge** (#159): the node settles on the final content, not the transient/blank value. (Red before the fix on `DynamicLayoutNode`.)
- **Normal re-evaluation**: unchanged.
- **`finally` reset**: a throwing factory does not freeze the node.
- **Never-converge cap**: the factory runs at most `MaxReevaluationPasses` times — no `StackOverflow`, no hang. (This case would crash the runner on the old code.)

## Verification
- 8 reentrancy tests pass. Full suite: 1597 pass.
- Full solution builds clean with self-analysis on.