### PR TITLE
chore: prepare release 0.16.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,18 +10,48 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.15.1</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fixes**
+    <VersionPrefix>0.16.0</VersionPrefix>
+    <PackageReleaseNotes>**New Features**
 
-- **Fixed CJK and Unicode display width handling** ([#321](https://github.com/Aaronontheweb/termina/pull/321))
-  - Terminal rendering now correctly accounts for East Asian and wide Unicode character widths in layout and cursor behavior
+- **Roslyn analyzers now ship with the Termina library** ([#346](https://github.com/Aaronontheweb/termina/pull/346))
+  - Termina now includes its Roslyn analyzers in the package.
+  - The compiler runs the analyzers on your project and reports common layout node mistakes at build time.
+  - This change also fixes a node that Termina did not dispose when content switched.
 
-**Dependency Updates**
+- **New analyzer TERMINA003 for layout node child disposal** ([#343](https://github.com/Aaronontheweb/termina/pull/343))
+  - TERMINA003 warns when code disposes a child layout node outside `Dispose()`.
+  - `Dispose()` destroys the node, so the node can no longer render or handle input.
+  - The analyzer tells you to call `OnDeactivate()` to switch content.
 
-- Updated `actions/setup-dotnet` from 5.2.0 to 5.3.0 ([#270](https://github.com/Aaronontheweb/termina/pull/270))
-- Updated `Microsoft.Extensions.TimeProvider.Testing` from 10.6.0 to 10.7.0 ([#288](https://github.com/Aaronontheweb/termina/pull/288))
-- Updated `dotnet-sdk` from 10.0.201 to 10.0.301 ([#290](https://github.com/Aaronontheweb/termina/pull/290))
-- Updated `Microsoft.NET.Test.Sdk` from 18.6.0 to 18.7.0 ([#319](https://github.com/Aaronontheweb/termina/pull/319))</PackageReleaseNotes>
+- **New analyzer TERMINA004 for stateful node recreation** ([#337](https://github.com/Aaronontheweb/termina/pull/337))
+  - TERMINA004 warns when a dynamic layout factory creates a new stateful node on each run.
+  - A new node resets state such as the scroll position.
+  - The analyzer tells you to reuse the node, to invalidate a smaller child, or to use `KeyedDynamicLayoutNode`.
+
+**Bug Fixes**
+
+- **Fixed glyph corruption when word-wrap breaks a long word that contains wide characters** ([#351](https://github.com/Aaronontheweb/termina/pull/351))
+  - `StyledLine.SliceByColumns` no longer drops or reorders glyphs.
+  - The corruption occurred when a long word contained wide characters (CJK or emoji) across segments.
+  - Streamed text now keeps the correct content and order.
+
+- **Fixed the style of word-wrap space separators** ([#349](https://github.com/Aaronontheweb/termina/pull/349))
+  - Word-wrap space separators now inherit the whitespace style from the source text.
+  - A wrapped line keeps the correct foreground and background for the space between words.
+
+- **Guarded dynamic layout nodes against re-entrant Invalidate** ([#348](https://github.com/Aaronontheweb/termina/pull/348))
+  - `DynamicLayoutNode` and `KeyedDynamicLayoutNode` no longer re-enter `Invalidate()`.
+  - The guard prevents a stack overflow and inconsistent layout during a factory run.
+
+- **Fixed GridNode cell subscription tracking on content swap** ([#347](https://github.com/Aaronontheweb/termina/pull/347))
+  - `GridNode` now tracks cell subscriptions per content node.
+  - The grid deactivates the old subscriptions when it swaps a cell.
+  - This change prevents stale updates and resource leaks.
+
+**Documentation**
+
+- **Documented the built-in back navigation APIs** ([#350](https://github.com/Aaronontheweb/termina/pull/350))
+  - New documentation explains the back navigation APIs.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,53 @@
+# Release Notes — Termina 0.16.0
+
+**Release date:** 2026-08-07
+
+####
+
+**New Features**
+
+- **Roslyn analyzers now ship with the Termina library** ([#346](https://github.com/Aaronontheweb/termina/pull/346))
+  - Termina now includes its Roslyn analyzers in the package.
+  - The compiler runs the analyzers on your project and reports common layout node mistakes at build time.
+  - This change also fixes a node that Termina did not dispose when content switched.
+
+- **New analyzer TERMINA003 for layout node child disposal** ([#343](https://github.com/Aaronontheweb/termina/pull/343))
+  - TERMINA003 warns when code disposes a child layout node outside `Dispose()`.
+  - `Dispose()` destroys the node, so the node can no longer render or handle input.
+  - The analyzer tells you to call `OnDeactivate()` to switch content.
+
+- **New analyzer TERMINA004 for stateful node recreation** ([#337](https://github.com/Aaronontheweb/termina/pull/337))
+  - TERMINA004 warns when a dynamic layout factory creates a new stateful node on each run.
+  - A new node resets state such as the scroll position.
+  - The analyzer tells you to reuse the node, to invalidate a smaller child, or to use `KeyedDynamicLayoutNode`.
+
+**Bug Fixes**
+
+- **Fixed glyph corruption when word-wrap breaks a long word that contains wide characters** ([#351](https://github.com/Aaronontheweb/termina/pull/351))
+  - `StyledLine.SliceByColumns` no longer drops or reorders glyphs.
+  - The corruption occurred when a long word contained wide characters (CJK or emoji) across segments.
+  - Streamed text now keeps the correct content and order.
+
+- **Fixed the style of word-wrap space separators** ([#349](https://github.com/Aaronontheweb/termina/pull/349))
+  - Word-wrap space separators now inherit the whitespace style from the source text.
+  - A wrapped line keeps the correct foreground and background for the space between words.
+
+- **Guarded dynamic layout nodes against re-entrant Invalidate** ([#348](https://github.com/Aaronontheweb/termina/pull/348))
+  - `DynamicLayoutNode` and `KeyedDynamicLayoutNode` no longer re-enter `Invalidate()`.
+  - The guard prevents a stack overflow and inconsistent layout during a factory run.
+
+- **Fixed GridNode cell subscription tracking on content swap** ([#347](https://github.com/Aaronontheweb/termina/pull/347))
+  - `GridNode` now tracks cell subscriptions per content node.
+  - The grid deactivates the old subscriptions when it swaps a cell.
+  - This change prevents stale updates and resource leaks.
+
+**Documentation**
+
+- **Documented the built-in back navigation APIs** ([#350](https://github.com/Aaronontheweb/termina/pull/350))
+  - New documentation explains the back navigation APIs.
+
+####
+
 # Release Notes — Termina 0.15.1
 
 **Release date:** 2026-07-21


### PR DESCRIPTION
## Prepare release 0.16.0

This PR prepares the 0.16.0 release. It bumps the version and adds the release notes. It does not tag or publish.

### Changes
- Set `<VersionPrefix>` to `0.16.0` in `Directory.Build.props`.
- Refresh `<PackageReleaseNotes>` from the new 0.16.0 section (via `build.ps1`).
- Add the 0.16.0 section to `RELEASE_NOTES.md`.

### Highlights

**New Features**
- Roslyn analyzers now ship with the Termina library (#346).
- New analyzer TERMINA003 for layout node child disposal (#343).
- New analyzer TERMINA004 for stateful node recreation (#337).

**Bug Fixes**
- Fixed glyph corruption when word-wrap breaks a long word that contains wide characters (#351).
- Fixed the style of word-wrap space separators (#349).
- Guarded dynamic layout nodes against re-entrant `Invalidate` (#348).
- Fixed GridNode cell subscription tracking on content swap (#347).

**Documentation**
- Documented the built-in back navigation APIs (#350).

### Release step for the maintainer
The maintainer creates the `0.16.0` tag after this PR merges to `dev`. Use the numeric tag `0.16.0` with no `v` prefix. GitHub Actions handles the publish.
