### PR TITLE
Add cache policy to keyed dynamic layouts

### DIFF
--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -42,7 +42,7 @@ Termina provides a set of built-in layout nodes (components) for building termin
 | [ReactiveLayoutNode](/components/reactive-layout) | Updates content from observables |
 | [ConditionalNode](/components/conditional-node) | Show/hide based on condition |
 | `DynamicLayoutNode` | Re-evaluates factory on invalidation |
-| `KeyedDynamicLayoutNode` | Key-based content with all-key or current-only caching |
+| `KeyedDynamicLayoutNode` | Key-based content with retained or transition-evicted children |
 
 ## Composite Components
 

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -42,7 +42,7 @@ Termina provides a set of built-in layout nodes (components) for building termin
 | [ReactiveLayoutNode](/components/reactive-layout) | Updates content from observables |
 | [ConditionalNode](/components/conditional-node) | Show/hide based on condition |
 | `DynamicLayoutNode` | Re-evaluates factory on invalidation |
-| `KeyedDynamicLayoutNode` | Key-based content switching with caching |
+| `KeyedDynamicLayoutNode` | Key-based content with all-key or current-only caching |
 
 ## Composite Components
 

--- a/docs/concepts/dynamic-layouts.md
+++ b/docs/concepts/dynamic-layouts.md
@@ -2,14 +2,93 @@
 
 `DynamicLayoutNode` evaluates a factory on the first render. It evaluates the factory again after a call to `Invalidate()`.
 
-`KeyedDynamicLayoutNode<TKey>` preserves content while a key stays active. Its cache policy controls retention of inactive content.
+`KeyedDynamicLayoutNode<TKey>` selects a child from a key after each invalidation.
+The cache policy controls whether that child remains available after another key becomes active.
+
+## Cache Policies
+
+| Event | `RetainAll` (default) | `EvictOnKeyChange` |
+|-------|-----------------------|--------------------|
+| First use of key A | Create and cache child A | Create child A |
+| Invalidate while key A stays active | Reuse child A | Reuse child A |
+| Change from key A to key B | Retain child A and activate child B | Create child B, deactivate and retire child A, then activate child B |
+| Return from key B to key A | Reuse child A with its prior state | Create a new child A with fresh state |
+| Dispose the keyed layout | Dispose every cached child | Dispose the active child and any child that awaits deferred disposal |
+
+`RetainAll` makes each key a stable child identity. Use it when a return must restore text, focus, selection, or scroll state.
+
+`EvictOnKeyChange` makes a key transition a screen boundary. Use it when a return must build a fresh screen.
+
+## Think of the Key as Screen Identity
+
+Choose a key that changes only when the current child must become a different screen instance.
+
+- With `RetainAll`, a key identifies one persistent child. A return to that key restores the child.
+- With `EvictOnKeyChange`, an equal key keeps the active child. A different key replaces the child.
+
+Do not include every view-model value in the key. A key that changes too often will reset text, selection, focus, and scroll state.
+
+### Example: List and Editor Workflow
+
+This page must keep editor state during validation updates. It must create a fresh editor after the user leaves and returns.
+
+```csharp
+private enum WorkflowScreen { List, Editor }
+
+private WorkflowScreen _screen = WorkflowScreen.List;
+private KeyedDynamicLayoutNode<WorkflowScreen> _content = null!;
+
+public override ILayoutNode BuildLayout()
+{
+    _content = Layouts.KeyedDynamic(
+        () => _screen,
+        screen => screen switch
+        {
+            WorkflowScreen.List => BuildList(),
+            WorkflowScreen.Editor => BuildEditor(),
+            _ => Layouts.Empty()
+        },
+        KeyedDynamicCachePolicy.EvictOnKeyChange);
+
+    return _content;
+}
+
+private void ShowEditor()
+{
+    _screen = WorkflowScreen.Editor;
+    _content.Invalidate();
+}
+
+private void ShowList()
+{
+    _screen = WorkflowScreen.List;
+    _content.Invalidate();
+}
+```
+
+The editor child remains active while the key stays `Editor`. Its controls can process validation updates without a state reset.
+
+The transition to `List` evicts the editor. A later transition to `Editor` calls `BuildEditor()` again.
+
+Use a composite key when the same workflow state sometimes needs a forced reset:
+
+```csharp
+private int _editorRevision;
+
+var content = Layouts.KeyedDynamic(
+    () => (Screen: _screen, Revision: _screen == WorkflowScreen.Editor ? _editorRevision : 0),
+    key => BuildScreen(key.Screen),
+    KeyedDynamicCachePolicy.EvictOnKeyChange);
+```
+
+Increment `_editorRevision` only when the editor must discard its current controls and state.
 
 ## When to Use
 
 | Scenario | Use |
 |----------|-----|
-| Tabs or wizard steps must keep state after a return | `Layouts.KeyedDynamic<TKey>()` with the default `AllKeys` policy |
-| A workflow screen must be fresh after a return | `Layouts.KeyedDynamic<TKey>()` with `CurrentOnly` |
+| Tabs or wizard steps must keep state after a return | `Layouts.KeyedDynamic<TKey>()` with the default `RetainAll` policy |
+| A workflow screen must be fresh after a return | `Layouts.KeyedDynamic<TKey>()` with `EvictOnKeyChange` |
 | Observable-driven content updates | `ReactiveProperty<T>` + `.AsLayout()` or `factory.AsDynamicLayout(trigger)` |
 | Advanced: custom factory with manual caching | `Layouts.Dynamic()` — low-level, you manage caching |
 
@@ -17,7 +96,7 @@
 
 ### KeyedDynamic (Recommended)
 
-The natural way to write content that switches based on a key. No manual caching needed — child state (highlights, typed text, focus) is preserved across key changes:
+Use the default policy when each key must keep one child instance. The child keeps its text, selection, focus, and scroll state:
 
 ```csharp
 public override ILayoutNode BuildLayout()
@@ -41,20 +120,26 @@ public override ILayoutNode BuildLayout()
 }
 ```
 
-### Current-Only Cache
+### Evict on Key Change
 
-Use `CurrentOnly` for a workflow state machine. The node preserves the active screen during same-key invalidation.
+Use `EvictOnKeyChange` when a workflow transition must discard the prior screen.
+An invalidation with the same key still reuses the active child.
 
-A new key replaces the active screen. A return to a prior key creates fresh content.
+A different key deactivates and evicts the active child. A return to a prior key calls the factory again.
 
 ```csharp
 var layout = Layouts.KeyedDynamic(
     () => currentStep,
     step => BuildStep(step),
-    KeyedDynamicCachePolicy.CurrentOnly);
+    KeyedDynamicCachePolicy.EvictOnKeyChange);
 ```
 
-Termina deactivates replaced content during invalidation. It disposes the content on the next layout pass.
+Termina deactivates the replaced child during invalidation.
+Termina disposes that child on the next measure or render pass, after the current input callback completes.
+
+The keyed layout owns each child that its factory returns.
+With `EvictOnKeyChange`, return a new child instance after every key change.
+Use `Layouts.Deferred()` when the selected content is owned outside the keyed layout.
 
 ### Dynamic (Low-Level)
 
@@ -70,8 +155,8 @@ dynamicNode.Invalidate();
 
 | Need | Use |
 |------|-----|
-| Tabs or wizard steps must keep state after a return | `Layouts.KeyedDynamic<TKey>()` with `AllKeys` |
-| A workflow screen must be fresh after a return | `Layouts.KeyedDynamic<TKey>()` with `CurrentOnly` |
+| Tabs or wizard steps must keep state after a return | `Layouts.KeyedDynamic<TKey>()` with `RetainAll` |
+| A workflow screen must be fresh after a return | `Layouts.KeyedDynamic<TKey>()` with `EvictOnKeyChange` |
 | Observable-driven content updates | `observable.AsLayout()` or `factory.AsDynamicLayout(trigger)` |
 | Advanced: custom factory with manual caching | `Layouts.Dynamic()` — low-level, you manage caching |
 
