### PR TITLE
ci: deploy docs on release tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - dev
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
+    tags:
+      - '*'
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Problem

The **Deploy Documentation** workflow did not run for the 0.16.0 release, so the website did not update.

Both of its triggers missed:
- **`release: [published]`** — the GitHub Release was created by the `publish_nuget` workflow using the default `GITHUB_TOKEN`. GitHub does not start workflows from events that `GITHUB_TOKEN` creates (anti-recursion), so this never fired.
- **`push` to `dev`** — path-filtered to `docs/**`. The release commit only changed `Directory.Build.props` and `RELEASE_NOTES.md`, so it did not match.

Every historical docs deploy has been a `docs/**` push; the release path has effectively never worked.

## Fix

Add a **tag push trigger** so every release tag deploys the docs. The tag is pushed with a real user credential (not `GITHUB_TOKEN`), so it triggers normally.

I removed the `paths` filter from the `push` block on purpose: a single `push` block applies its `paths` filter to tag pushes too, which would suppress release-tag deploys. The trade-off is that the docs now also rebuild on every `dev` push (about one minute), not only on `docs/**` changes.

`release: [published]` and `workflow_dispatch` are kept as-is.

### Alternative considered
Keep the `paths` filter and instead have `publish_nuget.yml` dispatch this workflow after it creates the release (or create the release with a PAT so `release: [published]` fires). Happy to switch to that if you'd rather preserve path-filtered `dev` pushes.

## Note

0.16.0's docs were already deployed manually via `workflow_dispatch` while this PR was prepared, so the live site is current. This PR makes it automatic for future releases.
