### PR TITLE
fix(streaming): wide-character slice corruption in styled word wrap

### DIFF
--- a/src/Termina/Components/Streaming/StyledLine.cs
+++ b/src/Termina/Components/Streaming/StyledLine.cs
@@ -258,14 +258,29 @@ public sealed class StyledLine
             }
 
             var localStart = Math.Max(0, startColumn - currentColumn);
-            var localText = DisplayWidth.SliceByColumns(segment.Text, localStart, maxColumns - taken);
-            if (!string.IsNullOrEmpty(localText))
+            var remainingBudget = maxColumns - taken;
+
+            // Take the whole tail of this segment from localStart, then compare it to the budget.
+            // This tells us whether the budget ends inside this segment or the segment ends first.
+            var fullTail = DisplayWidth.SliceByColumns(segment.Text, localStart, int.MaxValue);
+            var fullTailColumns = DisplayWidth.GetColumnCount(fullTail);
+            var budgetEndsInsideSegment = fullTailColumns > remainingBudget;
+
+            var localText = budgetEndsInsideSegment
+                ? DisplayWidth.SliceByColumns(segment.Text, localStart, remainingBudget)
+                : fullTail;
+
+            if (localText.Length > 0)
             {
                 result.AppendInternal(new StyledSegment(localText, segment.Style));
                 taken += DisplayWidth.GetColumnCount(localText);
-                if (taken >= maxColumns)
-                    break;
             }
+
+            // Stop when the budget ends inside this segment. A wide glyph that straddles the budget
+            // boundary is skipped, so the slice is shorter than the budget. The slice must be a
+            // contiguous column range, so no later segment can join it.
+            if (budgetEndsInsideSegment || taken >= maxColumns)
+                break;
 
             currentColumn += segmentColumns;
         }

--- a/src/Termina/Components/Streaming/WordWrapper.cs
+++ b/src/Termina/Components/Streaming/WordWrapper.cs
@@ -90,7 +90,9 @@ public static class WordWrapper
             result.Add(currentLine.ToString());
         }
 
-        return result;
+        // A whitespace-only line that is wider than the width produces no words. Return one blank
+        // line so the result matches the empty-string case and the styled wrapper.
+        return result.Count > 0 ? result : [""];
     }
 
     /// <summary>

--- a/tests/Termina.Tests/Components/Streaming/StyledLineTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/StyledLineTests.cs
@@ -172,4 +172,32 @@ public class StyledLineTests
         Assert.Equal(11, line.Length);
         Assert.Equal(5, clone.Length);
     }
+
+    [Fact]
+    public void SliceByColumns_WideGlyphAtBudgetBoundary_DoesNotPullFromNextSegment()
+    {
+        // The first segment is "cc中" (c=1, c=1, 中=2 columns). A three-column slice can take
+        // "cc" only, because the wide glyph needs two columns and 2 + 2 > 3. The slice must stop
+        // there. It must NOT skip the rest of the first segment and take "e" from the next segment.
+        var line = new StyledLine();
+        line.Append(new StyledSegment("cc中", new TextStyle(Color.Red)));
+        line.Append(new StyledSegment("e", new TextStyle(Color.Blue)));
+
+        var slice = line.SliceByColumns(0, 3);
+
+        Assert.Equal("cc", slice.ToPlainText());
+    }
+
+    [Fact]
+    public void SliceByColumns_StartInsideMultiSegmentLine_KeepsColumnsContiguous()
+    {
+        // Skip the first two columns ("cc"), then take the rest across the segment boundary.
+        var line = new StyledLine();
+        line.Append(new StyledSegment("cc中", new TextStyle(Color.Red)));
+        line.Append(new StyledSegment("e", new TextStyle(Color.Blue)));
+
+        var slice = line.SliceByColumns(2, 100);
+
+        Assert.Equal("中e", slice.ToPlainText());
+    }
 }

