### PR TITLE
Report modified Enter input capability

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,8 +10,13 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.17.0-beta.2</VersionPrefix>
+    <VersionPrefix>0.17.0-beta.3</VersionPrefix>
     <PackageReleaseNotes>**New Features**
+
+- **Added a modified Enter key capability result** ([#240](https://github.com/Aaronontheweb/termina/issues/240))
+  - Termina queries active Kitty keyboard flags without a terminal-name guess.
+  - `TerminalInputCapabilitiesChanged` reports whether modified Enter keys remain distinct.
+  - Windows console records report native modifier support.
 
 - **Added semantic clipboard content for copyable text**
   - `WithSemanticContent` separates complete clipboard text from compact display text.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,19 @@
-# Release Notes — Termina 0.17.0-beta.1
+# Release Notes — Termina 0.17.0-beta.3
 
 **Release date:** 2026-08-11
 
 ####
 
 **New Features**
+
+- **Added a modified Enter key capability result** ([#240](https://github.com/Aaronontheweb/termina/issues/240))
+  - Termina queries active Kitty keyboard flags without a terminal-name guess.
+  - `TerminalInputCapabilitiesChanged` reports whether modified Enter keys remain distinct.
+  - Windows console records report native modifier support.
+
+- **Added semantic clipboard content for copyable text**
+  - `WithSemanticContent` separates complete clipboard text from compact display text.
+  - `TryCopy` reports clipboard failure and preserves the current selection.
 
 - **Added an opt-in inline presentation mode** ([#366](https://github.com/Aaronontheweb/termina/issues/366))
   - `TerminalPresentationMode.Inline` keeps settled output in the primary buffer.

--- a/docs/components/text-area-node.md
+++ b/docs/components/text-area-node.md
@@ -83,6 +83,11 @@ Ctrl+Enter will behave the same as Enter (submit). **Alt+Enter always works** as
 fallback because terminals encode the Alt modifier as an ESC prefix (`ESC` + `CR`), which is
 reliably detected even inside tmux.
 
+Termina probes the active Kitty flags at startup. It publishes a
+`TerminalInputCapabilitiesChanged` event after the probe. Read
+`TerminalInputCapabilities.ModifiedEnterKeySupport` before you claim that a modified Enter
+shortcut works. The result is also available from `TerminaApplication.InputCapabilities`.
+
 ## Word Wrap
 
 Word wrap is enabled by default. Text wraps at word boundaries when it exceeds the available width:

--- a/docs/concepts/terminal-input-modes.md
+++ b/docs/concepts/terminal-input-modes.md
@@ -113,6 +113,18 @@ Termina can negotiate kitty keyboard protocol flags during app startup:
 
 Use `ReportAllKeys` or `ReportAllKeysPlusDisambiguate` when you want the parser to treat real arrows and wheel ticks as structurally distinct byte streams under alternate-scroll.
 
+## Input capability result
+
+Termina queries the active Kitty flags after it requests a keyboard mode. A primary device
+attributes response closes the query. The result does not depend on a terminal name.
+
+Subscribe to `TerminalInputCapabilitiesChanged` through the normal input event stream. The
+`ModifiedEnterKeySupport` value tells the application whether modified Enter keys remain distinct.
+`TerminaApplication.InputCapabilities` contains the latest result.
+
+Windows console records preserve modifiers without Kitty. Termina reports that native path as
+available. A legacy byte path reports unavailable when the terminal does not answer the Kitty query.
+
 ### `CtrlCHandlingMode`
 
 `DoublePressWhenRawInput` is the default.

--- a/src/Termina/Input/EscapeSequenceParser.cs
+++ b/src/Termina/Input/EscapeSequenceParser.cs
@@ -183,6 +183,24 @@ internal sealed class EscapeSequenceParser
                 _seqBuffer.Append(key.KeyChar);
                 var seq = new InputSequence(_seqBuffer.ToString());
 
+                if (key.KeyChar == 'u'
+                    && TerminalCapabilityResponseDecoder.TryDecodeKeyboardFlags(seq, out var keyboardFlags))
+                {
+                    results.Add(new KittyKeyboardFlagsReported(keyboardFlags));
+                    _seqBuffer.Clear();
+                    _state = State.Normal;
+                    break;
+                }
+
+                if (key.KeyChar == 'c'
+                    && TerminalCapabilityResponseDecoder.IsPrimaryDeviceAttributes(seq))
+                {
+                    results.Add(new PrimaryDeviceAttributesReported());
+                    _seqBuffer.Clear();
+                    _state = State.Normal;
+                    break;
+                }
+
                 // Bracketed paste start: ESC[200~
                 if (BracketedPasteDecoder.IsStartSequence(seq))
                 {
@@ -267,7 +285,8 @@ internal sealed class EscapeSequenceParser
                 }
 
                 // If this sequence can no longer match any recognized pattern, flush as raw keys
-                if (!UnknownSequenceFallbackDecoder.CouldLeadToRecognizedSequence(seq))
+                if (!TerminalCapabilityResponseDecoder.CouldBeResponse(seq)
+                    && !UnknownSequenceFallbackDecoder.CouldLeadToRecognizedSequence(seq))
                 {
                     UnknownSequenceFallbackDecoder.AppendRawKeyEvents(seq.Text, results);
                     _seqBuffer.Clear();

--- a/src/Termina/Input/TerminalCapabilityResponseDecoder.cs
+++ b/src/Termina/Input/TerminalCapabilityResponseDecoder.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Decodes terminal responses which close the Kitty keyboard capability probe.
+/// </summary>
+internal static class TerminalCapabilityResponseDecoder
+{
+    public static bool CouldBeResponse(InputSequence sequence)
+    {
+        var text = sequence.Text;
+        if (!text.StartsWith("[?", StringComparison.Ordinal) || text.Length > 32)
+            return false;
+
+        return ContainsOnlyParameters(text.AsSpan(2));
+    }
+
+    public static bool TryDecodeKeyboardFlags(InputSequence sequence, out int flags)
+    {
+        flags = 0;
+        var text = sequence.Text;
+        return text.Length >= 4
+               && text.StartsWith("[?", StringComparison.Ordinal)
+               && text[^1] == 'u'
+               && int.TryParse(text.AsSpan(2, text.Length - 3), out flags);
+    }
+
+    public static bool IsPrimaryDeviceAttributes(InputSequence sequence)
+    {
+        var text = sequence.Text;
+        if (text.Length < 3
+            || !text.StartsWith("[?", StringComparison.Ordinal)
+            || text[^1] != 'c')
+            return false;
+
+        var attributes = text.AsSpan(2, text.Length - 3);
+        return ContainsOnlyParameters(attributes);
+    }
+
+    private static bool ContainsOnlyParameters(ReadOnlySpan<char> value)
+    {
+        foreach (var character in value)
+        {
+            if (!char.IsAsciiDigit(character) && character != ';')
+                return false;
+        }
+
+        return true;
+    }
+}
+
+internal sealed record KittyKeyboardFlagsReported(int Flags) : IInputEvent;
+
+internal sealed record PrimaryDeviceAttributesReported : IInputEvent;

--- a/src/Termina/Input/TerminalInputCapabilities.cs
+++ b/src/Termina/Input/TerminalInputCapabilities.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+namespace Termina.Input;
+
+/// <summary>
+/// Describes whether the active input path preserves modifiers on the Enter key.
+/// </summary>
+public enum TerminalCapabilityAvailability
+{
+    /// <summary>
+    /// The input path has not supplied a conclusive result.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The input path preserves modified Enter keys.
+    /// </summary>
+    Available,
+
+    /// <summary>
+    /// The input path cannot distinguish modified Enter keys from bare Enter.
+    /// </summary>
+    Unavailable,
+}
+
+/// <summary>
+/// Identifies the source of a terminal input capability result.
+/// </summary>
+public enum TerminalInputCapabilitySource
+{
+    /// <summary>
+    /// No input path has supplied a result.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// A native console input record preserves key modifiers.
+    /// </summary>
+    NativeConsole,
+
+    /// <summary>
+    /// The Kitty keyboard protocol reported its active flags.
+    /// </summary>
+    KittyKeyboardProtocol,
+
+    /// <summary>
+    /// The active terminal uses a legacy byte input path.
+    /// </summary>
+    LegacyTerminal,
+
+    /// <summary>
+    /// The application supplied its own input source.
+    /// </summary>
+    CustomInput,
+}
+
+/// <summary>
+/// Describes capabilities of the active terminal input path.
+/// </summary>
+/// <param name="ModifiedEnterKeySupport">Whether the path preserves modifiers on Enter.</param>
+/// <param name="Source">The source of the capability result.</param>
+public readonly record struct TerminalInputCapabilities(
+    TerminalCapabilityAvailability ModifiedEnterKeySupport,
+    TerminalInputCapabilitySource Source);
+
+/// <summary>
+/// Reports a change to the active terminal input capabilities.
+/// </summary>
+/// <param name="Capabilities">The current capabilities.</param>
+public sealed record TerminalInputCapabilitiesChanged(TerminalInputCapabilities Capabilities) : IInputEvent;
+

--- a/src/Termina/Platform/KittyKeyboardEnhancement.cs
+++ b/src/Termina/Platform/KittyKeyboardEnhancement.cs
@@ -53,6 +53,30 @@ internal static class KittyKeyboardEnhancement
     }
 
     /// <summary>
+    /// Queries active keyboard flags and then requests primary device attributes.
+    /// </summary>
+    /// <remarks>
+    /// A compatible terminal returns keyboard flags before device attributes.
+    /// An incompatible terminal returns only device attributes.
+    /// </remarks>
+    public static bool TryQuery(object traceSource)
+    {
+        try
+        {
+            Console.Out.Write(AnsiCodes.QueryKittyKeyboard);
+            Console.Out.Write(AnsiCodes.RequestPrimaryDeviceAttributes);
+            Console.Out.Flush();
+            TerminaTrace.Platform.Info(traceSource, "Queried kitty keyboard support");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            TerminaTrace.Platform.Error(traceSource, "Failed to query kitty keyboard support: {0}", ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Pops the kitty enhancement from the terminal's per-screen stack by writing
     /// <c>CSI &lt; u</c>. Safe to call on shutdown / restore paths; swallows failures.
     /// </summary>

--- a/src/Termina/Platform/TerminalCapabilities.cs
+++ b/src/Termina/Platform/TerminalCapabilities.cs
@@ -10,4 +10,10 @@ namespace Termina.Platform;
 /// True when the console is delivering raw bytes to the parser rather than relying on
 /// <see cref="Console.ReadKey(bool)"/> or other cooked input handling.
 /// </param>
-public readonly record struct TerminalCapabilities(bool RawInputActive);
+public readonly record struct TerminalCapabilities(bool RawInputActive)
+{
+    /// <summary>
+    /// Gets whether the platform input path preserves key modifiers without a terminal protocol.
+    /// </summary>
+    public bool PreservesKeyModifiers { get; init; }
+}

--- a/src/Termina/Platform/WindowsConsole.cs
+++ b/src/Termina/Platform/WindowsConsole.cs
@@ -248,7 +248,10 @@ public sealed class WindowsConsole : IPlatformConsole
     public Observable<ConsoleResizeEvent> Resized => _resized;
 
     /// <inheritdoc />
-    public TerminalCapabilities Capabilities => new(RawInputActive: _rawVtMode);
+    public TerminalCapabilities Capabilities => new(RawInputActive: _rawVtMode)
+    {
+        PreservesKeyModifiers = !_rawVtMode,
+    };
 
     /// <inheritdoc />
     public void Initialize()

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -70,6 +70,9 @@ public sealed class TerminaApplication : IInlineOutput
     private bool _mouseEnabledByApp;
     private bool _wheelScrollEnabledByApp;
     private int _pendingNavigationRequests;
+    private TerminalInputCapabilities _inputCapabilities = new(
+        TerminalCapabilityAvailability.Unknown,
+        TerminalInputCapabilitySource.None);
 
     /// <summary>
     /// Creates a new Termina application.
@@ -167,6 +170,11 @@ public sealed class TerminaApplication : IInlineOutput
     /// Observable stream of input events. ViewModels subscribe to this.
     /// </summary>
     public Observable<IInputEvent> Input => _inputSubject.AsObservable();
+
+    /// <summary>
+    /// Gets the latest capabilities of the active terminal input path.
+    /// </summary>
+    public TerminalInputCapabilities InputCapabilities => _inputCapabilities;
 
     /// <summary>
     /// Gets the R3 frame provider bound to this application's render loop.
@@ -584,11 +592,18 @@ public sealed class TerminaApplication : IInlineOutput
 
             var kittyFlags = GetKittyKeyboardFlags();
             var kittyReportAllKeysVisible = _rawInputActive && (kittyFlags & 8) != 0;
+            _inputCapabilities = InitialInputCapabilities(platformConsole.Capabilities, kittyFlags);
 
             _inputSources.Add(new PlatformInputSource(
                 platformConsole,
                 new PlatformInputConfiguration(_rawInputActive, kittyReportAllKeysVisible)));
             TerminaTrace.Input.Debug(this, "Added PlatformInputSource");
+        }
+        else
+        {
+            _inputCapabilities = new TerminalInputCapabilities(
+                TerminalCapabilityAvailability.Unknown,
+                TerminalInputCapabilitySource.CustomInput);
         }
 
         // Create linked token - cancelled by either external token OR Shutdown()
@@ -604,7 +619,6 @@ public sealed class TerminaApplication : IInlineOutput
             .ToList();
 
         TerminaTrace.Input.Debug(this, "Input tasks started, count={0}", inputTasks.Count);
-
         try
         {
             try
@@ -634,6 +648,17 @@ public sealed class TerminaApplication : IInlineOutput
 
                 var kittyFlags = GetKittyKeyboardFlags();
                 _kittyKeyboardPushed = KittyKeyboardEnhancement.TryEnter(this, kittyFlags, inTmux);
+                if (_rawInputActive && kittyFlags > 0)
+                {
+                    if (!_kittyKeyboardPushed || !KittyKeyboardEnhancement.TryQuery(this))
+                    {
+                        _inputCapabilities = new TerminalInputCapabilities(
+                            TerminalCapabilityAvailability.Unavailable,
+                            TerminalInputCapabilitySource.LegacyTerminal);
+                    }
+                }
+
+                _inputSubject.OnNext(new TerminalInputCapabilitiesChanged(_inputCapabilities));
 
                 if (_runtimeOptions.ScrollInputMode == ScrollInputMode.AlternateScroll && _rawInputActive)
                 {
@@ -774,6 +799,29 @@ public sealed class TerminaApplication : IInlineOutput
         // Handle system events
         switch (evt)
         {
+            case KittyKeyboardFlagsReported keyboardFlags:
+                var supportsModifiedEnter = (keyboardFlags.Flags & 9) != 0;
+                PublishInputCapabilities(new TerminalInputCapabilities(
+                    supportsModifiedEnter
+                        ? TerminalCapabilityAvailability.Available
+                        : TerminalCapabilityAvailability.Unavailable,
+                    TerminalInputCapabilitySource.KittyKeyboardProtocol));
+                return;
+
+            case PrimaryDeviceAttributesReported:
+                if (_inputCapabilities.ModifiedEnterKeySupport == TerminalCapabilityAvailability.Unknown
+                    && _inputCapabilities.Source == TerminalInputCapabilitySource.KittyKeyboardProtocol)
+                {
+                    PublishInputCapabilities(new TerminalInputCapabilities(
+                        TerminalCapabilityAvailability.Unavailable,
+                        TerminalInputCapabilitySource.LegacyTerminal));
+                }
+                return;
+
+            case TerminalInputCapabilitiesChanged capabilitiesChanged:
+                _inputCapabilities = capabilitiesChanged.Capabilities;
+                break;
+
             case ShutdownRequested:
                 TerminaTrace.Page.Info(this, "ShutdownRequested received");
                 Shutdown();
@@ -971,6 +1019,35 @@ public sealed class TerminaApplication : IInlineOutput
     }
 
     private int GetKittyKeyboardFlags() => (int)_runtimeOptions.KittyKeyboardMode;
+
+    private static TerminalInputCapabilities InitialInputCapabilities(
+        TerminalCapabilities platformCapabilities,
+        int kittyFlags)
+    {
+        if (platformCapabilities.PreservesKeyModifiers)
+        {
+            return new TerminalInputCapabilities(
+                TerminalCapabilityAvailability.Available,
+                TerminalInputCapabilitySource.NativeConsole);
+        }
+
+        return kittyFlags > 0 && platformCapabilities.RawInputActive
+            ? new TerminalInputCapabilities(
+                TerminalCapabilityAvailability.Unknown,
+                TerminalInputCapabilitySource.KittyKeyboardProtocol)
+            : new TerminalInputCapabilities(
+                TerminalCapabilityAvailability.Unavailable,
+                TerminalInputCapabilitySource.LegacyTerminal);
+    }
+
+    private void PublishInputCapabilities(TerminalInputCapabilities capabilities)
+    {
+        if (_inputCapabilities == capabilities)
+            return;
+
+        _inputCapabilities = capabilities;
+        _inputSubject.OnNext(new TerminalInputCapabilitiesChanged(capabilities));
+    }
 
     private static void ValidateRuntimeOptions(TerminaRuntimeOptions options)
     {

--- a/src/Termina/Terminal/AnsiCodes.cs
+++ b/src/Termina/Terminal/AnsiCodes.cs
@@ -238,6 +238,16 @@ public static class AnsiCodes
     public static string EnableKittyKeyboard(int flags) => $"{Csi}>{flags}u";
 
     /// <summary>
+    /// Query the active kitty keyboard protocol flags. Format: CSI ? u
+    /// </summary>
+    internal const string QueryKittyKeyboard = $"{Csi}?u";
+
+    /// <summary>
+    /// Request primary device attributes. Format: CSI c
+    /// </summary>
+    internal const string RequestPrimaryDeviceAttributes = $"{Csi}c";
+
+    /// <summary>
     /// Pop the kitty keyboard protocol flag stack, restoring the terminal's
     /// previous keyboard mode. Format: CSI &lt; u
     /// </summary>

--- a/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
+++ b/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
@@ -30,6 +30,7 @@ namespace Termina
         public string? CurrentPath { get; }
         public Termina.Input.IFocusManager Focus { get; }
         public R3.Observable<Termina.Input.IInputEvent> Input { get; }
+        public Termina.Input.TerminalInputCapabilities InputCapabilities { get; }
         public R3.FrameProvider RenderFrameProvider { get; }
         public Termina.TerminaApplication AddInputSource(Termina.Input.IInputSource inputSource) { }
         public System.Threading.Tasks.ValueTask CommitAsync(Termina.Layout.ILayoutNode content, System.Threading.CancellationToken cancellationToken) { }
@@ -541,6 +542,31 @@ namespace Termina.Input
         public ResizeEvent(int Width, int Height) { }
         public int Height { get; init; }
         public int Width { get; init; }
+    }
+    public enum TerminalCapabilityAvailability
+    {
+        Unknown = 0,
+        Available = 1,
+        Unavailable = 2,
+    }
+    public readonly struct TerminalInputCapabilities : System.IEquatable<Termina.Input.TerminalInputCapabilities>
+    {
+        public TerminalInputCapabilities(Termina.Input.TerminalCapabilityAvailability ModifiedEnterKeySupport, Termina.Input.TerminalInputCapabilitySource Source) { }
+        public Termina.Input.TerminalCapabilityAvailability ModifiedEnterKeySupport { get; init; }
+        public Termina.Input.TerminalInputCapabilitySource Source { get; init; }
+    }
+    public sealed class TerminalInputCapabilitiesChanged : System.IEquatable<Termina.Input.TerminalInputCapabilitiesChanged>, Termina.Input.IInputEvent
+    {
+        public TerminalInputCapabilitiesChanged(Termina.Input.TerminalInputCapabilities Capabilities) { }
+        public Termina.Input.TerminalInputCapabilities Capabilities { get; init; }
+    }
+    public enum TerminalInputCapabilitySource
+    {
+        None = 0,
+        NativeConsole = 1,
+        KittyKeyboardProtocol = 2,
+        LegacyTerminal = 3,
+        CustomInput = 4,
     }
     public sealed class VirtualInputSource : Termina.Input.IInputSource
     {
@@ -1683,6 +1709,7 @@ namespace Termina.Platform
     public readonly struct TerminalCapabilities : System.IEquatable<Termina.Platform.TerminalCapabilities>
     {
         public TerminalCapabilities(bool RawInputActive) { }
+        public bool PreservesKeyModifiers { get; init; }
         public bool RawInputActive { get; init; }
     }
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]

--- a/tests/Termina.Tests/Hosting/TerminaRuntimeOptionsTests.cs
+++ b/tests/Termina.Tests/Hosting/TerminaRuntimeOptionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using R3;
 using Termina.Hosting;
 using Termina.Input;
 using Termina.Layout;
@@ -239,6 +240,50 @@ public class TerminaRuntimeOptionsTests
     }
 
     [Fact]
+    public void ProcessEvent_KittyFlagReportMarksModifiedEnterAvailable()
+    {
+        var app = CreateApp(new VirtualTerminal(), new TerminaRuntimeOptions());
+        var changes = new List<TerminalInputCapabilitiesChanged>();
+        using var subscription = app.Input
+            .OfType<IInputEvent, TerminalInputCapabilitiesChanged>()
+            .Subscribe(changes.Add);
+        SetInputCapabilities(app, new TerminalInputCapabilities(
+            TerminalCapabilityAvailability.Unknown,
+            TerminalInputCapabilitySource.KittyKeyboardProtocol));
+
+        InvokeProcessEvent(app, new KittyKeyboardFlagsReported(9));
+
+        Assert.Equal(
+            new TerminalInputCapabilities(
+                TerminalCapabilityAvailability.Available,
+                TerminalInputCapabilitySource.KittyKeyboardProtocol),
+            app.InputCapabilities);
+        Assert.Equal(app.InputCapabilities, Assert.Single(changes).Capabilities);
+    }
+
+    [Fact]
+    public void ProcessEvent_DeviceAttributesWithoutKittyReportMarksModifiedEnterUnavailable()
+    {
+        var app = CreateApp(new VirtualTerminal(), new TerminaRuntimeOptions());
+        var changes = new List<TerminalInputCapabilitiesChanged>();
+        using var subscription = app.Input
+            .OfType<IInputEvent, TerminalInputCapabilitiesChanged>()
+            .Subscribe(changes.Add);
+        SetInputCapabilities(app, new TerminalInputCapabilities(
+            TerminalCapabilityAvailability.Unknown,
+            TerminalInputCapabilitySource.KittyKeyboardProtocol));
+
+        InvokeProcessEvent(app, new PrimaryDeviceAttributesReported());
+
+        Assert.Equal(
+            new TerminalInputCapabilities(
+                TerminalCapabilityAvailability.Unavailable,
+                TerminalInputCapabilitySource.LegacyTerminal),
+            app.InputCapabilities);
+        Assert.Equal(app.InputCapabilities, Assert.Single(changes).Capabilities);
+    }
+
+    [Fact]
     public void EscapeSequenceParser_CsiArrowIsKeyBeforeDeckmConfirmed_AndKeyWithKitty()
     {
         // Without DECCKM confirmed, CSI A is a keyboard arrow.
@@ -286,6 +331,16 @@ public class TerminaRuntimeOptionsTests
     {
         var field = typeof(TerminaApplication).GetField(
             "_rawInputActive",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.NotNull(field);
+        field!.SetValue(app, value);
+    }
+
+    private static void SetInputCapabilities(TerminaApplication app, TerminalInputCapabilities value)
+    {
+        var field = typeof(TerminaApplication).GetField(
+            "_inputCapabilities",
             BindingFlags.NonPublic | BindingFlags.Instance);
 
         Assert.NotNull(field);

--- a/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
@@ -356,6 +356,31 @@ public class EscapeSequenceParserTests
     }
 
     [Fact]
+    public void KittyKeyboardFlagResponse_EmitsCapabilityReport()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[?9u"));
+
+        var report = Assert.IsType<KittyKeyboardFlagsReported>(Assert.Single(events));
+        Assert.Equal(9, report.Flags);
+        Assert.False(parser.IsBufferingEscape);
+    }
+
+    [Fact]
+    public void PrimaryDeviceAttributesResponse_ClosesCapabilityProbe()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = new List<IInputEvent>();
+        events.AddRange(parser.Process(EscKey()));
+        events.AddRange(FeedString(parser, "[?1;2c"));
+
+        Assert.IsType<PrimaryDeviceAttributesReported>(Assert.Single(events));
+        Assert.False(parser.IsBufferingEscape);
+    }
+
+    [Fact]
     public void CsiU_CtrlEnter_InsertsNewlineInTextAreaNode()
     {
         // End-to-end: CSI u Ctrl+Enter should insert a newline in a TextAreaNode


### PR DESCRIPTION
Closes #240.

This change adds an input capability result for modified Enter keys.

- Termina queries active Kitty keyboard flags.
- A device-attributes response closes the probe without a timer.
- Windows console records report native modifier support.
- Applications receive `TerminalInputCapabilitiesChanged` through the current input stream.
- `TerminaApplication.InputCapabilities` exposes the latest result.
- Existing public constructors and default behavior remain unchanged.

Validation:

- 1,702 Termina tests passed.
- The public API approval test passed.
- Slopwatch found no new violations against clean `origin/dev`.
- `git diff --check` passed.