### PR TITLE
chore: prepare release 0.16.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,48 +10,14 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.16.0</VersionPrefix>
+    <VersionPrefix>0.16.1</VersionPrefix>
     <PackageReleaseNotes>**New Features**
 
-- **Roslyn analyzers now ship with the Termina library** ([#346](https://github.com/Aaronontheweb/termina/pull/346))
-  - Termina now includes its Roslyn analyzers in the package.
-  - The compiler runs the analyzers on your project and reports common layout node mistakes at build time.
-  - This change also fixes a node that Termina did not dispose when content switched.
-
-- **New analyzer TERMINA003 for layout node child disposal** ([#343](https://github.com/Aaronontheweb/termina/pull/343))
-  - TERMINA003 warns when code disposes a child layout node outside `Dispose()`.
-  - `Dispose()` destroys the node, so the node can no longer render or handle input.
-  - The analyzer tells you to call `OnDeactivate()` to switch content.
-
-- **New analyzer TERMINA004 for stateful node recreation** ([#337](https://github.com/Aaronontheweb/termina/pull/337))
-  - TERMINA004 warns when a dynamic layout factory creates a new stateful node on each run.
-  - A new node resets state such as the scroll position.
-  - The analyzer tells you to reuse the node, to invalidate a smaller child, or to use `KeyedDynamicLayoutNode`.
-
-**Bug Fixes**
-
-- **Fixed glyph corruption when word-wrap breaks a long word that contains wide characters** ([#351](https://github.com/Aaronontheweb/termina/pull/351))
-  - `StyledLine.SliceByColumns` no longer drops or reorders glyphs.
-  - The corruption occurred when a long word contained wide characters (CJK or emoji) across segments.
-  - Streamed text now keeps the correct content and order.
-
-- **Fixed the style of word-wrap space separators** ([#349](https://github.com/Aaronontheweb/termina/pull/349))
-  - Word-wrap space separators now inherit the whitespace style from the source text.
-  - A wrapped line keeps the correct foreground and background for the space between words.
-
-- **Guarded dynamic layout nodes against re-entrant Invalidate** ([#348](https://github.com/Aaronontheweb/termina/pull/348))
-  - `DynamicLayoutNode` and `KeyedDynamicLayoutNode` no longer re-enter `Invalidate()`.
-  - The guard prevents a stack overflow and inconsistent layout during a factory run.
-
-- **Fixed GridNode cell subscription tracking on content swap** ([#347](https://github.com/Aaronontheweb/termina/pull/347))
-  - `GridNode` now tracks cell subscriptions per content node.
-  - The grid deactivates the old subscriptions when it swaps a cell.
-  - This change prevents stale updates and resource leaks.
-
-**Documentation**
-
-- **Documented the built-in back navigation APIs** ([#350](https://github.com/Aaronontheweb/termina/pull/350))
-  - New documentation explains the back navigation APIs.</PackageReleaseNotes>
+- **Added cache policy to keyed dynamic layouts** ([#361](https://github.com/Aaronontheweb/termina/pull/361))
+  - `KeyedDynamicLayoutNode` now supports `AllKeys` and `CurrentOnly` cache policies.
+  - `AllKeys` remains the default policy, preserving existing behavior and source compatibility.
+  - `CurrentOnly` keeps only the active child and replaces it when the key changes.
+  - Replaced children deactivate immediately and dispose during the next layout pass.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+# Release Notes — Termina 0.16.1
+
+**Release date:** 2026-08-08
+
+####
+
+**New Features**
+
+- **Added cache policy to keyed dynamic layouts** ([#361](https://github.com/Aaronontheweb/termina/pull/361))
+  - `KeyedDynamicLayoutNode` now supports `AllKeys` and `CurrentOnly` cache policies.
+  - `AllKeys` remains the default policy, preserving existing behavior and source compatibility.
+  - `CurrentOnly` keeps only the active child and replaces it when the key changes.
+  - Replaced children deactivate immediately and dispose during the next layout pass.
+
+####
+
 # Release Notes — Termina 0.16.0
 
 **Release date:** 2026-08-07


### PR DESCRIPTION
## Prepare release 0.16.1

This PR prepares the 0.16.1 release. It bumps the version and adds the release notes. It does not tag or publish.

### Changes
- Set `<VersionPrefix>` to `0.16.1` in `Directory.Build.props`.
- Refresh `<PackageReleaseNotes>` from the new 0.16.1 section (via `build.ps1`).
- Add the 0.16.1 section to `RELEASE_NOTES.md`.

### Highlights

**New Features**
- Added cache policy to keyed dynamic layouts (#361).

### Release step for the maintainer
The maintainer creates the `0.16.1` tag after this PR merges to `dev`. Use the numeric tag `0.16.1` with no `v` prefix. GitHub Actions handles the publish.