### PR TITLE
fix(streaming): word-wrap separators inherit source whitespace style

### DIFF
--- a/docs/components/streaming-text-node.md
+++ b/docs/components/streaming-text-node.md
@@ -191,6 +191,17 @@ stream.Append(
 );
 ```
 
+Background highlights stay contiguous across a wrap. The space that joins two words on a wrapped line takes the style of the whitespace that separated them in the source. A highlighted phrase keeps its background across the whole phrase, and an unstyled gap between two highlighted words does not pick up a background.
+
+```csharp
+// The yellow highlight covers the whole phrase, including the spaces between words.
+stream.Append(
+    "Highlighted message that wraps",
+    foreground: Color.Black,
+    background: Color.Yellow
+);
+```
+
 ## Text Composition and Tracked Segments
 
 StreamingTextNode supports **tracked segments** - text elements that can be independently animated and later removed or replaced. This enables inline animations like spinners, progress bars, timers, and other dynamic content that appears alongside static text.

--- a/src/Termina/Components/Streaming/StyledWordWrapper.cs
+++ b/src/Termina/Components/Streaming/StyledWordWrapper.cs
@@ -28,6 +28,18 @@ namespace Termina.Components.Streaming;
 public static class StyledWordWrapper
 {
     /// <summary>
+    /// A word split out of a styled line, together with the style of the whitespace
+    /// that separated it from the previous word in the source line.
+    /// </summary>
+    /// <remarks>
+    /// The wrapper discards whitespace when it splits a line into words, then re-inserts a
+    /// single space between words that share an output line. That separator must carry the
+    /// style of the original whitespace, so a background highlight stays contiguous and an
+    /// unstyled gap between two styled words does not pick up a background color.
+    /// </remarks>
+    private readonly record struct StyledWord(StyledLine Line, TextStyle SeparatorStyle);
+
+    /// <summary>
     /// Wraps a styled line to fit within the specified width, preserving styling.
     /// </summary>
     /// <param name="line">The line to wrap.</param>
@@ -55,7 +67,7 @@ public static class StyledWordWrapper
 
         foreach (var word in words)
         {
-            var wordWidth = word.ColumnCount;
+            var wordWidth = word.Line.ColumnCount;
 
             // If word itself is longer than width, break it
             if (wordWidth > width)
@@ -69,7 +81,7 @@ public static class StyledWordWrapper
                 }
 
                 // Break long word into chunks while preserving styles
-                var remaining = word;
+                var remaining = word.Line;
                 while (remaining.ColumnCount > width)
                 {
                     var chunk = remaining.SliceByColumns(0, width);
@@ -90,7 +102,7 @@ public static class StyledWordWrapper
             else if (currentWidth == 0)
             {
                 // Start of line - add word directly
-                foreach (var segment in word.Segments)
+                foreach (var segment in word.Line.Segments)
                 {
                     currentLine.Append(segment);
                 }
@@ -98,27 +110,22 @@ public static class StyledWordWrapper
             }
             else if (currentWidth + 1 + wordWidth <= width)
             {
-                // Word fits with space separator. Only inherit background color if BOTH the preceding segment and incoming word segment share the exact same background color.
-                var prevStyle = currentLine.Segments.Count > 0 ? currentLine.Segments[^1].Style : TextStyle.Default;
-                var nextStyle = word.Segments.Count > 0 ? word.Segments[0].Style : TextStyle.Default;
-
-                var hasSameBg = prevStyle.HasBackground && nextStyle.HasBackground && prevStyle.Background.Equals(nextStyle.Background);
-                var spaceBg = hasSameBg ? nextStyle.Background : Color.Default;
-                var spaceStyle = new TextStyle(nextStyle.Foreground, spaceBg, nextStyle.Decoration);
-
-                currentLine.Append(new StyledSegment(" ", spaceStyle));
-                foreach (var segment in word.Segments)
+                // Word fits with a single-space separator. The separator carries the style of the
+                // whitespace that separated the two words in the source line, so a background
+                // highlight stays contiguous and an unstyled gap stays unstyled.
+                currentLine.Append(new StyledSegment(" ", word.SeparatorStyle));
+                foreach (var segment in word.Line.Segments)
                 {
                     currentLine.Append(segment);
                 }
-                currentWidth = currentLine.ColumnCount;
+                currentWidth += 1 + wordWidth;
             }
             else
             {
                 // Word doesn't fit, start new line
                 result.Add(currentLine);
                 currentLine = new StyledLine();
-                foreach (var segment in word.Segments)
+                foreach (var segment in word.Line.Segments)
                 {
                     currentLine.Append(segment);
                 }
@@ -176,12 +183,16 @@ public static class StyledWordWrapper
     /// <remarks>
     /// This handles the complex case where a word may span multiple segments with
     /// different styles. Each resulting "word" is a StyledLine that may contain
-    /// multiple segments.
+    /// multiple segments, together with the style of the whitespace that preceded it.
     /// </remarks>
-    private static List<StyledLine> SplitIntoStyledWords(StyledLine line)
+    private static List<StyledWord> SplitIntoStyledWords(StyledLine line)
     {
-        var words = new List<StyledLine>();
+        var words = new List<StyledWord>();
         var currentWord = new StyledLine();
+
+        // Style of the whitespace that precedes the word currently being built.
+        // The first word has no preceding whitespace, so its separator style is never used.
+        var separatorStyle = TextStyle.Default;
 
         foreach (var segment in line.Segments)
         {
@@ -203,10 +214,12 @@ public static class StyledWordWrapper
                     // If we have a word, add it to results
                     if (!currentWord.IsEmpty)
                     {
-                        words.Add(currentWord);
+                        words.Add(new StyledWord(currentWord, separatorStyle));
                         currentWord = new StyledLine();
                     }
 
+                    // The style of this whitespace separates the previous word from the next one.
+                    separatorStyle = segment.Style;
                     currentSegmentStart = i + 1;
                 }
             }
@@ -222,7 +235,7 @@ public static class StyledWordWrapper
         // Add final word if any
         if (!currentWord.IsEmpty)
         {
-            words.Add(currentWord);
+            words.Add(new StyledWord(currentWord, separatorStyle));
         }
 
         return words;

--- a/tests/Termina.Tests/Components/Streaming/StyledWordWrapperTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/StyledWordWrapperTests.cs
@@ -111,8 +111,11 @@ public class StyledWordWrapperTests
 
         var wrapped = StyledWordWrapper.WrapLine(line, 8);
 
-        // Should handle multiple spaces between words
-        Assert.True(wrapped.Count >= 2);
+        // The two words do not fit together at width 8, so they wrap onto separate lines and
+        // the whitespace is dropped at the break.
+        Assert.Equal(2, wrapped.Count);
+        Assert.Equal("Hello", wrapped[0].ToPlainText());
+        Assert.Equal("World", wrapped[1].ToPlainText());
     }
 
     [Fact]
@@ -192,6 +195,157 @@ public class StyledWordWrapperTests
         // Find the space segment between [YT] and [GIFT SUB]
         var spaceSegment = wrapped[0].Segments.First(s => s.Text == " ");
         Assert.NotEqual(Color.BrightGreen, spaceSegment.Style.Background);
+    }
+
+    // The separator inserted between two words on a wrapped line must carry the style of the
+    // whitespace that separated them in the SOURCE. These cases force a real wrap so the
+    // separator branch runs, unlike the two fast-path cases above.
+
+    [Fact]
+    public void WrapLine_ContiguousHighlight_ForcedWrap_SeparatorKeepsSourceBackground()
+    {
+        // Single magenta segment. The space between the two words is magenta in the source.
+        // Trailing "EXTRA" pushes the line past the width so the wrapper actually runs.
+        var line = new StyledLine();
+        var style = new TextStyle(Color.Black, Color.BrightMagenta, TextDecoration.Bold);
+        line.Append(new StyledSegment("[Highlighted Message] EXTRA", style));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 21);
+
+        Assert.Equal("[Highlighted Message]", wrapped[0].ToPlainText());
+        foreach (var segment in wrapped[0].Segments)
+            Assert.Equal(Color.BrightMagenta, segment.Style.Background);
+
+        // The separator shares the words' style, so the whole line coalesces into one segment.
+        Assert.Single(wrapped[0].Segments);
+    }
+
+    [Fact]
+    public void WrapLine_UnstyledSpaceBetweenBadges_ForcedWrap_SeparatorHasNoBackground()
+    {
+        // The space between [YT] and [GIFT is a default-styled segment in the source.
+        var line = new StyledLine();
+        line.Append(new StyledSegment("[YT]", new TextStyle(Color.Red)));
+        line.Append(new StyledSegment(" ", TextStyle.Default));
+        line.Append(new StyledSegment("[GIFT SUB] and more text", new TextStyle(Color.Black, Color.BrightGreen, TextDecoration.Bold)));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 10);
+
+        var spaceSegment = wrapped[0].Segments.First(s => s.Text == " ");
+        Assert.NotEqual(Color.BrightGreen, spaceSegment.Style.Background);
+    }
+
+    [Fact]
+    public void WrapLine_SameBackgroundButUnstyledSourceSpace_ForcedWrap_SeparatorStaysUnstyled()
+    {
+        // Two magenta words separated by a DEFAULT space in the source. A same-background
+        // heuristic would paint the separator magenta. The source space was unstyled, so the
+        // separator must stay unstyled.
+        var line = new StyledLine();
+        var magenta = new TextStyle(Color.White, Color.BrightMagenta);
+        line.Append(new StyledSegment("AAA", magenta));
+        line.Append(new StyledSegment(" ", TextStyle.Default));
+        line.Append(new StyledSegment("BBB", magenta));
+        line.Append(new StyledSegment(" CCC", magenta)); // extra word forces a wrap at width 8
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 8);
+
+        Assert.Equal("AAA BBB", wrapped[0].ToPlainText());
+        var spaceSegment = wrapped[0].Segments.First(s => s.Text == " ");
+        Assert.NotEqual(Color.BrightMagenta, spaceSegment.Style.Background);
+    }
+
+    [Fact]
+    public void WrapLine_DifferentBackgrounds_ForcedWrap_SeparatorHasNoBackground()
+    {
+        // Red-background word, a default source space, then a green-background word. The words
+        // stay on one line after a forced wrap. The separator must not bleed either background.
+        var line = new StyledLine();
+        line.Append(new StyledSegment("AAA", new TextStyle(Color.Default, Color.Red)));
+        line.Append(new StyledSegment(" ", TextStyle.Default));
+        line.Append(new StyledSegment("BBB CCC", new TextStyle(Color.Default, Color.BrightGreen)));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 8);
+
+        Assert.Equal("AAA BBB", wrapped[0].ToPlainText());
+        var spaceSegment = wrapped[0].Segments.First(s => s.Text == " ");
+        Assert.Equal(Color.Default, spaceSegment.Style.Background);
+    }
+
+    [Fact]
+    public void WrapLine_StyledSourceSpace_ForcedWrap_SeparatorMatchesSourceWhitespace()
+    {
+        // The source space between AA and BB carries a green background. The separator must
+        // reproduce that source style, not a default space.
+        var line = new StyledLine();
+        line.Append(new StyledSegment("AA", TextStyle.Default));
+        line.Append(new StyledSegment(" ", new TextStyle(Color.Default, Color.BrightGreen)));
+        line.Append(new StyledSegment("BB CC", TextStyle.Default));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 6);
+
+        Assert.Equal("AA BB", wrapped[0].ToPlainText());
+        var spaceSegment = wrapped[0].Segments.First(s => s.Text == " ");
+        Assert.Equal(Color.BrightGreen, spaceSegment.Style.Background);
+    }
+
+    [Fact]
+    public void WrapLine_WideCharacterWord_BreaksOnColumns_PreservesStyle()
+    {
+        // Each CJK glyph is two columns wide. A four-column width must break the word on
+        // display columns, not on char count, and keep the style on both halves.
+        var line = new StyledLine();
+        var style = new TextStyle(Color.Yellow, Color.Default, TextDecoration.Bold);
+        line.Append(new StyledSegment("你好世界", style));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 4);
+
+        Assert.Equal(2, wrapped.Count);
+        Assert.Equal("你好", wrapped[0].ToPlainText());
+        Assert.Equal("世界", wrapped[1].ToPlainText());
+        Assert.Equal(Color.Yellow, wrapped[0].Segments[0].Style.Foreground);
+        Assert.Equal(TextDecoration.Bold, wrapped[1].Segments[0].Style.Decoration);
+    }
+
+    // Characterization of CURRENT behavior. A future refactor that preserves whitespace runs
+    // and leading indentation would change these two cases, and should update them on purpose.
+
+    [Fact]
+    public void WrapLine_FastPath_PreservesMultipleSpacesVerbatim()
+    {
+        // When the whole line fits, it is cloned verbatim, so runs of spaces survive.
+        var line = new StyledLine();
+        line.Append(new StyledSegment("Hi     There", new TextStyle(Color.Red)));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 20);
+
+        Assert.Single(wrapped);
+        Assert.Equal("Hi     There", wrapped[0].ToPlainText());
+    }
+
+    [Fact]
+    public void WrapLine_ForcedWrap_CollapsesInternalSpaceRunToSingleSeparator()
+    {
+        // When a wrap runs, a run of spaces between two words on one output line collapses to a
+        // single separator space.
+        var line = new StyledLine();
+        line.Append(new StyledSegment("AA    BB CCCCCCCC", new TextStyle(Color.Red)));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 6);
+
+        Assert.Equal("AA BB", wrapped[0].ToPlainText());
+    }
+
+    [Fact]
+    public void WrapLine_ForcedWrap_DropsLeadingIndentation()
+    {
+        // When a wrap runs, leading whitespace is dropped rather than kept as indentation.
+        var line = new StyledLine();
+        line.Append(new StyledSegment("    Hello World", new TextStyle(Color.Red)));
+
+        var wrapped = StyledWordWrapper.WrapLine(line, 6);
+
+        Assert.Equal("Hello", wrapped[0].ToPlainText());
     }
 
     private static StyledLine CreateLine(string text, Color color)


### PR DESCRIPTION
## Summary

This is a follow-up to #335. It fixes the word-wrap separator bug at its root and removes the heuristic that #335 added.

`StyledWordWrapper` splits a line into words and discards the whitespace between them. It then inserts a single space between words that share an output line. That separator used a default style, so a background highlight lost its color at the separator. #335 patched the symptom with a same-background heuristic, but that heuristic can also paint a separator whose source space was unstyled.

This change makes each word carry the style of the whitespace that preceded it in the source. The separator renders with that style, so it always matches the source.

## Behavior

- A highlighted phrase stays contiguous across a wrap.
- An unstyled gap between two highlighted words stays unstyled.
- A styled source space (for example, a highlighted gap) is reproduced faithfully.

The single-space behavior and all column math are unchanged, so line counts in `WindowedStreamBuffer` and `PersistedStreamBuffer` are not affected. The separator branch also drops an O(n) re-measure per word (`currentWidth += 1 + wordWidth` instead of re-summing `ColumnCount`).

## Why this supersedes the #335 heuristic

The heuristic guesses the separator style from the two adjacent words. The wrapper already had the true answer one step earlier, before it discarded the whitespace. This change keeps that answer instead of guessing. The test `WrapLine_SameBackgroundButUnstyledSourceSpace_ForcedWrap_SeparatorStaysUnstyled` covers a case where the heuristic paints an unstyled gap and this change does not.

## Tests

The wrapper test file goes from 13 to 22 tests.

- Separator style in several directions: contiguous highlight, unstyled gap, same-background-but-unstyled source space, different backgrounds, and a styled source space.
- Wide-character word break on display columns with style preserved.
- Characterization of current behavior that a later refactor would change on purpose: multiple-space collapse on wrap, leading-indentation drop on wrap, and fast-path whitespace preservation.
- The two fast-path tests from #335 are kept as fast-path guards.

Verification:

- Wrapper tests: 22 passed.
- Full suite: 1608 passed, 0 failed.
- Build: 0 warnings, 0 errors.

## Docs

Add a background note and example to the "Style Preservation in Word Wrap" section of the streaming text node docs.

## Out of scope

This is the lean fix. It keeps the existing single-space behavior. A larger follow-up could preserve whitespace runs and leading indentation. That needs a whitespace-trim policy decision and broader tests. The two characterization tests mark that behavior so the shift is visible when we do it.