--- a/tests/Termina.Tests/Components/Streaming/StyledWordWrapperInvariantTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/StyledWordWrapperInvariantTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Termina.Components.Streaming;
+using Termina.Terminal;
+
+namespace Termina.Tests.Components.Streaming;
+
+/// <summary>
+/// Invariant and oracle checks for <see cref="StyledWordWrapper"/>.
+/// </summary>
+/// <remarks>
+/// These checks run over many randomly generated inputs from fixed seeds, so failures are
+/// deterministic and reproducible. Each generated case must satisfy every property. A failure
+/// message prints the seed, the width, and the input, so you can reproduce the case exactly.
+/// This is a zero-dependency stand-in for a property-based testing library. It also acts as a
+/// differential oracle against the independent plain <see cref="WordWrapper"/>.
+/// </remarks>
+public class StyledWordWrapperInvariantTests
+{
+    private const int Iterations = 50000;
+
+    private static readonly Color[] Palette =
+    {
+        Color.Default, Color.Red, Color.Green, Color.Blue, Color.BrightMagenta, Color.BrightGreen,
+    };
+
+    private static readonly TextDecoration[] Decorations =
+    {
+        TextDecoration.None, TextDecoration.Bold, TextDecoration.Underline,
+    };
+
+    [Fact]
+    public void Invariants_HoldOverManyRandomInputs()
+    {
+        var counts = new Dictionary<string, int>();
+        var examples = new List<string>();
+
+        void Record(string property, string detail)
+        {
+            counts[property] = counts.GetValueOrDefault(property) + 1;
+            if (examples.Count < 12)
+                examples.Add($"[{property}] {detail}");
+        }
+
+        for (var seed = 0; seed < Iterations; seed++)
+        {
+            var rng = new Random(seed);
+            var line = GenerateLine(rng);
+            var width = rng.Next(2, 31); // width >= 2 keeps a 2-column glyph sliceable
+
+            List<StyledLine> wrapped;
+            try
+            {
+                wrapped = StyledWordWrapper.WrapLine(line, width);
+            }
+            catch (Exception ex)
+            {
+                Record("THROW", $"{ex.GetType().Name}: {ex.Message} | seed={seed} width={width} input={Describe(line)}");
+                continue;
+            }
+
+            var context = $"seed={seed} width={width} input={Describe(line)} wrapped={Describe(wrapped)}";
+
+            if (CheckContentAndStylePreserved(line, wrapped) is { } p1) Record("P1-content-style", $"{p1} | {context}");
+            if (CheckWidthBound(wrapped, width) is { } p2) Record("P2-width-bound", $"{p2} | {context}");
+            if (CheckMaximalPacking(line, wrapped, width) is { } p3) Record("P3-maximal-packing", $"{p3} | {context}");
+            if (CheckMatchesPlainOracle(line, wrapped, width) is { } d1) Record("D1-plain-oracle", $"{d1} | {context}");
+        }
+
+        if (counts.Count > 0)
+        {
+            var summary = string.Join(", ", counts.OrderBy(kv => kv.Key).Select(kv => $"{kv.Key}={kv.Value}"));
+            Assert.Fail($"Invariant/oracle failures over {Iterations} inputs.\nCounts: {summary}\n\n{string.Join("\n", examples)}");
+        }
+    }
+
+    // P1: no non-whitespace glyph is lost, added, reordered, or restyled.
+    private static string? CheckContentAndStylePreserved(StyledLine input, List<StyledLine> wrapped)
+    {
+        var expected = NonWhitespaceGlyphs(input.Segments);
+        var actual = NonWhitespaceGlyphs(wrapped.SelectMany(l => l.Segments));
+        return expected.SequenceEqual(actual)
+            ? null
+            : $"content/style changed: expected {expected.Count} glyphs, got {actual.Count}";
+    }
+
+    // P2: every output line fits within the width.
+    private static string? CheckWidthBound(List<StyledLine> wrapped, int width)
+    {
+        foreach (var l in wrapped)
+            if (l.ColumnCount > width)
+                return $"line width {l.ColumnCount} exceeds {width}";
+        return null;
+    }
+
+    // P3: greedy packing is maximal. When no source word is wider than the width, the first word
+    // of a line must not fit at the end of the previous line.
+    private static string? CheckMaximalPacking(StyledLine input, List<StyledLine> wrapped, int width)
+    {
+        var words = input.ToPlainText().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0) return null;
+        if (words.Max(w => DisplayWidth.GetColumnCount(w)) > width) return null; // long-word breaking is exempt
+
+        for (var i = 0; i + 1 < wrapped.Count; i++)
+        {
+            var prevWidth = wrapped[i].ColumnCount;
+            var nextFirst = wrapped[i + 1].ToPlainText().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (nextFirst is null) continue;
+            var nextFirstWidth = DisplayWidth.GetColumnCount(nextFirst);
+            if (prevWidth + 1 + nextFirstWidth <= width)
+                return $"line {i} (width {prevWidth}) could still take next word (width {nextFirstWidth})";
+        }
+        return null;
+    }
+
+    // D1: the styled wrapper must agree with the independent plain-string wrapper on where breaks land.
+    private static string? CheckMatchesPlainOracle(StyledLine input, List<StyledLine> wrapped, int width)
+    {
+        var styled = wrapped.Select(l => l.ToPlainText()).ToList();
+        var plain = WordWrapper.WrapLine(input.ToPlainText(), width);
+        return styled.SequenceEqual(plain)
+            ? null
+            : $"oracle mismatch: styled={FormatLines(styled)} plain={FormatLines(plain)}";
+    }
+
+    private static List<(char Ch, TextStyle Style)> NonWhitespaceGlyphs(IEnumerable<StyledSegment> segments)
+    {
+        var result = new List<(char, TextStyle)>();
+        foreach (var seg in segments)
+            foreach (var c in seg.Text)
+                if (!char.IsWhiteSpace(c))
+                    result.Add((c, seg.Style));
+        return result;
+    }
+
+    private static StyledLine GenerateLine(Random rng)
+    {
+        var line = new StyledLine();
+        var segmentCount = rng.Next(0, 6);
+        for (var s = 0; s < segmentCount; s++)
+        {
+            var text = GenerateText(rng);
+            if (text.Length == 0) continue;
+            var style = new TextStyle(Pick(rng, Palette), Pick(rng, Palette), Pick(rng, Decorations));
+            line.Append(new StyledSegment(text, style));
+        }
+        return line;
+    }
+
+    private static string GenerateText(Random rng)
+    {
+        var len = rng.Next(0, 9);
+        var sb = new System.Text.StringBuilder(len);
+        for (var i = 0; i < len; i++)
+        {
+            var r = rng.Next(0, 100);
+            if (r < 55) sb.Append((char)('a' + rng.Next(0, 5)));       // letters a-e
+            else if (r < 85) sb.Append(' ');                           // spaces: word boundaries and runs
+            else sb.Append(rng.Next(0, 2) == 0 ? '中' : '文'); // wide (2-column) BMP glyphs
+        }
+        return sb.ToString();
+    }
+
+    private static T Pick<T>(Random rng, T[] items) => items[rng.Next(0, items.Length)];
+
+    private static string Describe(StyledLine line) =>
+        "[" + string.Join(", ", line.Segments.Select(s => $"\"{s.Text}\"({s.Style.Foreground}/{s.Style.Background}/{s.Style.Decoration})")) + "]";
+
+    private static string Describe(List<StyledLine> lines) => FormatLines(lines.Select(l => l.ToPlainText()));
+
+    private static string FormatLines(IEnumerable<string> lines) => "«" + string.Join("│", lines) + "»";
+}

