### PR TITLE
Link analyzer diagnostics to repair guidance

### DIFF
--- a/docs/analyzers/termina004.md
+++ b/docs/analyzers/termina004.md
@@ -7,7 +7,7 @@
 | Severity | Warning |
 | Category | `Termina.State` |
 | First known version | 0.16.0 |
-| Code fix | None in the current source |
+| Code fix | No automatic fix; select a repair from this guide |
 
 ## Bad behavior
 
@@ -47,7 +47,18 @@ public sealed class ResultsPage
 
 Each `Invalidate()` call creates a new `ScrollableContainerNode`. The new node does not keep the old scroll state.
 
-## Good example
+## Choose the correct repair
+
+`TERMINA004` identifies state loss, but it cannot determine the intended screen identity. Choose the repair that matches the page behavior:
+
+| Required behavior | Repair |
+| --- | --- |
+| Keep one stateful child while the surrounding content updates | Create the child outside the factory, or cache it with `??=` |
+| Update only a stateless or reactive section inside the stateful child | Put that section in a smaller dynamic node and invalidate that node |
+| Restore each screen when its key becomes active again | Use `KeyedDynamicLayoutNode<TKey>` with the default `RetainAll` policy |
+| Create a fresh screen after the user leaves and returns | Use `KeyedDynamicLayoutNode<TKey>` with `EvictOnKeyChange` |
+
+### Reuse one child
 
 Create the stateful node once and reuse it in the factory.
 
