### PR TITLE
docs: add analyzer rule reference

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       { text: 'Styling', link: '/styling/' },
       { text: 'Concepts', link: '/concepts/' },
       { text: 'Advanced', link: '/advanced/' },
+      { text: 'Analyzers', link: '/analyzers/' },
       { text: 'Changelog', link: '/changelog' }
     ],
 
@@ -127,6 +128,12 @@ export default defineConfig({
         { text: 'Custom Components', link: '/advanced/custom-components' },
         { text: 'AOT Compilation', link: '/advanced/aot' },
         { text: 'Akka.NET Integration', link: '/advanced/akka-integration' }
+      ],
+      '/analyzers/': [
+        { text: 'Analyzer Reference', link: '/analyzers/' },
+        { text: 'TERMINA002: Layout Nodes in ViewModels', link: '/analyzers/termina002' },
+        { text: 'TERMINA003: Child Disposal', link: '/analyzers/termina003' },
+        { text: 'TERMINA004: Stateful Node Recreation', link: '/analyzers/termina004' }
       ],
       '/comparison/': [
         { text: 'Comparisons', link: '/comparison/' },

--- a/docs/analyzers/index.md
+++ b/docs/analyzers/index.md
@@ -1,0 +1,13 @@
+# Analyzer reference
+
+Termina ships Roslyn analyzers that report common layout node errors at build time.
+
+This reference covers the analyzer rules that exist in the current source:
+
+- [TERMINA002: Layout nodes in ViewModels](./termina002)
+- [TERMINA003: Layout node child disposal](./termina003)
+- [TERMINA004: Stateful node recreation](./termina004)
+
+Termina does not define a `TERMINA001` rule in the current source.
+
+The analyzer package contains no automatic code fixes. Apply the fix guidance on each rule page, then rebuild the project.

--- a/docs/analyzers/termina002.md
+++ b/docs/analyzers/termina002.md
@@ -1,0 +1,82 @@
+# TERMINA002: Layout nodes in ViewModels
+
+## Summary
+
+| Property | Value |
+| --- | --- |
+| Severity | Error |
+| Category | `Termina.Architecture` |
+| First known version | 0.3.0 |
+| Code fix | None in the current source |
+
+## Bad behavior
+
+The rule reports a field or property that meets both conditions:
+
+- The containing type derives from `ReactiveViewModel`.
+- The field or property type implements `ILayoutNode`.
+
+The rule reports fields and properties. It does not report local variables.
+
+## Risk
+
+A ViewModel should contain application state and business logic. A layout node is a UI component. When a ViewModel stores a layout node, the UI and application state share one type boundary. This reduces testability and breaks the MVVM separation.
+
+## Bad example
+
+```csharp
+using Termina.Layout;
+using Termina.Reactive;
+
+public sealed class ChatViewModel : ReactiveViewModel
+{
+    private readonly TextNode _message = new("Ready");
+}
+```
+
+`TextNode` implements `ILayoutNode`, so `TERMINA002` reports `_message`.
+
+## Good example
+
+Keep state in the ViewModel and create the layout node in the Page.
+
+```csharp
+using Termina.Layout;
+using Termina.Reactive;
+
+public sealed class ChatViewModel : ReactiveViewModel
+{
+    public string Message { get; set; } = "Ready";
+}
+
+public sealed class ChatPage
+{
+    private readonly ChatViewModel _viewModel = new();
+
+    public ILayoutNode BuildLayout()
+        => new TextNode(_viewModel.Message);
+}
+```
+
+## Fix guidance
+
+1. Remove the layout node field or property from the ViewModel.
+2. Keep the data that the ViewModel needs to expose.
+3. Create the layout node in the Page `BuildLayout()` method.
+4. Let the Page observe ViewModel state and update the layout.
+
+## Code-fix status
+
+The current analyzer source defines a `DiagnosticAnalyzer`. It does not define a `CodeFixProvider`. No automatic code fix exists.
+
+## Suppression guidance
+
+Do not suppress this rule when the type stores a UI component by mistake. If the design has a reviewed exception, suppress the diagnostic at the smallest scope:
+
+```csharp
+#pragma warning disable TERMINA002
+private readonly TextNode _message = new("Ready");
+#pragma warning restore TERMINA002
+```
+
+Document the reason for the exception. A project-wide suppression hides later MVVM boundary errors.

--- a/docs/analyzers/termina003.md
+++ b/docs/analyzers/termina003.md
@@ -1,0 +1,91 @@
+# TERMINA003: Layout node child disposal
+
+## Summary
+
+| Property | Value |
+| --- | --- |
+| Severity | Warning |
+| Category | `Termina.Lifecycle` |
+| First known version | 0.16.0 |
+| Code fix | None in the current source |
+
+## Bad behavior
+
+The rule reports `Dispose()` on a field or property that implements `ILayoutNode` when all conditions below apply:
+
+- The access uses the current container, such as `_child`, `this._child`, or `base._child`.
+- The containing type derives from `LayoutNode`.
+- The call is outside the container teardown.
+
+The rule does not report disposal in `Dispose()`, `DisposeAsync()`, `Dispose(bool)`, or a finalizer. It also does not report locals, parameters, collection elements, or members of another object.
+
+## Risk
+
+Termina uses an active and inactive lifecycle for layout nodes. `Dispose()` destroys a child. A destroyed child cannot render or handle input. A content switch should deactivate the old child and keep it available for later use or final cleanup.
+
+## Bad example
+
+```csharp
+using Termina.Layout;
+
+public sealed class ContentContainer : LayoutNode
+{
+    private ContentNode? _currentChild;
+
+    public void SwitchTo(ContentNode next)
+    {
+        _currentChild?.Dispose();
+        _currentChild = next;
+    }
+}
+```
+
+`TERMINA003` reports the `Dispose()` call because `SwitchTo` is not teardown.
+
+## Good example
+
+Call `OnDeactivate()` when the container switches content. Dispose the child in the container teardown.
+
+```csharp
+using Termina.Layout;
+
+public sealed class ContentContainer : LayoutNode
+{
+    private ContentNode? _currentChild;
+
+    public void SwitchTo(ContentNode next)
+    {
+        _currentChild?.OnDeactivate();
+        _currentChild = next;
+    }
+
+    public override void Dispose()
+    {
+        _currentChild?.Dispose();
+        base.Dispose();
+    }
+}
+```
+
+## Fix guidance
+
+1. Use `OnDeactivate()` when the old child leaves the active content.
+2. Keep the child reference if the container can reuse it.
+3. Dispose the child in the container's final teardown.
+4. Confirm that the child implements the activation lifecycle before you call `OnDeactivate()`.
+
+## Code-fix status
+
+The current analyzer source defines a `DiagnosticAnalyzer`. It does not define a `CodeFixProvider`. No automatic code fix exists.
+
+## Suppression guidance
+
+Do not suppress this rule to keep a content switch simple. If disposal is intentional and the lifecycle contract allows it, suppress the diagnostic at the call site and document why disposal is safe:
+
+```csharp
+#pragma warning disable TERMINA003
+_currentChild?.Dispose();
+#pragma warning restore TERMINA003
+```
+
+Do not use suppression to bypass final cleanup guidance.

--- a/docs/analyzers/termina004.md
+++ b/docs/analyzers/termina004.md
@@ -1,0 +1,100 @@
+# TERMINA004: Stateful node recreation
+
+## Summary
+
+| Property | Value |
+| --- | --- |
+| Severity | Warning |
+| Category | `Termina.State` |
+| First known version | 0.16.0 |
+| Code fix | None in the current source |
+
+## Bad behavior
+
+The rule reports a call to `Invalidate()` on a `DynamicLayoutNode` field when its factory creates a stateful layout node. The current source treats these types as stateful:
+
+- `ScrollableContainerNode`
+- `SelectionListNode<T>`
+- `TextInputNode`
+- `StreamingTextNode`
+
+The analyzer also checks a private helper that the factory calls one level deep. It treats a `??=` or `??` fallback as a reuse pattern.
+
+## Risk
+
+`DynamicLayoutNode` runs its factory again when code calls `Invalidate()`. A new stateful node loses state such as scroll offset, selected index, input text, or cursor position. The user can lose their current UI position or input.
+
+## Bad example
+
+```csharp
+using Termina.Layout;
+
+public sealed class ResultsPage
+{
+    private DynamicLayoutNode? _content;
+
+    public ILayoutNode BuildLayout()
+    {
+        _content = new DynamicLayoutNode(
+            () => new ScrollableContainerNode());
+        return _content;
+    }
+
+    public void Refresh()
+        => _content?.Invalidate();
+}
+```
+
+Each `Invalidate()` call creates a new `ScrollableContainerNode`. The new node does not keep the old scroll state.
+
+## Good example
+
+Create the stateful node once and reuse it in the factory.
+
+```csharp
+using Termina.Layout;
+
+public sealed class ResultsPage
+{
+    private DynamicLayoutNode? _content;
+    private ScrollableContainerNode? _scroll;
+
+    public ILayoutNode BuildLayout()
+    {
+        _content = new DynamicLayoutNode(() =>
+        {
+            _scroll ??= new ScrollableContainerNode();
+            return _scroll;
+        });
+        return _content;
+    }
+
+    public void Refresh()
+        => _content?.Invalidate();
+}
+```
+
+You can also invalidate a smaller child node or use `KeyedDynamicLayoutNode` when the content changes by key.
+
+## Fix guidance
+
+1. Create the stateful node outside the factory, or cache it with `??=` inside the factory.
+2. Return the same stateful node instance on each factory call.
+3. Invalidate a smaller child when only that child content changed.
+4. Use `KeyedDynamicLayoutNode` when keyed content needs state preservation.
+
+## Code-fix status
+
+The current analyzer source defines a `DiagnosticAnalyzer`. It does not define a `CodeFixProvider`. No automatic code fix exists.
+
+## Suppression guidance
+
+Do not suppress this rule when a factory creates a stateful node on every run. If the factory preserves state through another mechanism that the analyzer cannot detect, suppress the diagnostic at the `Invalidate()` call and document that mechanism:
+
+```csharp
+#pragma warning disable TERMINA004
+_content?.Invalidate();
+#pragma warning restore TERMINA004
+```
+
+Review the state-preservation mechanism when the factory changes.


### PR DESCRIPTION
## Summary

- Add the analyzer index and reference pages for TERMINA002, TERMINA003, and TERMINA004.
- Add analyzer navigation and sidebar links.
- Do not add a TERMINA001 page because current source does not define that rule.

## Validation

- `npm run build` passes in `docs/`.
- `git diff --check` passes.