@@ -129,11 +214,12 @@ var layout = Layouts.KeyedDynamic(
 
 - The factory is called once on first `Measure()`/`Render()`, then only when `Invalidate()` is called
 - `Invalidate()` eagerly evaluates the factory so the new child is immediately available for tree traversal (e.g., focus propagation)
-- **Reference equality** detects child changes — returning the same instance avoids lifecycle transitions
+- Under `RetainAll`, reference equality avoids lifecycle transitions when the node restores a cached child
 - When the child changes: the old child is deactivated, the new child is activated (mirrors `ReactiveLayoutNode` behavior)
-- The default `AllKeys` policy reuses content after a return to a prior key
-- The `CurrentOnly` policy reuses content only while the key stays active
-- `CurrentOnly` disposes replaced content on the next layout pass
+- The default `RetainAll` policy assigns one persistent child to each visited key
+- The `EvictOnKeyChange` policy keeps the child only until the selected key changes
+- `EvictOnKeyChange` deactivates the replaced child during invalidation
+- `EvictOnKeyChange` disposes the replaced child on the next measure or render pass
 - `GetChildNodes()` returns the current child for focus tree traversal
 - Extends `LayoutNode` so fluent sizing (`.Fill()`, `.Width()`, `.Height()`) works
 

--- a/docs/concepts/dynamic-layouts.md
+++ b/docs/concepts/dynamic-layouts.md
@@ -1,12 +1,15 @@
 # Dynamic Layouts
 
-`DynamicLayoutNode` evaluates a factory function once on first render, then re-evaluates only when `Invalidate()` is called. For content that switches based on a key (enum, step index, tab), use `KeyedDynamicLayoutNode<TKey>` which caches content by key and preserves child state across key changes.
+`DynamicLayoutNode` evaluates a factory on the first render. It evaluates the factory again after a call to `Invalidate()`.
+
+`KeyedDynamicLayoutNode<TKey>` preserves content while a key stays active. Its cache policy controls retention of inactive content.
 
 ## When to Use
 
 | Scenario | Use |
 |----------|-----|
-| Content switches based on a key (enum, int, string) | `Layouts.KeyedDynamic<TKey>()` — caches by key, preserves state |
+| Tabs or wizard steps must keep state after a return | `Layouts.KeyedDynamic<TKey>()` with the default `AllKeys` policy |
+| A workflow screen must be fresh after a return | `Layouts.KeyedDynamic<TKey>()` with `CurrentOnly` |
 | Observable-driven content updates | `ReactiveProperty<T>` + `.AsLayout()` or `factory.AsDynamicLayout(trigger)` |
 | Advanced: custom factory with manual caching | `Layouts.Dynamic()` — low-level, you manage caching |
 
@@ -38,6 +41,21 @@ public override ILayoutNode BuildLayout()
 }
 ```
 
+### Current-Only Cache
+
+Use `CurrentOnly` for a workflow state machine. The node preserves the active screen during same-key invalidation.
+
+A new key replaces the active screen. A return to a prior key creates fresh content.
+
+```csharp
+var layout = Layouts.KeyedDynamic(
+    () => currentStep,
+    step => BuildStep(step),
+    KeyedDynamicCachePolicy.CurrentOnly);
+```
+
+Termina deactivates replaced content during invalidation. It disposes the content on the next layout pass.
+
 ### Dynamic (Low-Level)
 
 For cases where you need full control over the factory:
@@ -52,7 +70,8 @@ dynamicNode.Invalidate();
 
 | Need | Use |
 |------|-----|
-| Content switches based on a key (enum, int, string) | `Layouts.KeyedDynamic<TKey>()` — caches by key, preserves state |
+| Tabs or wizard steps must keep state after a return | `Layouts.KeyedDynamic<TKey>()` with `AllKeys` |
+| A workflow screen must be fresh after a return | `Layouts.KeyedDynamic<TKey>()` with `CurrentOnly` |
 | Observable-driven content updates | `observable.AsLayout()` or `factory.AsDynamicLayout(trigger)` |
 | Advanced: custom factory with manual caching | `Layouts.Dynamic()` — low-level, you manage caching |
 
@@ -112,7 +131,9 @@ var layout = Layouts.KeyedDynamic(
 - `Invalidate()` eagerly evaluates the factory so the new child is immediately available for tree traversal (e.g., focus propagation)
 - **Reference equality** detects child changes — returning the same instance avoids lifecycle transitions
 - When the child changes: the old child is deactivated, the new child is activated (mirrors `ReactiveLayoutNode` behavior)
-- `KeyedDynamicLayoutNode<TKey>` additionally caches content by key — navigating back to a previous key reuses the cached instance
+- The default `AllKeys` policy reuses content after a return to a prior key
+- The `CurrentOnly` policy reuses content only while the key stays active
+- `CurrentOnly` disposes replaced content on the next layout pass
 - `GetChildNodes()` returns the current child for focus tree traversal
 - Extends `LayoutNode` so fluent sizing (`.Fill()`, `.Width()`, `.Height()`) works
 

--- a/src/Termina/Layout/DynamicLayoutNode.cs
+++ b/src/Termina/Layout/DynamicLayoutNode.cs
@@ -134,6 +134,8 @@ public sealed class DynamicLayoutNode : LayoutNode, IInvalidatingNode
         {
             newLayoutNode.OnActivate();
         }
+
+        RuntimeContext?.NotifyLayoutStructureChanged();
     }
 
     /// <summary>

--- a/src/Termina/Layout/KeyedDynamicLayoutNode.cs
+++ b/src/Termina/Layout/KeyedDynamicLayoutNode.cs
@@ -7,25 +7,44 @@ using Termina.Rendering;
 namespace Termina.Layout;
 
 /// <summary>
-/// A dynamic layout node that caches content by key. When the key changes, looks up the cache
-/// first — only creates new content on cache miss. Navigating back to a previous key reuses the
-/// cached instance, preserving all child state (highlights, typed text, focus).
+/// Defines how a keyed dynamic layout retains inactive content.
+/// </summary>
+public enum KeyedDynamicCachePolicy
+{
+    /// <summary>
+    /// Retain content for every visited key. A return to a key restores its prior state.
+    /// </summary>
+    AllKeys,
+
+    /// <summary>
+    /// Retain content only while its key stays active. A return to a prior key creates fresh content.
+    /// </summary>
+    CurrentOnly
+}
+
+/// <summary>
+/// A dynamic layout node that preserves content while a key stays active.
+/// Its cache policy controls retention of inactive content.
 /// </summary>
 /// <typeparam name="TKey">The type of key used to identify content variants.</typeparam>
 /// <remarks>
-/// This is the preferred API for content that switches based on a key (enum, step index, tab).
-/// Use <see cref="Layouts.KeyedDynamic{TKey}"/> to create instances.
+/// The default policy retains all visited keys. <see cref="KeyedDynamicCachePolicy.CurrentOnly"/>
+/// creates fresh content after a return to a prior key.
+/// Use <see cref="Layouts.KeyedDynamic{TKey}(Func{TKey}, Func{TKey, ILayoutNode})"/> to create instances.
 /// </remarks>
 public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     where TKey : notnull
 {
     private readonly Func<TKey> _keySelector;
     private readonly Func<TKey, ILayoutNode> _contentFactory;
+    private readonly KeyedDynamicCachePolicy _cachePolicy;
     private readonly Dictionary<TKey, ILayoutNode> _cache = new();
+    private readonly List<ILayoutNode> _retiredChildren = [];
     private readonly Subject<Unit> _invalidated = new();
     private IDisposable? _childInvalidationSubscription;
     private ILayoutNode _currentChild;
     private TKey? _currentKey;
+    private bool _hasCurrentKey;
     private bool _isActive;
     private bool _needsEvaluation = true;
     private bool _isEvaluating;
@@ -44,9 +63,27 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     /// <param name="keySelector">Function that returns the current key.</param>
     /// <param name="contentFactory">Function that creates content for a given key (called once per key).</param>
     public KeyedDynamicLayoutNode(Func<TKey> keySelector, Func<TKey, ILayoutNode> contentFactory)
+        : this(keySelector, contentFactory, KeyedDynamicCachePolicy.AllKeys)
     {
+    }
+
+    /// <summary>
+    /// Create a keyed dynamic layout node with an explicit cache policy.
+    /// </summary>
+    /// <param name="keySelector">Function that returns the current key.</param>
+    /// <param name="contentFactory">Function that creates content for a key.</param>
+    /// <param name="cachePolicy">The policy that controls retention of inactive content.</param>
+    public KeyedDynamicLayoutNode(
+        Func<TKey> keySelector,
+        Func<TKey, ILayoutNode> contentFactory,
+        KeyedDynamicCachePolicy cachePolicy)
+    {
+        if (!Enum.IsDefined(cachePolicy))
+            throw new ArgumentOutOfRangeException(nameof(cachePolicy), cachePolicy, "The cache policy is not valid.");
+
         _keySelector = keySelector;
         _contentFactory = contentFactory;
+        _cachePolicy = cachePolicy;
         _currentChild = new EmptyNode();
     }
 
@@ -124,14 +161,31 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
         _needsEvaluation = false;
         var key = _keySelector();
 
-        // Look up cache, create on miss
-        if (!_cache.TryGetValue(key, out var newChild))
+        if (_cachePolicy == KeyedDynamicCachePolicy.CurrentOnly
+            && _hasCurrentKey
+            && EqualityComparer<TKey>.Default.Equals(key, _currentKey))
+            return;
+
+        ILayoutNode newChild;
+        if (_cachePolicy == KeyedDynamicCachePolicy.AllKeys)
+        {
+            if (_cache.TryGetValue(key, out var cachedChild))
+            {
+                newChild = cachedChild;
+            }
+            else
+            {
+                newChild = _contentFactory(key);
+                _cache[key] = newChild;
+            }
+        }
+        else
         {
             newChild = _contentFactory(key);
-            _cache[key] = newChild;
         }
 
         _currentKey = key;
+        _hasCurrentKey = true;
 
         // Same instance — no lifecycle churn needed
         if (ReferenceEquals(newChild, _currentChild))
@@ -142,6 +196,11 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
         {
             oldLayoutNode.OnDeactivate();
         }
+
+        // Invalidate can run inside the old child's input callback. Defer disposal until the next
+        // layout pass, after input dispatch completes.
+        if (_cachePolicy == KeyedDynamicCachePolicy.CurrentOnly)
+            _retiredChildren.Add(_currentChild);
 
         _currentChild = newChild;
         ApplyRuntimeContextToChild(newChild);
@@ -182,6 +241,7 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     /// <inheritdoc />
     public override Size Measure(Size available)
     {
+        DisposeRetiredChildren();
         EvaluateFactory();
 
         var childSize = _currentChild.Measure(available);
@@ -195,8 +255,20 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     /// <inheritdoc />
     public override void Render(IRenderContext context, Rect bounds)
     {
+        DisposeRetiredChildren();
         EvaluateFactory();
         _currentChild.Render(context, bounds);
+    }
+
+    private void DisposeRetiredChildren()
+    {
+        foreach (var child in _retiredChildren)
+        {
+            if (!ReferenceEquals(child, _currentChild))
+                child.Dispose();
+        }
+
+        _retiredChildren.Clear();
     }
 
     /// <inheritdoc />
@@ -237,6 +309,8 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
         _childInvalidationSubscription?.Dispose();
         _invalidated.OnCompleted();
         _invalidated.Dispose();
+
+        DisposeRetiredChildren();
 
         // Check if _currentChild is in the cache (it won't be if factory was never evaluated)
         var currentChildInCache = _cache.Values.Any(c => ReferenceEquals(c, _currentChild));

--- a/src/Termina/Layout/KeyedDynamicLayoutNode.cs
+++ b/src/Termina/Layout/KeyedDynamicLayoutNode.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
 using R3;
+using System.Runtime.CompilerServices;
 using Termina.Rendering;
 
 namespace Termina.Layout;
@@ -12,14 +13,16 @@ namespace Termina.Layout;
 public enum KeyedDynamicCachePolicy
 {
     /// <summary>
-    /// Retain content for every visited key. A return to a key restores its prior state.
+    /// Retain one child for every visited key until the keyed layout is disposed.
+    /// A return to a key reuses the same child and its state.
     /// </summary>
-    AllKeys,
+    RetainAll,
 
     /// <summary>
-    /// Retain content only while its key stays active. A return to a prior key creates fresh content.
+    /// Evict the active child when the selected key changes.
+    /// A return to a prior key creates a new child with fresh state.
     /// </summary>
-    CurrentOnly
+    EvictOnKeyChange
 }
 
 /// <summary>
@@ -28,17 +31,19 @@ public enum KeyedDynamicCachePolicy
 /// </summary>
 /// <typeparam name="TKey">The type of key used to identify content variants.</typeparam>
 /// <remarks>
-/// The default policy retains all visited keys. <see cref="KeyedDynamicCachePolicy.CurrentOnly"/>
-/// creates fresh content after a return to a prior key.
+/// The default policy retains a child for every visited key.
+/// <see cref="KeyedDynamicCachePolicy.EvictOnKeyChange"/> creates a new child after each key transition.
 /// Use <see cref="Layouts.KeyedDynamic{TKey}(Func{TKey}, Func{TKey, ILayoutNode})"/> to create instances.
 /// </remarks>
 public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     where TKey : notnull
 {
+    private static readonly object OwnedChildMarker = new();
     private readonly Func<TKey> _keySelector;
     private readonly Func<TKey, ILayoutNode> _contentFactory;
     private readonly KeyedDynamicCachePolicy _cachePolicy;
     private readonly Dictionary<TKey, ILayoutNode> _cache = new();
+    private readonly ConditionalWeakTable<ILayoutNode, object> _evictionOwnedChildren = new();
     private readonly List<ILayoutNode> _retiredChildren = [];
     private readonly Subject<Unit> _invalidated = new();
     private IDisposable? _childInvalidationSubscription;
@@ -49,6 +54,7 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     private bool _needsEvaluation = true;
     private bool _isEvaluating;
     private bool _reevaluationRequested;
+    private bool _disposed;
 
     // Bounds the settle loop when the key selector or content factory invalidates its own node on every
     // pass (never converges).
@@ -63,7 +69,7 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     /// <param name="keySelector">Function that returns the current key.</param>
     /// <param name="contentFactory">Function that creates content for a given key (called once per key).</param>
     public KeyedDynamicLayoutNode(Func<TKey> keySelector, Func<TKey, ILayoutNode> contentFactory)
-        : this(keySelector, contentFactory, KeyedDynamicCachePolicy.AllKeys)
+        : this(keySelector, contentFactory, KeyedDynamicCachePolicy.RetainAll)
     {
     }
 
@@ -73,6 +79,11 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     /// <param name="keySelector">Function that returns the current key.</param>
     /// <param name="contentFactory">Function that creates content for a key.</param>
     /// <param name="cachePolicy">The policy that controls retention of inactive content.</param>
+    /// <remarks>
+    /// <see cref="KeyedDynamicCachePolicy.EvictOnKeyChange"/> transfers ownership of each returned child
+    /// to this layout. The factory must return a new child after each key change.
+    /// Wrap externally owned content in a <see cref="DeferredNode"/>.
+    /// </remarks>
     public KeyedDynamicLayoutNode(
         Func<TKey> keySelector,
         Func<TKey, ILayoutNode> contentFactory,
@@ -94,6 +105,9 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     /// </summary>
     public void Invalidate()
     {
+        if (_disposed)
+            return;
+
         _needsEvaluation = true;
 
         // A re-entrant call from inside the key selector or content factory: request another pass of the
@@ -160,14 +174,16 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     {
         _needsEvaluation = false;
         var key = _keySelector();
+        if (key is null)
+            throw new InvalidOperationException("The key selector returned null.");
 
-        if (_cachePolicy == KeyedDynamicCachePolicy.CurrentOnly
+        if (_cachePolicy == KeyedDynamicCachePolicy.EvictOnKeyChange
             && _hasCurrentKey
             && EqualityComparer<TKey>.Default.Equals(key, _currentKey))
             return;
 
         ILayoutNode newChild;
-        if (_cachePolicy == KeyedDynamicCachePolicy.AllKeys)
+        if (_cachePolicy == KeyedDynamicCachePolicy.RetainAll)
         {
             if (_cache.TryGetValue(key, out var cachedChild))
             {
@@ -175,13 +191,22 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
             }
             else
             {
-                newChild = _contentFactory(key);
+                newChild = _contentFactory(key)
+                    ?? throw new InvalidOperationException("The content factory returned null.");
                 _cache[key] = newChild;
             }
         }
         else
         {
-            newChild = _contentFactory(key);
+            newChild = _contentFactory(key)
+                ?? throw new InvalidOperationException("The content factory returned null.");
+            if (_evictionOwnedChildren.TryGetValue(newChild, out _))
+            {
+                throw new InvalidOperationException(
+                    "The content factory reused a child with EvictOnKeyChange. Return a new child after each key change.");
+            }
+
+            _evictionOwnedChildren.Add(newChild, OwnedChildMarker);
         }
 
         _currentKey = key;
@@ -199,7 +224,7 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
 
         // Invalidate can run inside the old child's input callback. Defer disposal until the next
         // layout pass, after input dispatch completes.
-        if (_cachePolicy == KeyedDynamicCachePolicy.CurrentOnly)
+        if (_cachePolicy == KeyedDynamicCachePolicy.EvictOnKeyChange)
             _retiredChildren.Add(_currentChild);
 
         _currentChild = newChild;
@@ -211,6 +236,8 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
         {
             newLayoutNode.OnActivate();
         }
+
+        RuntimeContext?.NotifyLayoutStructureChanged();
     }
 
     /// <summary>
@@ -262,13 +289,17 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
 
     private void DisposeRetiredChildren()
     {
-        foreach (var child in _retiredChildren)
+        if (_retiredChildren.Count == 0)
+            return;
+
+        var retiredChildren = _retiredChildren.ToArray();
+        _retiredChildren.Clear();
+
+        foreach (var child in retiredChildren)
         {
             if (!ReferenceEquals(child, _currentChild))
                 child.Dispose();
         }
-
-        _retiredChildren.Clear();
     }
 
     /// <inheritdoc />
@@ -306,9 +337,11 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     /// <inheritdoc />
     public override void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         _childInvalidationSubscription?.Dispose();
-        _invalidated.OnCompleted();
-        _invalidated.Dispose();
 
         DisposeRetiredChildren();
 
@@ -327,6 +360,9 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
         {
             _currentChild.Dispose();
         }
+
+        _invalidated.OnCompleted();
+        _invalidated.Dispose();
 
         base.Dispose();
     }

--- a/src/Termina/Layout/KeyedDynamicLayoutNode.cs
+++ b/src/Termina/Layout/KeyedDynamicLayoutNode.cs
@@ -38,12 +38,23 @@ public enum KeyedDynamicCachePolicy
 public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
     where TKey : notnull
 {
-    private static readonly object OwnedChildMarker = new();
+    private sealed class SeenChildMarker
+    {
+        public static SeenChildMarker Instance { get; } = new();
+
+        private SeenChildMarker()
+        {
+        }
+    }
+
     private readonly Func<TKey> _keySelector;
     private readonly Func<TKey, ILayoutNode> _contentFactory;
     private readonly KeyedDynamicCachePolicy _cachePolicy;
     private readonly Dictionary<TKey, ILayoutNode> _cache = new();
-    private readonly ConditionalWeakTable<ILayoutNode, object> _evictionOwnedChildren = new();
+
+    // Weak keys let retired children be collected after disposal. The set still rejects an instance
+    // that the factory retains and returns again.
+    private readonly ConditionalWeakTable<ILayoutNode, SeenChildMarker> _seenEvictionChildren = new();
     private readonly List<ILayoutNode> _retiredChildren = [];
     private readonly Subject<Unit> _invalidated = new();
     private IDisposable? _childInvalidationSubscription;
@@ -200,13 +211,13 @@ public sealed class KeyedDynamicLayoutNode<TKey> : LayoutNode, IInvalidatingNode
         {
             newChild = _contentFactory(key)
                 ?? throw new InvalidOperationException("The content factory returned null.");
-            if (_evictionOwnedChildren.TryGetValue(newChild, out _))
+            if (_seenEvictionChildren.TryGetValue(newChild, out _))
             {
                 throw new InvalidOperationException(
                     "The content factory reused a child with EvictOnKeyChange. Return a new child after each key change.");
             }
 
-            _evictionOwnedChildren.Add(newChild, OwnedChildMarker);
+            _seenEvictionChildren.Add(newChild, SeenChildMarker.Instance);
         }
 
         _currentKey = key;

--- a/src/Termina/Layout/Layout.cs
+++ b/src/Termina/Layout/Layout.cs
@@ -104,6 +104,10 @@ public static class Layouts
     /// <typeparam name="TKey">The type of key used to identify content variants.</typeparam>
     /// <param name="keySelector">Function that returns the current key.</param>
     /// <param name="contentFactory">Function that creates content for a given key (called once per key).</param>
+    /// <remarks>
+    /// The keyed layout owns every child that <paramref name="contentFactory"/> returns.
+    /// Wrap externally owned content in a <see cref="DeferredNode"/>.
+    /// </remarks>
     public static KeyedDynamicLayoutNode<TKey> KeyedDynamic<TKey>(
         Func<TKey> keySelector,
         Func<TKey, ILayoutNode> contentFactory)
@@ -116,6 +120,11 @@ public static class Layouts
     /// <param name="keySelector">A function that returns the current key.</param>
     /// <param name="contentFactory">A function that creates content for a key.</param>
     /// <param name="cachePolicy">The policy that controls retention of inactive content.</param>
+    /// <remarks>
+    /// The keyed layout owns every child that <paramref name="contentFactory"/> returns.
+    /// <see cref="KeyedDynamicCachePolicy.EvictOnKeyChange"/> requires a new child after each key change.
+    /// Wrap externally owned content in a <see cref="DeferredNode"/>.
+    /// </remarks>
     public static KeyedDynamicLayoutNode<TKey> KeyedDynamic<TKey>(
         Func<TKey> keySelector,
         Func<TKey, ILayoutNode> contentFactory,

--- a/src/Termina/Layout/Layout.cs
+++ b/src/Termina/Layout/Layout.cs
@@ -92,7 +92,7 @@ public static class Layouts
     /// </summary>
     /// <remarks>
     /// For content that switches based on a key (enum, step index, tab), prefer
-    /// <see cref="KeyedDynamic{TKey}"/> which provides automatic caching and state preservation.
+    /// <see cref="KeyedDynamic{TKey}(Func{TKey}, Func{TKey, ILayoutNode})"/> which provides automatic caching and state preservation.
     /// </remarks>
     /// <param name="factory">Factory that returns the current child node.</param>
     public static DynamicLayoutNode Dynamic(Func<ILayoutNode> factory) => new(factory);
@@ -108,4 +108,17 @@ public static class Layouts
         Func<TKey> keySelector,
         Func<TKey, ILayoutNode> contentFactory)
         where TKey : notnull => new(keySelector, contentFactory);
+
+    /// <summary>
+    /// Create a keyed dynamic layout node with an explicit cache policy.
+    /// </summary>
+    /// <typeparam name="TKey">The type of key that identifies content variants.</typeparam>
+    /// <param name="keySelector">A function that returns the current key.</param>
+    /// <param name="contentFactory">A function that creates content for a key.</param>
+    /// <param name="cachePolicy">The policy that controls retention of inactive content.</param>
+    public static KeyedDynamicLayoutNode<TKey> KeyedDynamic<TKey>(
+        Func<TKey> keySelector,
+        Func<TKey, ILayoutNode> contentFactory,
+        KeyedDynamicCachePolicy cachePolicy)
+        where TKey : notnull => new(keySelector, contentFactory, cachePolicy);
 }

--- a/src/Termina/Layout/LayoutRuntimeContext.cs
+++ b/src/Termina/Layout/LayoutRuntimeContext.cs
@@ -17,14 +17,28 @@ public sealed class LayoutRuntimeContext
         FrameProvider renderFrameProvider,
         TimeProvider timeProvider,
         Action requestRedraw)
+        : this(renderFrameProvider, timeProvider, requestRedraw, static () => { })
+    {
+    }
+
+    /// <summary>
+    /// Creates a new layout runtime context with a structural-change callback.
+    /// </summary>
+    public LayoutRuntimeContext(
+        FrameProvider renderFrameProvider,
+        TimeProvider timeProvider,
+        Action requestRedraw,
+        Action notifyLayoutStructureChanged)
     {
         ArgumentNullException.ThrowIfNull(renderFrameProvider);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(requestRedraw);
+        ArgumentNullException.ThrowIfNull(notifyLayoutStructureChanged);
 
         RenderFrameProvider = renderFrameProvider;
         TimeProvider = timeProvider;
         RequestRedraw = requestRedraw;
+        NotifyLayoutStructureChanged = notifyLayoutStructureChanged;
     }
 
     /// <summary>
@@ -41,6 +55,11 @@ public sealed class LayoutRuntimeContext
     /// Requests a redraw from the owning Termina application.
     /// </summary>
     public Action RequestRedraw { get; }
+
+    /// <summary>
+    /// Notifies the owning page that the set of child nodes changed.
+    /// </summary>
+    public Action NotifyLayoutStructureChanged { get; }
 }
 
 /// <summary>

--- a/src/Termina/Layout/ReactiveLayoutNode.cs
+++ b/src/Termina/Layout/ReactiveLayoutNode.cs
@@ -49,6 +49,7 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
                     newChildNode.OnActivate();
                 }
 
+                RuntimeContext?.NotifyLayoutStructureChanged();
                 _invalidated.OnNext(Unit.Default);
             });
     }
@@ -122,6 +123,7 @@ public sealed class ReactiveLayoutNode : LayoutNode, IInvalidatingNode
                         newChildNode.OnActivate();
                     }
 
+                    RuntimeContext?.NotifyLayoutStructureChanged();
                     _invalidated.OnNext(Unit.Default);
                 });
         }
@@ -210,6 +212,7 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
                     newChildNode.OnActivate();
                 }
 
+                RuntimeContext?.NotifyLayoutStructureChanged();
                 _invalidated.OnNext(Unit.Default);
             });
     }
@@ -281,6 +284,7 @@ public sealed class ReactiveLayoutNode<T> : LayoutNode, IInvalidatingNode
                         newChildNode.OnActivate();
                     }
 
+                    RuntimeContext?.NotifyLayoutStructureChanged();
                     _invalidated.OnNext(Unit.Default);
                 });
         }

--- a/src/Termina/Reactive/ReactivePage.cs
+++ b/src/Termina/Reactive/ReactivePage.cs
@@ -353,31 +353,7 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
             if (newRoot is IActivatableNode newNode)
                 newNode.OnActivate();
 
-            // Focus handling: preserve user focus if the focused node still
-            // exists in the new tree (common case when BuildLayout reuses
-            // page-field nodes). Otherwise the focused node is orphaned —
-            // clear focus and fall back to the policy default on the new
-            // tree so the user has somewhere to land.
-            if (Focus is not null && Focus.CurrentFocus is { } currentFocus)
-            {
-                var newFocusables = Focus.CollectFocusables(newRoot);
-                var stillPresent = false;
-                foreach (var f in newFocusables)
-                {
-                    if (ReferenceEquals(f, currentFocus))
-                    {
-                        stillPresent = true;
-                        break;
-                    }
-                }
-
-                if (!stillPresent)
-                {
-                    Focus.ClearFocus();
-                    if (FocusPolicy != FocusPolicy.Manual)
-                        ApplyFocusPolicy(newRoot);
-                }
-            }
+            ReconcileFocus(newRoot);
 
             // Request a redraw so the new tree actually renders. Without
             // this, callers who invalidate in response to an event that
@@ -451,12 +427,33 @@ public abstract class ReactivePage<TViewModel> : IBindablePage, IDisposable
         return visited;
     }
 
+    private void OnLayoutStructureChanged()
+    {
+        if (_layoutRoot is { } root)
+            ReconcileFocus(root);
+    }
+
+    private void ReconcileFocus(ILayoutNode root)
+    {
+        if (Focus is null || Focus.CurrentFocus is not { } currentFocus)
+            return;
+
+        var focusables = Focus.CollectFocusables(root);
+        if (focusables.Any(focusable => ReferenceEquals(focusable, currentFocus)))
+            return;
+
+        Focus.ClearFocus();
+        if (FocusPolicy != FocusPolicy.Manual)
+            ApplyFocusPolicy(root);
+    }
+
     private void ApplyRuntimeContext(ILayoutNode root)
     {
         var context = new LayoutRuntimeContext(
             ViewModel.RenderFrameProvider,
             ViewModel.TimeProvider,
-            ViewModel.RequestRedraw);
+            ViewModel.RequestRedraw,
+            OnLayoutStructureChanged);
         LayoutRuntimeContextInjector.Apply(root, context);
     }
 

--- a/tests/Termina.Tests/Layout/KeyedDynamicLayoutNodePropertyTests.cs
+++ b/tests/Termina.Tests/Layout/KeyedDynamicLayoutNodePropertyTests.cs
@@ -1,0 +1,289 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CsCheck;
+using Termina.Layout;
+using Termina.Rendering;
+using Termina.Terminal;
+using LayoutSize = Termina.Layout.Size;
+
+namespace Termina.Tests.Layout;
+
+/// <summary>
+/// Property-based lifecycle tests for <see cref="KeyedDynamicLayoutNode{TKey}"/> (CsCheck).
+/// </summary>
+/// <remarks>
+/// <para>
+/// USER STORY. A page can change its selected key several times before the terminal draws another
+/// frame. <see cref="KeyedDynamicCachePolicy.RetainAll"/> must restore each visited screen.
+/// <see cref="KeyedDynamicCachePolicy.EvictOnKeyChange"/> must create a fresh screen after a key
+/// change.
+/// </para>
+/// <para>
+/// THE RISK. Event order can expose stale children, early disposal, missed disposal, or duplicate
+/// disposal. Specific examples cover known orders but cannot cover their many combinations.
+/// </para>
+/// <para>
+/// THE ORACLE. A small reference model tracks the selected key, the expected child identity, and
+/// children that await a layout pass. It checks the public child and each disposal count after every
+/// generated step.
+/// </para>
+/// <para>
+/// HOW TO REPRODUCE A FAILURE. CsCheck prints a reduced command trace and a seed. Set
+/// <c>CsCheck_Seed</c> to that seed to run the same trace again.
+/// </para>
+/// </remarks>
+public class KeyedDynamicLayoutNodePropertyTests
+{
+    private const int Iter = 2_000;
+    private static readonly LayoutSize Available = new(80, 24);
+    private static readonly Rect Bounds = new(0, 0, 80, 24);
+    private static readonly NullRenderContext RenderContext = new();
+
+    // A small key set makes returns to prior keys common. An optional layout pass creates batches of
+    // one or more retired children between frames.
+    private static readonly Gen<List<TraceStep>> TraceGen =
+        (from key in Gen.Int[0, 3]
+         from layoutPass in Gen.OneOfConst(LayoutPass.None, LayoutPass.Measure, LayoutPass.Render)
+         select new TraceStep(key, layoutPass)).List[1, 40];
+
+    // The factory first returns fresh children. It then returns one prior child, which can be the
+    // current child or a child that a prior layout pass disposed.
+    private static readonly Gen<ReuseScenario> ReuseScenarioGen =
+        from freshTransitions in Gen.Int[1, 12]
+        from reuseIndex in Gen.Int[0, freshTransitions]
+        select new ReuseScenario(freshTransitions, reuseIndex);
+
+    [Fact]
+    public void RetainAll_RestoresEachVisitedScreenWithoutEarlyDisposal() =>
+        // A user can leave a tab and return later. The tab must keep the same controls and state, and
+        // no visited tab can receive disposal before the parent layout receives disposal.
+        TraceGen.Sample(trace => VerifyTrace(KeyedDynamicCachePolicy.RetainAll, trace), iter: Iter);
+
+    [Fact]
+    public void EvictOnKeyChange_CreatesFreshScreensAndDefersDisposal() =>
+        // A workflow can change screens more than once during one input callback. Each transition
+        // needs a fresh child, while all retired children stay alive until the next layout pass.
+        TraceGen.Sample(trace => VerifyTrace(KeyedDynamicCachePolicy.EvictOnKeyChange, trace), iter: Iter);
+
+    [Fact]
+    public void EvictOnKeyChange_RejectsEveryPreviouslyReturnedScreen() =>
+        // A factory can accidentally retain an old screen and return it later. Termina must reject
+        // that screen instead of restoring stale state or activating a child that it disposed.
+        ReuseScenarioGen.Sample(VerifyPriorChildReuseFails, iter: Iter);
+
+    private static void VerifyTrace(KeyedDynamicCachePolicy policy, IReadOnlyList<TraceStep> trace)
+    {
+        var selectedKey = 0;
+        var children = new List<TrackingNode>();
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => selectedKey,
+            key =>
+            {
+                var child = new TrackingNode(key, children.Count);
+                children.Add(child);
+                return child;
+            },
+            policy);
+
+        node.OnActivate();
+        node.Measure(Available);
+        node.Measure(Available); // Dispose the initial EmptyNode under EvictOnKeyChange.
+
+        var expectedFactoryCalls = 1;
+        var expectedCurrent = Assert.Single(children);
+        var activeKey = 0;
+        var firstChildByKey = new Dictionary<int, TrackingNode> { [0] = expectedCurrent };
+        var pendingDisposal = new List<TrackingNode>();
+        var expectedDisposed = new HashSet<TrackingNode>();
+
+        foreach (var step in trace)
+        {
+            var keyChanged = step.Key != activeKey;
+            var previousChild = expectedCurrent;
+            selectedKey = step.Key;
+
+            node.Invalidate();
+
+            if (policy == KeyedDynamicCachePolicy.RetainAll)
+            {
+                if (!firstChildByKey.TryGetValue(step.Key, out expectedCurrent))
+                {
+                    expectedFactoryCalls++;
+                    Assert.Equal(expectedFactoryCalls, children.Count);
+                    expectedCurrent = children[^1];
+                    firstChildByKey.Add(step.Key, expectedCurrent);
+                }
+            }
+            else if (keyChanged)
+            {
+                expectedFactoryCalls++;
+                pendingDisposal.Add(previousChild);
+                Assert.Equal(expectedFactoryCalls, children.Count);
+                expectedCurrent = children[^1];
+            }
+
+            activeKey = step.Key;
+            AssertState(node, children, expectedCurrent, expectedFactoryCalls, expectedDisposed);
+
+            if (step.LayoutPass != LayoutPass.None)
+            {
+                ApplyLayoutPass(node, step.LayoutPass);
+                expectedDisposed.UnionWith(pendingDisposal);
+                pendingDisposal.Clear();
+            }
+
+            AssertState(node, children, expectedCurrent, expectedFactoryCalls, expectedDisposed);
+        }
+
+        node.Dispose();
+
+        Assert.All(children, child => Assert.Equal(1, child.DisposeCount));
+    }
+
+    private static void VerifyPriorChildReuseFails(ReuseScenario scenario)
+    {
+        var selectedKey = 0;
+        var returnPriorChild = false;
+        var children = new List<TrackingNode>();
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => selectedKey,
+            key =>
+            {
+                if (returnPriorChild)
+                    return children[scenario.ReuseIndex];
+
+                var child = new TrackingNode(key, children.Count);
+                children.Add(child);
+                return child;
+            },
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
+
+        node.Measure(Available);
+        node.Measure(Available);
+
+        for (var key = 1; key <= scenario.FreshTransitions; key++)
+        {
+            selectedKey = key;
+            node.Invalidate();
+            node.Measure(Available);
+        }
+
+        returnPriorChild = true;
+        selectedKey = scenario.FreshTransitions + 1;
+
+        var exception = Assert.Throws<InvalidOperationException>(node.Invalidate);
+
+        Assert.Contains("Return a new child", exception.Message);
+
+        node.Dispose();
+
+        Assert.All(children, child => Assert.Equal(1, child.DisposeCount));
+    }
+
+    private static void ApplyLayoutPass(KeyedDynamicLayoutNode<int> node, LayoutPass layoutPass)
+    {
+        switch (layoutPass)
+        {
+            case LayoutPass.Measure:
+                node.Measure(Available);
+                break;
+            case LayoutPass.Render:
+                node.Render(RenderContext, Bounds);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(layoutPass), layoutPass, "A layout pass is required.");
+        }
+    }
+
+    private static void AssertState(
+        KeyedDynamicLayoutNode<int> node,
+        IReadOnlyCollection<TrackingNode> children,
+        TrackingNode expectedCurrent,
+        int expectedFactoryCalls,
+        IReadOnlySet<TrackingNode> expectedDisposed)
+    {
+        Assert.Equal(expectedFactoryCalls, children.Count);
+        Assert.Same(expectedCurrent, node.GetChildNodes().Single());
+        Assert.Equal(0, expectedCurrent.DisposeCount);
+
+        foreach (var child in children)
+            Assert.Equal(expectedDisposed.Contains(child) ? 1 : 0, child.DisposeCount);
+    }
+
+    private readonly record struct TraceStep(int Key, LayoutPass LayoutPass);
+
+    private readonly record struct ReuseScenario(int FreshTransitions, int ReuseIndex);
+
+    private enum LayoutPass
+    {
+        None,
+        Measure,
+        Render
+    }
+
+    private sealed class TrackingNode(int key, int instance) : LayoutNode
+    {
+        public int Key { get; } = key;
+        public int Instance { get; } = instance;
+        public int DisposeCount { get; private set; }
+
+        public override string ToString() => $"Child {Instance} for key {Key}";
+
+        public override LayoutSize Measure(LayoutSize available) => new(10, 1);
+
+        public override void Render(IRenderContext context, Rect bounds)
+        {
+        }
+
+        public override void Dispose()
+        {
+            DisposeCount++;
+            base.Dispose();
+        }
+    }
+
+    private sealed class NullRenderContext : IRenderContext
+    {
+        public int Width => Bounds.Width;
+        public int Height => Bounds.Height;
+
+        public void WriteAt(int x, int y, string text)
+        {
+        }
+
+        public void WriteAt(int x, int y, char c)
+        {
+        }
+
+        public void SetForeground(Color color)
+        {
+        }
+
+        public void SetBackground(Color color)
+        {
+        }
+
+        public void ResetColors()
+        {
+        }
+
+        public void SetDecoration(TextDecoration decoration)
+        {
+        }
+
+        public void ApplyStyle(TextStyle style)
+        {
+        }
+
+        public void Fill(int x, int y, int width, int height, char c = ' ')
+        {
+        }
+
+        public void Clear()
+        {
+        }
+
+        public IRenderContext CreateSubContext(Rect bounds) => this;
+    }
+}

--- a/tests/Termina.Tests/Layout/KeyedDynamicLayoutNodeTests.cs
+++ b/tests/Termina.Tests/Layout/KeyedDynamicLayoutNodeTests.cs
@@ -221,6 +221,106 @@ public class KeyedDynamicLayoutNodeTests
         Assert.IsType<SizeConstraint.Fixed>(result.HeightConstraint);
     }
 
+    [Fact]
+    public void CurrentOnly_SameKeyPreservesTextInputState()
+    {
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => 0,
+            _ => new TextInputNode(),
+            KeyedDynamicCachePolicy.CurrentOnly);
+        node.Measure(new Size(80, 24));
+        var input = Assert.IsType<TextInputNode>(node.GetChildNodes().Single());
+        input.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false));
+        input.HandleInput(new ConsoleKeyInfo('b', ConsoleKey.B, false, false, false));
+
+        node.Invalidate();
+
+        var preservedInput = Assert.IsType<TextInputNode>(node.GetChildNodes().Single());
+        Assert.Same(input, preservedInput);
+        Assert.Equal("ab", preservedInput.Text);
+    }
+
+    [Fact]
+    public void CurrentOnly_ReturnToPriorKeyCreatesFreshContent()
+    {
+        var currentKey = 0;
+        var factoryCallCount = 0;
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            _ =>
+            {
+                factoryCallCount++;
+                return new SpyLifecycleNode();
+            },
+            KeyedDynamicCachePolicy.CurrentOnly);
+
+        node.Measure(new Size(80, 24));
+        var firstChild = node.GetChildNodes().Single();
+        currentKey = 1;
+        node.Invalidate();
+        currentKey = 0;
+        node.Invalidate();
+
+        Assert.Equal(3, factoryCallCount);
+        Assert.NotSame(firstChild, node.GetChildNodes().Single());
+    }
+
+    [Fact]
+    public void CurrentOnly_DisposesRetiredContentOnTheNextLayoutPass()
+    {
+        var currentKey = 0;
+        var children = new List<SpyLifecycleNode>();
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            _ =>
+            {
+                var child = new SpyLifecycleNode();
+                children.Add(child);
+                return child;
+            },
+            KeyedDynamicCachePolicy.CurrentOnly);
+        node.OnActivate();
+        node.Measure(new Size(80, 24));
+
+        currentKey = 1;
+        node.Invalidate();
+
+        Assert.Equal(1, children[0].DeactivateCount);
+        Assert.False(children[0].WasDisposed);
+        Assert.Equal(1, children[1].ActivateCount);
+
+        node.Measure(new Size(80, 24));
+
+        Assert.True(children[0].WasDisposed);
+        Assert.False(children[1].WasDisposed);
+
+        node.Dispose();
+
+        Assert.True(children[1].WasDisposed);
+    }
+
+    [Fact]
+    public void LayoutsFactorySupportsCurrentOnlyPolicy()
+    {
+        var node = Layouts.KeyedDynamic(
+            () => 0,
+            _ => new EmptyNode(),
+            KeyedDynamicCachePolicy.CurrentOnly);
+
+        Assert.IsType<KeyedDynamicLayoutNode<int>>(node);
+    }
+
+    [Fact]
+    public void ConstructorRejectsAnUnknownCachePolicy()
+    {
+        var unknownPolicy = (KeyedDynamicCachePolicy)int.MaxValue;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new KeyedDynamicLayoutNode<int>(() => 0, _ => new EmptyNode(), unknownPolicy));
+
+        Assert.Equal("cachePolicy", exception.ParamName);
+    }
+
     #region Test helpers
 
     private class SpyLifecycleNode : LayoutNode

--- a/tests/Termina.Tests/Layout/KeyedDynamicLayoutNodeTests.cs
+++ b/tests/Termina.Tests/Layout/KeyedDynamicLayoutNodeTests.cs
@@ -222,12 +222,12 @@ public class KeyedDynamicLayoutNodeTests
     }
 
     [Fact]
-    public void CurrentOnly_SameKeyPreservesTextInputState()
+    public void EvictOnKeyChange_SameKeyPreservesTextInputState()
     {
         var node = new KeyedDynamicLayoutNode<int>(
             () => 0,
             _ => new TextInputNode(),
-            KeyedDynamicCachePolicy.CurrentOnly);
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
         node.Measure(new Size(80, 24));
         var input = Assert.IsType<TextInputNode>(node.GetChildNodes().Single());
         input.HandleInput(new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false));
@@ -241,7 +241,7 @@ public class KeyedDynamicLayoutNodeTests
     }
 
     [Fact]
-    public void CurrentOnly_ReturnToPriorKeyCreatesFreshContent()
+    public void EvictOnKeyChange_ReturnToPriorKeyCreatesFreshContent()
     {
         var currentKey = 0;
         var factoryCallCount = 0;
@@ -252,7 +252,7 @@ public class KeyedDynamicLayoutNodeTests
                 factoryCallCount++;
                 return new SpyLifecycleNode();
             },
-            KeyedDynamicCachePolicy.CurrentOnly);
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
 
         node.Measure(new Size(80, 24));
         var firstChild = node.GetChildNodes().Single();
@@ -266,7 +266,7 @@ public class KeyedDynamicLayoutNodeTests
     }
 
     [Fact]
-    public void CurrentOnly_DisposesRetiredContentOnTheNextLayoutPass()
+    public void EvictOnKeyChange_DisposesRetiredContentOnTheNextLayoutPass()
     {
         var currentKey = 0;
         var children = new List<SpyLifecycleNode>();
@@ -278,7 +278,7 @@ public class KeyedDynamicLayoutNodeTests
                 children.Add(child);
                 return child;
             },
-            KeyedDynamicCachePolicy.CurrentOnly);
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
         node.OnActivate();
         node.Measure(new Size(80, 24));
 
@@ -300,14 +300,113 @@ public class KeyedDynamicLayoutNodeTests
     }
 
     [Fact]
-    public void LayoutsFactorySupportsCurrentOnlyPolicy()
+    public void LayoutsFactorySupportsEvictOnKeyChangePolicy()
     {
         var node = Layouts.KeyedDynamic(
             () => 0,
             _ => new EmptyNode(),
-            KeyedDynamicCachePolicy.CurrentOnly);
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
 
         Assert.IsType<KeyedDynamicLayoutNode<int>>(node);
+    }
+
+    [Fact]
+    public void EvictOnKeyChange_ReusedFactoryChildThrows()
+    {
+        var currentKey = 0;
+        var sharedChild = new EmptyNode();
+        var node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            _ => sharedChild,
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
+
+        node.Measure(new Size(80, 24));
+        currentKey = 1;
+
+        var exception = Assert.Throws<InvalidOperationException>(node.Invalidate);
+
+        Assert.Contains("Return a new child", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(KeyedDynamicCachePolicy.RetainAll)]
+    [InlineData(KeyedDynamicCachePolicy.EvictOnKeyChange)]
+    public void NullKeyThrowsForEveryCachePolicy(KeyedDynamicCachePolicy cachePolicy)
+    {
+        string? currentKey = null;
+        var node = new KeyedDynamicLayoutNode<string>(
+            () => currentKey!,
+            _ => new EmptyNode(),
+            cachePolicy);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => node.Measure(new Size(80, 24)));
+
+        Assert.Equal("The key selector returned null.", exception.Message);
+    }
+
+    [Fact]
+    public void EvictOnKeyChange_DisposalCanInvalidateWithoutMutatingTheActiveDisposalBatch()
+    {
+        var currentKey = 0;
+        var children = new Dictionary<int, SpyLifecycleNode>();
+        KeyedDynamicLayoutNode<int> node = null!;
+        node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key =>
+            {
+                var child = new SpyLifecycleNode(key == 0
+                    ? () =>
+                    {
+                        currentKey = 2;
+                        node.Invalidate();
+                    }
+                : null);
+                children.Add(key, child);
+                return child;
+            },
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
+
+        node.Measure(new Size(80, 24));
+        node.Measure(new Size(80, 24));
+        currentKey = 1;
+        node.Invalidate();
+
+        node.Measure(new Size(80, 24));
+
+        Assert.True(children[0].WasDisposed);
+        Assert.False(children[1].WasDisposed);
+        Assert.Same(children[2], node.GetChildNodes().Single());
+
+        node.Measure(new Size(80, 24));
+
+        Assert.True(children[1].WasDisposed);
+    }
+
+    [Fact]
+    public void EvictOnKeyChange_TeardownIgnoresReentrantInvalidationAndDisposesAllChildren()
+    {
+        var currentKey = 0;
+        var children = new Dictionary<int, SpyLifecycleNode>();
+        KeyedDynamicLayoutNode<int> node = null!;
+        node = new KeyedDynamicLayoutNode<int>(
+            () => currentKey,
+            key =>
+            {
+                var child = new SpyLifecycleNode(key == 0 ? node.Invalidate : null);
+                children.Add(key, child);
+                return child;
+            },
+            KeyedDynamicCachePolicy.EvictOnKeyChange);
+
+        node.Measure(new Size(80, 24));
+        node.Measure(new Size(80, 24));
+        currentKey = 1;
+        node.Invalidate();
+
+        node.Dispose();
+
+        Assert.True(children[0].WasDisposed);
+        Assert.True(children[1].WasDisposed);
     }
 
     [Fact]
@@ -325,6 +424,13 @@ public class KeyedDynamicLayoutNodeTests
 
     private class SpyLifecycleNode : LayoutNode
     {
+        private readonly Action? _onDispose;
+
+        public SpyLifecycleNode(Action? onDispose = null)
+        {
+            _onDispose = onDispose;
+        }
+
         public int ActivateCount { get; private set; }
         public int DeactivateCount { get; private set; }
         public bool WasDisposed { get; private set; }
@@ -344,6 +450,7 @@ public class KeyedDynamicLayoutNodeTests
         public override void Dispose()
         {
             WasDisposed = true;
+            _onDispose?.Invoke();
             base.Dispose();
         }
 

--- a/tests/Termina.Tests/Layout/LayoutRuntimeContextTests.cs
+++ b/tests/Termina.Tests/Layout/LayoutRuntimeContextTests.cs
@@ -51,6 +51,48 @@ public class LayoutRuntimeContextTests
     }
 
     [Fact]
+    public void ReactiveLayoutNode_AfterReactivation_NotifiesStructuralChange()
+    {
+        var structureChanges = 0;
+        var timeProvider = new FakeTimeProvider();
+        var context = new LayoutRuntimeContext(
+            new TestFrameProvider(),
+            timeProvider,
+            () => { },
+            () => structureChanges++);
+        var source = new Subject<ILayoutNode>();
+        using var node = new ReactiveLayoutNode(source);
+        LayoutRuntimeContextInjector.Apply(node, context);
+
+        node.OnDeactivate();
+        node.OnActivate();
+        source.OnNext(new TextNode("replacement"));
+
+        Assert.Equal(1, structureChanges);
+    }
+
+    [Fact]
+    public void GenericReactiveLayoutNode_AfterReactivation_NotifiesStructuralChange()
+    {
+        var structureChanges = 0;
+        var timeProvider = new FakeTimeProvider();
+        var context = new LayoutRuntimeContext(
+            new TestFrameProvider(),
+            timeProvider,
+            () => { },
+            () => structureChanges++);
+        var source = new Subject<int>();
+        using var node = new ReactiveLayoutNode<int>(source, value => new TextNode(value.ToString()));
+        LayoutRuntimeContextInjector.Apply(node, context);
+
+        node.OnDeactivate();
+        node.OnActivate();
+        source.OnNext(1);
+
+        Assert.Equal(1, structureChanges);
+    }
+
+    [Fact]
     public void ContainerNode_AppliesContextToChildAddedAfterContext()
     {
         var context = CreateContext();

--- a/tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs
+++ b/tests/Termina.Tests/Reactive/ReactivePageInvalidateLayoutTests.cs
@@ -391,6 +391,33 @@ public class ReactivePageInvalidateLayoutTests
         Assert.Equal(string.Empty, secondInput.Text);
     }
 
+    [Fact]
+    public void ChildInvalidation_ReplacedFocusedNode_ClearsManualFocusBeforeDisposal()
+    {
+        using var focusManager = new FocusManager();
+
+        var page = new KeyedInputPage();
+        page.BindForTest(new EmptyViewModel());
+        page.WireFocusForTest(focusManager);
+        page.OnNavigatedTo();
+        page.MeasureLayout();
+
+        var firstInput = page.CurrentInput;
+        focusManager.SetFocus(firstInput);
+
+        page.ChangeKey(1);
+        var secondInput = page.CurrentInput;
+        Assert.NotSame(firstInput, secondInput);
+        Assert.Null(focusManager.CurrentFocus);
+
+        page.MeasureLayout();
+        var handled = focusManager.RouteInput(new ConsoleKeyInfo('x', (ConsoleKey)0, false, false, false));
+
+        Assert.False(handled);
+        Assert.Equal(string.Empty, firstInput.Text);
+        Assert.Equal(string.Empty, secondInput.Text);
+    }
+
     private sealed class CountingPage : ReactivePage<EmptyViewModel>
     {
         public int BuildLayoutCallCount { get; private set; }
@@ -518,6 +545,33 @@ public class ReactivePageInvalidateLayoutTests
         public void BindForTest(EmptyViewModel vm) => Bind(vm);
         public void CallInvalidateLayout() => InvalidateLayout();
         public void WireFocusForTest(IFocusManager focusManager) => ((Pages.IBindablePage)this).WireUpFocus(focusManager);
+    }
+
+    private sealed class KeyedInputPage : ReactivePage<EmptyViewModel>
+    {
+        private KeyedDynamicLayoutNode<int> _layout = null!;
+        private int _currentKey;
+
+        public TextInputNode CurrentInput { get; private set; } = null!;
+
+        public override ILayoutNode BuildLayout()
+        {
+            _layout = new KeyedDynamicLayoutNode<int>(
+                () => _currentKey,
+                _ => CurrentInput = new TextInputNode(),
+                KeyedDynamicCachePolicy.EvictOnKeyChange);
+            return _layout;
+        }
+
+        public void BindForTest(EmptyViewModel vm) => Bind(vm);
+        public void WireFocusForTest(IFocusManager focusManager) => ((Pages.IBindablePage)this).WireUpFocus(focusManager);
+        public void MeasureLayout() => _layout.Measure(new Size(80, 24));
+
+        public void ChangeKey(int key)
+        {
+            _currentKey = key;
+            _layout.Invalidate();
+        }
     }
 
     private sealed class TestInvalidatingNode : LayoutNode, IInvalidatingNode


### PR DESCRIPTION
## Summary

- Add `AllKeys` and `CurrentOnly` cache policies to keyed dynamic layouts.
- Keep `AllKeys` as the default policy for source and behavior compatibility.
- Let `CurrentOnly` retain the active child and replace a child after a key change.
- Deactivate replaced children at once and dispose them during the next layout pass.
- Document the policy choices and their state effects.

## Validation

- `dotnet test Termina.slnx`: 1,665 tests passed.
- The documentation site build passed.
- Netclaw compiled with zero warnings and zero errors against the local package.
- All 41 focused Netclaw tests passed.
- All 22 Netclaw native tapes and all 9 smoke scenarios passed.