### PR TITLE
Add semantic clipboard content

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,8 +10,12 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.17.0-beta.1</VersionPrefix>
+    <VersionPrefix>0.17.0-beta.2</VersionPrefix>
     <PackageReleaseNotes>**New Features**
+
+- **Added semantic clipboard content for copyable text**
+  - `WithSemanticContent` separates complete clipboard text from compact display text.
+  - `TryCopy` reports clipboard failure and preserves the current selection.
 
 - **Added an opt-in inline presentation mode** ([#366](https://github.com/Aaronontheweb/termina/issues/366))
   - `TerminalPresentationMode.Inline` keeps settled output in the primary buffer.

--- a/src/Termina/Layout/CopyableTextNode.cs
+++ b/src/Termina/Layout/CopyableTextNode.cs
@@ -23,6 +23,7 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
     ];
     private int _cursorPosition;
     private int _selectionStart = -1;
+    private string? _semanticContent;
     private bool _showInlineIndicator;
     private bool _hasFocus;
     private bool _disposed;
@@ -37,6 +38,15 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
     }
 
     public string Content { get; private set; }
+
+    /// <summary>
+    /// Gets the complete text used for a full-content copy action.
+    /// </summary>
+    /// <remarks>
+    /// This value defaults to <see cref="Content"/>. A text selection still copies
+    /// the selected display text.
+    /// </remarks>
+    public string SemanticContent => _semanticContent ?? Content;
 
     public string? Hint { get; private set; } = "Press Enter to copy";
 
@@ -90,6 +100,20 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         if (_selectionStart > Content.Length)
             _selectionStart = -1;
         Invalidate();
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the complete text used for a full-content copy action.
+    /// </summary>
+    /// <remarks>
+    /// Use this value when the display text contains decoration, truncation, or
+    /// terminal control data that the clipboard text must omit.
+    /// </remarks>
+    public CopyableTextNode WithSemanticContent(string semanticContent)
+    {
+        ArgumentNullException.ThrowIfNull(semanticContent);
+        _semanticContent = semanticContent;
         return this;
     }
 
@@ -182,7 +206,7 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         }
         else if (IsCopyBinding(key))
         {
-            CopySelectionOrContent();
+            TryCopy();
             handled = true;
         }
         else
@@ -268,13 +292,18 @@ public sealed class CopyableTextNode : LayoutNode, IFocusable, IInvalidatingNode
         base.Dispose();
     }
 
-    private bool CopySelectionOrContent()
+    /// <summary>
+    /// Copies the selected display text, or the complete semantic content when no
+    /// selection exists.
+    /// </summary>
+    /// <returns>True when at least one clipboard transport reported success.</returns>
+    public bool TryCopy()
     {
-        var textToCopy = HasSelection ? SelectedText : Content;
+        var textToCopy = HasSelection ? SelectedText : SemanticContent;
         TerminaTrace.Input.Info(this, "CopyableTextNode copy requested: contentLength={0}, selectionLength={1}", Content.Length, textToCopy.Length);
         var success = _clipboardService.Copy(textToCopy);
         ShowFeedback(success);
-        return true;
+        return success;
     }
 
     private bool IsCopyBinding(ConsoleKeyInfo key)

--- a/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
+++ b/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
@@ -627,6 +627,7 @@ namespace Termina.Layout
         public string SelectedText { get; }
         public Termina.Terminal.Color SelectionBackground { get; }
         public Termina.Terminal.Color SelectionForeground { get; }
+        public string SemanticContent { get; }
         public Termina.Notifications.ToastPosition ToastPosition { get; }
         public override void Dispose() { }
         public bool HandleInput(System.ConsoleKeyInfo key) { }
@@ -634,6 +635,7 @@ namespace Termina.Layout
         public void OnBlurred() { }
         public void OnFocused() { }
         public override void Render(Termina.Rendering.IRenderContext context, Termina.Layout.Rect bounds) { }
+        public bool TryCopy() { }
         public Termina.Layout.CopyableTextNode WithContent(string content) { }
         public Termina.Layout.CopyableTextNode WithCopyBindings(params Termina.Layout.CopyKeyBinding[] bindings) { }
         public Termina.Layout.CopyableTextNode WithFeedbackDuration(System.TimeSpan duration) { }
@@ -643,6 +645,7 @@ namespace Termina.Layout
         public Termina.Layout.CopyableTextNode WithHint(string? hint) { }
         public Termina.Layout.CopyableTextNode WithInlineIndicator(string text, Termina.Terminal.Color? foreground = default) { }
         public Termina.Layout.CopyableTextNode WithSelectionColors(Termina.Terminal.Color foreground, Termina.Terminal.Color background) { }
+        public Termina.Layout.CopyableTextNode WithSemanticContent(string semanticContent) { }
         public Termina.Layout.CopyableTextNode WithToastPosition(Termina.Notifications.ToastPosition position) { }
     }
     public sealed class DefaultFileSystemProvider : Termina.Layout.IFileSystemProvider

--- a/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
+++ b/tests/Termina.Tests/Layout/CopyableTextNodeTests.cs
@@ -26,6 +26,40 @@ public class CopyableTextNodeTests
     }
 
     [Fact]
+    public void Enter_CopiesCompleteSemanticContentWithoutDisplayDecoration()
+    {
+        const string display = "\u001b[32m✓ shell_execute → output...\u001b[0m";
+        const string semantic = "shell_execute\nExit code: 0\ncomplete output";
+        var clipboard = new TestClipboardService();
+        var node = new CopyableTextNode(clipboard, display)
+            .WithSemanticContent(semantic);
+
+        node.HandleInput(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+        var copiedText = Assert.IsType<string>(clipboard.LastCopiedText);
+        Assert.Equal(semantic, copiedText);
+        Assert.DoesNotContain('\u001b', copiedText);
+        Assert.DoesNotContain("✓", copiedText);
+    }
+
+    [Fact]
+    public void TryCopy_WhenClipboardFails_ReturnsFalseAndKeepsSelection()
+    {
+        var clipboard = new TestClipboardService { Succeeds = false };
+        var node = new CopyableTextNode(clipboard, "abcd");
+        node.OnFocused();
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, true, false, false));
+        node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, true, false, false));
+
+        var success = node.TryCopy();
+
+        Assert.False(success);
+        Assert.True(node.HasSelection);
+        Assert.Equal("ab", node.SelectedText);
+        Assert.Equal("ab", clipboard.LastCopiedText);
+    }
+
+    [Fact]
     public void NonEnterKey_IsNotHandled()
     {
         var clipboard = new TestClipboardService();
@@ -208,10 +242,12 @@ public class CopyableTextNodeTests
     {
         public string? LastCopiedText { get; private set; }
 
+        public bool Succeeds { get; init; } = true;
+
         public bool Copy(string text)
         {
             LastCopiedText = text;
-            return true;
+            return Succeeds;
         }
     }
 


### PR DESCRIPTION
## Summary

- add complete semantic content to `CopyableTextNode`
- report clipboard success through `TryCopy`
- preserve the current selection after a clipboard failure
- prepare the `0.17.0-beta.2` package

## Compatibility

This change only adds members to a sealed type. Existing constructors, defaults, and copy behavior remain unchanged.

## Validation

- all 1,698 Termina tests passed before the release version update
- focused copy tests passed after the update
- the public API approval test passed
- the changed files passed the format check
- `git diff --check` passed

Closes #367
Relates to #366