@@ -74,18 +85,91 @@ public sealed class ResultsPage
 }
 ```
 
-You can also invalidate a smaller child node or use `KeyedDynamicLayoutNode` when the content changes by key.
+This repair keeps the scroll container while the dynamic factory updates its surrounding content.
+
+### Invalidate a smaller child
+
+Keep the stateful container outside the broad factory. Put only the content that changes in a nested dynamic node.
+
+```csharp
+private ScrollableContainerNode? _scroll;
+private DynamicLayoutNode? _rows;
+
+public ILayoutNode BuildLayout()
+{
+    _rows = new DynamicLayoutNode(BuildRows);
+    _scroll = new ScrollableContainerNode().WithContent(_rows);
+    return _scroll;
+}
+
+public void RefreshRows()
+    => _rows?.Invalidate();
+```
+
+This repair preserves the container state because the refresh replaces only the row content.
+
+### Preserve each keyed screen
+
+Use the default `RetainAll` policy when a return to a key must restore its previous controls and state.
+
+```csharp
+private int _selectedTab;
+private KeyedDynamicLayoutNode<int>? _content;
+
+public ILayoutNode BuildLayout()
+{
+    _content = Layouts.KeyedDynamic(
+        () => _selectedTab,
+        tab => BuildTab(tab));
+
+    return _content;
+}
+```
+
+Each visited tab keeps one child until the keyed layout receives disposal.
+
+### Replace a keyed screen after a transition
+
+Use `EvictOnKeyChange` when the active screen must stay stable, but a later return must create a fresh screen.
+
+```csharp
+private enum WorkflowScreen { List, Editor }
+
+private WorkflowScreen _screen;
+private KeyedDynamicLayoutNode<WorkflowScreen>? _content;
+
+public ILayoutNode BuildLayout()
+{
+    _content = Layouts.KeyedDynamic(
+        () => _screen,
+        screen => BuildScreen(screen),
+        KeyedDynamicCachePolicy.EvictOnKeyChange);
+
+    return _content;
+}
+```
+
+An invalidation with the same key keeps the active child. A key change retires that child and creates a new child.
+
+See [Dynamic layouts](../concepts/dynamic-layouts) for the full policy lifecycle and key design guidance.
 
 ## Fix guidance
 
-1. Create the stateful node outside the factory, or cache it with `??=` inside the factory.
-2. Return the same stateful node instance on each factory call.
-3. Invalidate a smaller child when only that child content changed.
-4. Use `KeyedDynamicLayoutNode` when keyed content needs state preservation.
+1. Decide what identifies one screen instance.
+2. Decide whether a return must restore or replace that screen.
+3. Select the narrowest repair from the table above.
+4. Verify text, focus, selection, and scroll state across both refreshes and screen transitions.
 
 ## Code-fix status
 
-The current analyzer source defines a `DiagnosticAnalyzer`. It does not define a `CodeFixProvider`. No automatic code fix exists.
+No automatic code fix exists. The analyzer cannot infer:
+
+- which application value identifies a screen
+- whether a return to a prior key must restore or replace state
+- whether the application can invalidate a smaller child
+- which component owns each child and must dispose it
+
+A partial code fix would handle only some source shapes and could select the wrong lifecycle. Use this page to make the decision explicitly.
 
 ## Suppression guidance
 

--- a/src/Termina.Generators/LayoutNodeChildDisposalAnalyzer.cs
+++ b/src/Termina.Generators/LayoutNodeChildDisposalAnalyzer.cs
@@ -37,7 +37,8 @@ public sealed class LayoutNodeChildDisposalAnalyzer : DiagnosticAnalyzer
         category: Category,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Termina layout nodes use an active/inactive lifecycle. OnDeactivate() pauses a child and keeps it alive. Dispose() destroys it. A container should deactivate a switched-out child, not dispose it. Dispose a child only in the container's own teardown (Dispose/DisposeAsync/Dispose(bool)/finalizer).");
+        description: "Termina layout nodes use an active/inactive lifecycle. OnDeactivate() pauses a child and keeps it alive. Dispose() destroys it. A container should deactivate a switched-out child, not dispose it. Dispose a child only in the container's own teardown (Dispose/DisposeAsync/Dispose(bool)/finalizer).",
+        helpLinkUri: "https://aaronstannard.com/termina/analyzers/termina003");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Termina.Generators/LayoutNodeInViewModelAnalyzer.cs
+++ b/src/Termina.Generators/LayoutNodeInViewModelAnalyzer.cs
@@ -35,7 +35,8 @@ public sealed class LayoutNodeInViewModelAnalyzer : DiagnosticAnalyzer
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "ViewModels in the MVVM pattern should contain application state and business logic, not UI components. Layout nodes (ILayoutNode implementations) should be created in the Page class's BuildLayout() method. This separation ensures proper testability and maintains a clear boundary between UI and application logic.");
+        description: "ViewModels in the MVVM pattern should contain application state and business logic, not UI components. Layout nodes (ILayoutNode implementations) should be created in the Page class's BuildLayout() method. This separation ensures proper testability and maintains a clear boundary between UI and application logic.",
+        helpLinkUri: "https://aaronstannard.com/termina/analyzers/termina002");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         => ImmutableArray.Create(Rule);

--- a/src/Termina.Generators/StatefulLayoutNodeRecreationAnalyzer.cs
+++ b/src/Termina.Generators/StatefulLayoutNodeRecreationAnalyzer.cs
@@ -35,7 +35,8 @@ public sealed class StatefulLayoutNodeRecreationAnalyzer : DiagnosticAnalyzer
         category: Category,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Some layout nodes such as ScrollableContainerNode own UI state. A DynamicLayoutNode factory runs again on Invalidate(). If the factory creates the stateful node again, the node loses its state. Create the stateful node one time and reuse the instance.");
+        description: "Some layout nodes such as ScrollableContainerNode own UI state. A DynamicLayoutNode factory runs again on Invalidate(). If the factory creates the stateful node again, the node loses its state. Create the stateful node one time and reuse the instance.",
+        helpLinkUri: "https://aaronstannard.com/termina/analyzers/termina004");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 


### PR DESCRIPTION
## Summary

- add published help links to TERMINA002, TERMINA003, and TERMINA004
- explain why TERMINA004 cannot offer one safe automatic fix
- document child reuse, narrow invalidation, retained keys, and evicted keys
- link the rule page to the dynamic layout lifecycle guide

## Validation

- 54 focused analyzer tests passed
- all 1,676 tests passed
- the VitePress documentation build passed
- format checks passed for all changed C# files