--- a/tests/Termina.Tests/Components/Streaming/WordWrapperTests.cs
+++ b/tests/Termina.Tests/Components/Streaming/WordWrapperTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Termina.Components.Streaming;
+
+namespace Termina.Tests.Components.Streaming;
+
+/// <summary>
+/// Tests for the plain <see cref="WordWrapper"/>.
+/// </summary>
+public class WordWrapperTests
+{
+    [Fact]
+    public void WrapLine_WhitespaceOnlyLineWiderThanWidth_ReturnsOneBlankLine()
+    {
+        // A whitespace-only line that is wider than the width produces no words. The wrapper must
+        // still return one blank line, the same as it does for an empty string.
+        var wrapped = WordWrapper.WrapLine("   ", 2);
+
+        Assert.Single(wrapped);
+        Assert.Equal("", wrapped[0]);
+    }
+
+    [Fact]
+    public void WrapLine_EmptyString_ReturnsOneBlankLine()
+    {
+        var wrapped = WordWrapper.WrapLine("", 2);
+
+        Assert.Single(wrapped);
+        Assert.Equal("", wrapped[0]);
+    }
+}


### PR DESCRIPTION
## Summary

This fixes a pre-existing content-corruption bug in styled word wrapping, and adds the invariant/oracle test that found it. It is independent of #349.

## The bug

`StyledLine.SliceByColumns` did not stop when the column budget ended **inside** a segment. A wide (2-column) glyph that straddled the budget boundary made the slice shorter than the budget, so the loop fell through to later segments and appended their glyphs. The slice became non-contiguous.

`StyledWordWrapper` is the only caller. Its long-word break loop slices a word by columns, so a **multi-segment word that contained wide characters lost and reordered glyphs when it wrapped**. Example at width 3: the run `文中中中edbb中b中` should break to `文│中│中│中e│dbb│中b│中`, but it produced `文b│中b│edb│…` — wrong glyphs, wrong order.

## The fix

`SliceByColumns` now takes the segment tail from the start column, compares it to the remaining budget, and stops when the budget ends inside the segment. The slice stays a contiguous column range. A wide glyph that straddles the boundary is dropped, never replaced with content from a later segment.

`WordWrapper.WrapLine` now returns one blank line for a whitespace-only line that is wider than the width, to match the empty-string case and the styled wrapper.

## How it was found

I added an invariant and differential-oracle test (`StyledWordWrapperInvariantTests`). It generates many styled lines from fixed seeds (deterministic, reproducible) and checks four properties on every case:

- **Content and style are preserved** — no non-whitespace glyph is lost, added, reordered, or restyled.
- **Width bound** — every output line fits the width.
- **Maximal packing** — a line never leaves room for the next line's first word.
- **Oracle agreement** — the styled wrapper agrees with the independent plain `WordWrapper` on where breaks land.

Before the fix: 405 content failures and 407 oracle mismatches over 50,000 inputs. After: **0**.

## Tests

- `StyledWordWrapperInvariantTests` — the invariant/oracle sweep above.
- `StyledLineTests` — `SliceByColumns_WideGlyphAtBudgetBoundary_DoesNotPullFromNextSegment` (fails before the fix, passes after) and `SliceByColumns_StartInsideMultiSegmentLine_KeepsColumnsContiguous`.
- `WordWrapperTests` (new file) — the whitespace-only and empty-string cases.

Verification:

- Invariant sweep: 0 failures across 50,000 inputs.
- Full suite: 1613 passed, 0 failed.
- Build: 0 warnings, 0 errors.

## Follow-up

The survey behind this work produced a ranked plan for adopting property-based testing (CsCheck) and mutation testing (Stryker.NET) across the pure width/slice/diff/layout code — `DisplayWidth` first, then the `FrameBuffer` diff engine, then `StyledLine`. That is tracked separately, not in this PR.
