### PR TITLE
docs: document built-in back navigation APIs (#239)

### DIFF
--- a/docs/concepts/navigation.md
+++ b/docs/concepts/navigation.md
@@ -103,6 +103,117 @@ termina.RegisterRoute<DetailPage, DetailViewModel>(
   - `OnActivate()` resumes timers, animations, and subscriptions
 - Use for pages with expensive state, data caching, or complex UI state (e.g., form inputs, scroll positions)
 
+## Going Back
+
+Termina keeps a navigation history for you. Every forward navigation pushes the current page onto the stack, and the built-in back APIs pop it.
+
+### Navigation History
+
+When a page navigates to a different path, the current page is pushed onto the history stack:
+
+```csharp
+Navigate("/items/42");   // "/menu" is pushed onto history
+Navigate("/settings");   // "/items/42" is pushed onto history
+```
+
+History rules:
+
+- The concrete path is stored, so route parameters survive a back navigation.
+- Navigating to the same path does not push a new history entry.
+- Going back restores the previous route without re-pushing the current page, so a back navigation never creates a ping-pong loop between two pages.
+
+### Host-Driven Back Navigation
+
+The host owns the history. Call `TerminaApplication.GoBack()` to return to the previous route:
+
+```csharp
+if (termina.CanGoBack)
+{
+    termina.GoBack();
+}
+```
+
+- `CanGoBack` is `true` when the history stack has at least one entry.
+- `GoBack()` is a no-op when the history is empty. It does not throw and it does not shut the application down.
+- Call `GoBack()` from host code — event handlers, commands, or app-level key handling. Use this when a destination page can be reached from more than one caller, because the history stack always returns the user to the route they actually came from.
+
+### Page and ViewModel Patterns
+
+Pages handle back navigation through the key-binding capture phase. Key bindings registered in `OnNavigatedTo` are checked before focused components receive input, so Escape (or any key) can drive navigation even when a text input has focus:
+
+```csharp
+public override void OnNavigatedTo()
+{
+    base.OnNavigatedTo();
+
+    // Fixed caller route: navigate back explicitly
+    KeyBindings.Register(ConsoleKey.Escape, () => Navigate("/menu"));
+
+    // Multi-caller route: raise an event the host subscribes to
+    KeyBindings.Register(ConsoleKey.Escape, () => BackRequested?.Invoke());
+}
+
+// User-defined event, wired by host code to TerminaApplication.GoBack()
+public event Action? BackRequested;
+```
+
+Two patterns apply:
+
+1. **Fixed caller route** — when a page can only be reached from one place, register a key binding that calls `Navigate()` back to that route. This is the simplest pattern and needs no host wiring.
+2. **Multi-caller route** — when a page can be reached from several routes, do not hard-code a caller route. Raise an event or callback that host code handles by calling `TerminaApplication.GoBack()`, which returns the user to wherever they actually came from.
+
+ViewModels follow the same rules. Subscribe to `Input` for `KeyPressed` events, or expose navigation through commands that the host binds to `GoBack()`.
+
+### Nested State Consumes Escape First
+
+Components with their own internal state consume Escape before page-level navigation runs. The `WizardNode` is the reference example: Escape walks back through sub-steps and steps first, and only reports that it has nothing left to go back to when the wizard is at its first step:
+
+```csharp
+if (wizard.TryGoBack())
+{
+    // Escape was consumed by the wizard's internal state
+    return;
+}
+
+// Wizard is at its first step — page-level back navigation applies
+```
+
+Follow this pattern in your own components: consume the key locally until the nested state is exhausted, then let the page (or host) handle application-level back navigation.
+
+### NavigationBackRequested
+
+`Termina.Navigation.NavigationBackRequested` is the framework event that requests a history-based back navigation. The application event loop handles it by calling `GoBack()`:
+
+```csharp
+case NavigationBackRequested:
+    GoBack();
+    return;
+```
+
+The event is mainly useful for custom input sources that map a global key (for example Ctrl+B) to back navigation. An input source pushes events into the application channel, so it can emit `NavigationBackRequested` just like it emits `KeyPressed`:
+
+```csharp
+public sealed class BackKeyInputSource : IInputSource
+{
+    public async Task RunAsync(ChannelWriter<object> writer, CancellationToken cancellationToken)
+    {
+        // Read keys from the terminal; when Ctrl+B is pressed:
+        await writer.WriteAsync(new NavigationBackRequested(), cancellationToken);
+    }
+}
+```
+
+When no history exists, a `NavigationBackRequested` is ignored — the application does not shut down and no exception is raised. Prefer calling `GoBack()` directly from host code; reserve the event for input sources and integrations that push events into the application channel.
+
+### Back Navigation and PreserveState
+
+Going back to a page registered with `NavigationBehavior.PreserveState` reuses the cached page and ViewModel instances. The lifecycle methods still run:
+
+- `OnDeactivating()` runs on the page being left.
+- `OnActivated()` runs on the restored page when it becomes active again.
+
+State kept in `ReactiveProperty` fields survives the round trip, so a form partially filled in before navigating away is intact when the user comes back.
+
 ## Lifecycle Methods
 
 ### OnActivated

--- a/docs/concepts/navigation.md
+++ b/docs/concepts/navigation.md
@@ -105,7 +105,7 @@ termina.RegisterRoute<DetailPage, DetailViewModel>(
 
 ## Going Back
 
-Termina keeps a navigation history for you. Every forward navigation pushes the current page onto the stack, and the built-in back APIs pop it.
+Termina tracks navigation history automatically. A forward navigation pushes the current page onto the stack, and the back APIs pop it.
 
 ### Navigation History
 
@@ -119,8 +119,8 @@ Navigate("/settings");   // "/items/42" is pushed onto history
 History rules:
 
 - The concrete path is stored, so route parameters survive a back navigation.
-- Navigating to the same path does not push a new history entry.
-- Going back restores the previous route without re-pushing the current page, so a back navigation never creates a ping-pong loop between two pages.
+- Navigating to the same path does not push a new entry.
+- Going back restores the previous route without re-pushing the current page, so you never get a ping-pong loop between two pages.
 
 ### Host-Driven Back Navigation
 
@@ -135,11 +135,11 @@ if (termina.CanGoBack)
 
 - `CanGoBack` is `true` when the history stack has at least one entry.
 - `GoBack()` is a no-op when the history is empty. It does not throw and it does not shut the application down.
-- Call `GoBack()` from host code — event handlers, commands, or app-level key handling. Use this when a destination page can be reached from more than one caller, because the history stack always returns the user to the route they actually came from.
+- Call `GoBack()` from host code when a destination page can be reached from more than one caller. The history stack returns the user to the route they actually came from, so nothing gets hard-coded.
 
 ### Page and ViewModel Patterns
 
-Pages handle back navigation through the key-binding capture phase. Key bindings registered in `OnNavigatedTo` are checked before focused components receive input, so Escape (or any key) can drive navigation even when a text input has focus:
+Pages handle back navigation through the key-binding capture phase. Key bindings registered in `OnNavigatedTo` are checked before focused components receive input, so Escape can drive navigation even when a text input has focus:
 
 ```csharp
 public override void OnNavigatedTo()
@@ -159,14 +159,14 @@ public event Action? BackRequested;
 
 Two patterns apply:
 
-1. **Fixed caller route** — when a page can only be reached from one place, register a key binding that calls `Navigate()` back to that route. This is the simplest pattern and needs no host wiring.
-2. **Multi-caller route** — when a page can be reached from several routes, do not hard-code a caller route. Raise an event or callback that host code handles by calling `TerminaApplication.GoBack()`, which returns the user to wherever they actually came from.
+1. **Fixed caller route.** When a page can only be reached from one place, register a key binding that calls `Navigate()` back to that route. This is the simplest pattern and needs no host wiring.
+2. **Multi-caller route.** When a page can be reached from several routes, do not hard-code a caller route. Raise an event or callback that host code handles by calling `TerminaApplication.GoBack()`, which returns the user to wherever they actually came from.
 
-ViewModels follow the same rules. Subscribe to `Input` for `KeyPressed` events, or expose navigation through commands that the host binds to `GoBack()`.
+ViewModels can do the same. Subscribe to `Input` for `KeyPressed` events, and expose a callback or event that host code wires to `GoBack()`.
 
 ### Nested State Consumes Escape First
 
-Components with their own internal state consume Escape before page-level navigation runs. The `WizardNode` is the reference example: Escape walks back through sub-steps and steps first, and only reports that it has nothing left to go back to when the wizard is at its first step:
+Components with their own internal state consume Escape before page-level navigation runs. `WizardNode` is the reference example: Escape walks back through sub-steps and steps first, and `TryGoBack()` returns false when the wizard is already at its first step:
 
 ```csharp
 if (wizard.TryGoBack())
@@ -175,7 +175,7 @@ if (wizard.TryGoBack())
     return;
 }
 
-// Wizard is at its first step — page-level back navigation applies
+// Wizard is at its first step, so page-level back navigation applies
 ```
 
 Follow this pattern in your own components: consume the key locally until the nested state is exhausted, then let the page (or host) handle application-level back navigation.
@@ -203,7 +203,7 @@ public sealed class BackKeyInputSource : IInputSource
 }
 ```
 
-When no history exists, a `NavigationBackRequested` is ignored — the application does not shut down and no exception is raised. Prefer calling `GoBack()` directly from host code; reserve the event for input sources and integrations that push events into the application channel.
+When no history exists, a `NavigationBackRequested` is ignored. The application does not shut down and nothing throws. Prefer calling `GoBack()` directly from host code. Reserve the event for input sources and integrations that push events into the application channel.
 
 ### Back Navigation and PreserveState
 

--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -132,7 +132,7 @@ NavigateWithParams("/users/{name}", new { name = "alice" });
 
 ## Going Back
 
-Termina keeps a navigation history across route transitions. See [Navigation](/concepts/navigation.html#going-back) for `GoBack()`, `CanGoBack`, and `NavigationBackRequested`.
+Termina tracks navigation history across route transitions. See [Navigation](/concepts/navigation.html#going-back) for `GoBack()`, `CanGoBack`, and `NavigationBackRequested`.
 
 ## Route Source Code
 

--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -130,6 +130,10 @@ NavigateWithParams("/items/{id}", new { id = 42 });
 NavigateWithParams("/users/{name}", new { name = "alice" });
 ```
 
+## Going Back
+
+Termina keeps a navigation history across route transitions. See [Navigation](/concepts/navigation.html#going-back) for `GoBack()`, `CanGoBack`, and `NavigationBackRequested`.
+
 ## Route Source Code
 
 ::: details View RouteTemplate implementation


### PR DESCRIPTION
## What

Adds documentation for Termina's built-in back navigation APIs to [concepts/navigation](https://aaronstannard.com/termina/concepts/navigation.html), which previously only covered forward navigation and route registration.

## Changes

- **New "Going Back" section** in `docs/concepts/navigation.md`:
  - Navigation history semantics (what gets pushed, params preserved, no ping-pong loops)
  - Host-driven back navigation: `TerminaApplication.GoBack()` / `CanGoBack`, including no-op behavior when history is empty
  - Page/ViewModel patterns: fixed-caller `Navigate()` back vs. multi-caller callback wired to `GoBack()` — the exact guidance requested in the issue
  - Nested state consumes Escape first (WizardNode `TryGoBack()` pattern)
  - `NavigationBackRequested` event, its no-op-on-empty-history behavior, and when to use it (custom input sources)
  - Interaction with `NavigationBehavior.PreserveState` (cached VM/Page reuse, lifecycle methods still run)
- **Cross-reference** in `docs/concepts/routing.md`

## Notes

- Docs build passes (`vitepress build`)
- All API behavior verified against `src/Termina/TerminaApplication.cs` (GoBack/CanGoBack/event handling), `src/Termina/Reactive/ReactiveViewModel.cs` (Navigate/Shutdown wiring), and `src/Termina/Layout/WizardNode.cs` (TryGoBack)

Closes #239