### PR TITLE
Add prompt history cancellation and pointer wheel routing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,8 +10,17 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.17.0-beta.3</VersionPrefix>
+    <VersionPrefix>0.17.0-beta.4</VersionPrefix>
     <PackageReleaseNotes>**New Features**
+
+- **Added prompt history cancellation** ([#368](https://github.com/Aaronontheweb/termina/issues/368))
+  - `CancelHistoryNavigation` restores the draft that existed before history navigation.
+  - The API resets history navigation without a change to current method signatures.
+
+- **Added pointer-aware wheel routing** ([#240](https://github.com/Aaronontheweb/termina/issues/240))
+  - `MouseScrollEvent` preserves zero-based pointer coordinates and keyboard modifiers.
+  - Termina routes wheel input to the measured scroll region under the pointer.
+  - `ScrollableContainerNode` now implements the current `IScrollable` contract.
 
 - **Added a modified Enter key capability result** ([#240](https://github.com/Aaronontheweb/termina/issues/240))
   - Termina queries active Kitty keyboard flags without a terminal-name guess.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,19 @@
-# Release Notes — Termina 0.17.0-beta.3
+# Release Notes — Termina 0.17.0-beta.4
 
 **Release date:** 2026-08-11
 
 ####
 
 **New Features**
+
+- **Added prompt history cancellation** ([#368](https://github.com/Aaronontheweb/termina/issues/368))
+  - `CancelHistoryNavigation` restores the draft that existed before history navigation.
+  - The API resets history navigation without a change to current method signatures.
+
+- **Added pointer-aware wheel routing** ([#240](https://github.com/Aaronontheweb/termina/issues/240))
+  - `MouseScrollEvent` preserves zero-based pointer coordinates and keyboard modifiers.
+  - Termina routes wheel input to the measured scroll region under the pointer.
+  - `ScrollableContainerNode` now implements the current `IScrollable` contract.
 
 - **Added a modified Enter key capability result** ([#240](https://github.com/Aaronontheweb/termina/issues/240))
   - Termina queries active Kitty keyboard flags without a terminal-name guess.

--- a/docs/components/text-area-node.md
+++ b/docs/components/text-area-node.md
@@ -129,6 +129,17 @@ var textArea = new TextAreaNode()
     .WithHistory(maxEntries: 20);
 ```
 
+Cancel active history navigation to restore the saved draft:
+
+```csharp
+if (textArea.CancelHistoryNavigation())
+{
+    // The draft now contains the text from before the first Up key.
+}
+```
+
+The method returns `false` when no history navigation is active.
+
 ## Paste Handling
 
 Paste behavior is identical to `TextInputNode` — both use the shared `TextInputBaseNode` logic:
@@ -224,6 +235,7 @@ Text areas attached to a page layout tree receive runtime context automatically,
 | `HandlePaste(PasteEvent)` | Handle pasted content (shared base class logic) |
 | `Clear()` | Clear text and reset cursor |
 | `AddHistory(string)` | Programmatically add a history entry |
+| `CancelHistoryNavigation()` | Cancel history navigation and restore the saved draft |
 | `Start()` | Start cursor animation |
 | `Stop()` | Stop cursor animation |
 

--- a/docs/concepts/terminal-input-modes.md
+++ b/docs/concepts/terminal-input-modes.md
@@ -101,6 +101,17 @@ If raw input is requested on Unix and stdin is not a TTY, Termina falls back cle
 - leaves wheel input and native selection under terminal control
 - does not emit `MouseScrollEvent` values
 
+### Pointer-aware wheel routing
+
+SGR wheel input adds zero-based `X` and `Y` values to `MouseScrollEvent`.
+The values remain `null` when the input protocol does not report a position.
+
+Termina routes a positioned wheel event to the measured scroll region under the pointer.
+If no region matches, Termina uses the focused `IScrollable` component.
+
+`StreamingTextNode` and `ScrollableContainerNode` implement `IScrollable`.
+Their scroll operations use the dimensions from the most recent render pass.
+
 ### `KittyKeyboardMode`
 
 Termina can negotiate kitty keyboard protocol flags during app startup:

--- a/src/Termina/Input/MouseScrollEvent.cs
+++ b/src/Termina/Input/MouseScrollEvent.cs
@@ -17,4 +17,20 @@ namespace Termina.Input;
 /// Negative values indicate scrolling down (toward newer/later content).
 /// Each wheel tick typically has a magnitude of 1.
 /// </param>
-public sealed record MouseScrollEvent(int Delta) : IInputEvent;
+public sealed record MouseScrollEvent(int Delta) : IInputEvent
+{
+    /// <summary>
+    /// Gets the zero-based screen column for the wheel event when the terminal reports it.
+    /// </summary>
+    public int? X { get; init; }
+
+    /// <summary>
+    /// Gets the zero-based screen row for the wheel event when the terminal reports it.
+    /// </summary>
+    public int? Y { get; init; }
+
+    /// <summary>
+    /// Gets the keyboard modifiers that accompanied the wheel event.
+    /// </summary>
+    public ConsoleModifiers Modifiers { get; init; }
+}

--- a/src/Termina/Input/Semantic/PublicInputEventAdapter.cs
+++ b/src/Termina/Input/Semantic/PublicInputEventAdapter.cs
@@ -64,8 +64,8 @@ internal static class PublicInputEventAdapter
         {
             return pointerInput.Button switch
             {
-                MouseButton.WheelUp => [new MouseScrollEvent(+1)],
-                MouseButton.WheelDown => [new MouseScrollEvent(-1)],
+                MouseButton.WheelUp => [CreateMouseScrollEvent(+1, pointerInput)],
+                MouseButton.WheelDown => [CreateMouseScrollEvent(-1, pointerInput)],
                 _ => [],
             };
         }
@@ -77,6 +77,13 @@ internal static class PublicInputEventAdapter
             pointerInput.Action.ToMouseEventType(),
             pointerInput.Modifiers.ToConsoleModifiers())];
     }
+
+    private static MouseScrollEvent CreateMouseScrollEvent(int delta, PointerInput pointerInput) => new(delta)
+    {
+        X = pointerInput.X > 0 ? pointerInput.X - 1 : null,
+        Y = pointerInput.Y > 0 ? pointerInput.Y - 1 : null,
+        Modifiers = pointerInput.Modifiers.ToConsoleModifiers(),
+    };
 
     private static char KeyCharFromAssociatedText(string? text, TerminaKey key) =>
         string.IsNullOrEmpty(text) ? DefaultKeyChar(key) : text[0];

--- a/src/Termina/Layout/IScrollable.cs
+++ b/src/Termina/Layout/IScrollable.cs
@@ -39,3 +39,8 @@ public interface IScrollable
     /// <param name="lines">Number of lines to scroll. Defaults to 1.</param>
     void ScrollDown(int lines = 1);
 }
+
+internal interface IPointerScrollable : IScrollable
+{
+    ScreenBounds LastRenderedBounds { get; }
+}

--- a/src/Termina/Layout/ScrollableContainerNode.cs
+++ b/src/Termina/Layout/ScrollableContainerNode.cs
@@ -33,13 +33,14 @@ public enum AutoScrollPolicy
 /// A layout node that provides vertical scrolling for content that exceeds the viewport.
 /// Manages scroll position state internally.
 /// </summary>
-public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
+public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode, IScrollable, IPointerScrollable
 {
     private ILayoutNode _content = new EmptyNode();
     private int _scrollOffset;
     private int _contentHeight;
     private int _viewportHeight;
     private int _previousContentHeight;
+    private ScreenBounds _lastRenderedBounds = ScreenBounds.Empty;
     private readonly Subject<Unit> _invalidated = new();
     private IDisposable? _contentSubscription;
 
@@ -95,6 +96,8 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     /// Gets whether the view is at or near the bottom (within a few lines).
     /// </summary>
     public bool IsNearBottom => _scrollOffset >= MaxScroll - 2;
+
+    ScreenBounds IPointerScrollable.LastRenderedBounds => _lastRenderedBounds;
 
     /// <summary>
     /// Set the content to scroll.
@@ -169,6 +172,10 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
             _invalidated.OnNext(Unit.Default);
         }
     }
+
+    void IScrollable.ScrollDown(int lines) => ScrollTo(_scrollOffset + Math.Max(0, lines));
+
+    void IScrollable.ScrollUp(int lines) => ScrollTo(_scrollOffset - Math.Max(0, lines));
 
     /// <summary>
     /// Scroll down by a page.
@@ -294,6 +301,10 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     /// <inheritdoc />
     public override void Render(IRenderContext context, Rect bounds)
     {
+        _lastRenderedBounds = context is IScreenPositionedRenderContext positioned
+            ? positioned.GetScreenBounds(bounds)
+            : ScreenBounds.Empty;
+
         if (!bounds.HasArea)
             return;
 
@@ -370,7 +381,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
     /// <summary>
     /// A render context that applies vertical scroll offset.
     /// </summary>
-    private sealed class ScrolledRenderContext : IRenderContext
+    private sealed class ScrolledRenderContext : IRenderContext, IScreenPositionedRenderContext
     {
         private readonly IRenderContext _parent;
         private readonly int _offsetX;
@@ -452,6 +463,26 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode
                 _offsetY + clippedY,
                 clippedWidth,
                 clippedHeight);
+        }
+
+        ScreenBounds IScreenPositionedRenderContext.GetScreenBounds(Rect bounds)
+        {
+            var clippedX = Math.Max(0, bounds.X);
+            var clippedY = Math.Max(0, bounds.Y);
+            var clippedRight = Math.Min(Width, bounds.Right);
+            var clippedBottom = Math.Min(_clipHeight, bounds.Bottom);
+
+            if (clippedRight <= clippedX || clippedBottom <= clippedY
+                || _parent is not IScreenPositionedRenderContext positioned)
+            {
+                return ScreenBounds.Empty;
+            }
+
+            return positioned.GetScreenBounds(new Rect(
+                _offsetX + clippedX,
+                _offsetY + clippedY,
+                clippedRight - clippedX,
+                clippedBottom - clippedY));
         }
     }
 }

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -15,7 +15,7 @@ namespace Termina.Layout;
 /// StreamingTextNode wraps an IStreamingTextBuffer (either PersistedStreamBuffer or WindowedStreamBuffer)
 /// and renders the content with automatic word wrapping and optional scrolling.
 /// </remarks>
-public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollable
+public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollable, IPointerScrollable
 {
     private readonly IStreamingTextBuffer _buffer;
     private readonly Subject<Unit> _invalidated = new();
@@ -26,6 +26,7 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
     // Cached viewport dimensions, updated during Render() and used by IScrollable
     private int _lastViewportWidth = 80;
     private int _lastViewportHeight = 24;
+    private ScreenBounds _lastRenderedBounds = ScreenBounds.Empty;
 
     // Tracked segment infrastructure
     private readonly List<ContentElement> _content = new();  // Ordered list of all content
@@ -625,6 +626,8 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
 
     void IScrollable.ScrollDown(int lines) => ScrollDown(lines);
 
+    ScreenBounds IPointerScrollable.LastRenderedBounds => _lastRenderedBounds;
+
     /// <inheritdoc />
     public override Size Measure(Size available)
     {
@@ -636,6 +639,10 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
     /// <inheritdoc />
     public override void Render(IRenderContext context, Rect bounds)
     {
+        _lastRenderedBounds = context is IScreenPositionedRenderContext positioned
+            ? positioned.GetScreenBounds(bounds)
+            : ScreenBounds.Empty;
+
         if (!bounds.HasArea)
             return;
 

--- a/src/Termina/Layout/TextInputBaseNode.cs
+++ b/src/Termina/Layout/TextInputBaseNode.cs
@@ -304,6 +304,22 @@ public abstract class TextInputBaseNode : LayoutNode, IAnimatedNode, IInvalidati
     }
 
     /// <summary>
+    /// Cancels active history navigation and restores the input that existed before navigation started.
+    /// </summary>
+    /// <returns><see langword="true"/> when active history navigation was canceled; otherwise, <see langword="false"/>.</returns>
+    public bool CancelHistoryNavigation()
+    {
+        if (_historyIndex < 0)
+            return false;
+
+        var savedInput = _savedInput ?? "";
+        _historyIndex = -1;
+        _savedInput = null;
+        ApplyHistoryEntry(savedInput);
+        return true;
+    }
+
+    /// <summary>
     /// Clears the text and resets cursor position.
     /// Call this from ViewModel after handling submission.
     /// </summary>

--- a/src/Termina/Rendering/IRenderContext.cs
+++ b/src/Termina/Rendering/IRenderContext.cs
@@ -90,3 +90,8 @@ public interface IRenderContext
     /// <returns>A new render context clipped to the specified bounds.</returns>
     IRenderContext CreateSubContext(Layout.Rect bounds);
 }
+
+internal interface IScreenPositionedRenderContext
+{
+    Layout.ScreenBounds GetScreenBounds(Layout.Rect bounds);
+}

--- a/src/Termina/Rendering/RegionRenderContext.cs
+++ b/src/Termina/Rendering/RegionRenderContext.cs
@@ -9,7 +9,7 @@ namespace Termina.Rendering;
 /// Render context that translates relative coordinates to absolute screen positions.
 /// All rendering is clipped to the region bounds.
 /// </summary>
-public sealed class RegionRenderContext : IRenderContext
+public sealed class RegionRenderContext : IRenderContext, IScreenPositionedRenderContext
 {
     private readonly IAnsiTerminal _terminal;
     private readonly int _offsetX;
@@ -179,5 +179,22 @@ public sealed class RegionRenderContext : IRenderContext
             _offsetY + clippedY,
             clippedWidth,
             clippedHeight);
+    }
+
+    Layout.ScreenBounds IScreenPositionedRenderContext.GetScreenBounds(Layout.Rect bounds)
+    {
+        var clippedX = Math.Max(0, bounds.X);
+        var clippedY = Math.Max(0, bounds.Y);
+        var clippedRight = Math.Min(Width, bounds.Right);
+        var clippedBottom = Math.Min(Height, bounds.Bottom);
+
+        if (clippedRight <= clippedX || clippedBottom <= clippedY)
+            return Layout.ScreenBounds.Empty;
+
+        return new Layout.ScreenBounds(
+            _offsetX + clippedX,
+            _offsetY + clippedY,
+            clippedRight - clippedX,
+            clippedBottom - clippedY);
     }
 }

--- a/src/Termina/TerminaApplication.cs
+++ b/src/Termina/TerminaApplication.cs
@@ -16,6 +16,8 @@ using Termina.Reactive;
 using Termina.Rendering;
 using Termina.Routing;
 using Termina.Terminal;
+using InputMouseButton = Termina.Input.MouseButton;
+using InputMouseEventType = Termina.Input.MouseEventType;
 
 namespace Termina;
 
@@ -885,15 +887,22 @@ public sealed class TerminaApplication : IInlineOutput
 
             case MouseScrollEvent mouseScroll:
                 const int linesPerTick = 3;
-                if (_focusManager.CurrentFocus is IScrollable scrollable)
+                if (RouteMouseScroll(mouseScroll, linesPerTick))
+                    return;
+                break; // No scroll target — fall through to the ViewModel input observable
+
+            case MouseEvent { EventType: InputMouseEventType.Scroll } mouseEvent:
+                var adaptedScroll = new MouseScrollEvent(
+                    mouseEvent.Button == InputMouseButton.WheelUp ? +1 : -1)
                 {
-                    if (mouseScroll.Delta > 0)
-                        scrollable.ScrollUp(linesPerTick);
-                    else
-                        scrollable.ScrollDown(linesPerTick);
-                    return; // Handled by focused scrollable
-                }
-                break; // No focused scrollable — fall through to ViewModel input observable
+                    X = mouseEvent.X,
+                    Y = mouseEvent.Y,
+                    Modifiers = mouseEvent.Modifiers,
+                };
+                if (mouseEvent.Button is InputMouseButton.WheelUp or InputMouseButton.WheelDown
+                    && RouteMouseScroll(adaptedScroll, linesPerTick))
+                    return;
+                break; // Preserve the current public MouseEvent path when no target handles it
         }
 
         // Route input events: Page (capture) -> Focus Manager (bubble) -> ViewModel
@@ -1016,6 +1025,48 @@ public sealed class TerminaApplication : IInlineOutput
             if (found != null) return found;
         }
         return null;
+    }
+
+    private bool RouteMouseScroll(MouseScrollEvent mouseScroll, int linesPerTick)
+    {
+        var scrollable = mouseScroll is { X: { } x, Y: { } y }
+            ? FindScrollableAt(GetCurrentLayoutRoot(), x, y)
+            : null;
+        scrollable ??= _focusManager.CurrentFocus as IScrollable;
+
+        if (scrollable is null)
+            return false;
+
+        if (mouseScroll.Delta > 0)
+            scrollable.ScrollUp(linesPerTick);
+        else if (mouseScroll.Delta < 0)
+            scrollable.ScrollDown(linesPerTick);
+
+        return mouseScroll.Delta != 0;
+    }
+
+    private static IScrollable? FindScrollableAt(ILayoutNode? node, int x, int y)
+    {
+        if (node is null)
+            return null;
+
+        var children = node switch
+        {
+            LayoutNode layoutNode => layoutNode.GetChildNodes(),
+            IContainerNode container => container.Children,
+            _ => Enumerable.Empty<ILayoutNode>()
+        };
+
+        foreach (var child in children.Reverse())
+        {
+            if (FindScrollableAt(child, x, y) is { } childTarget)
+                return childTarget;
+        }
+
+        return node is IPointerScrollable pointerScrollable
+            && pointerScrollable.LastRenderedBounds.Contains(x, y)
+                ? pointerScrollable
+                : null;
     }
 
     private int GetKittyKeyboardFlags() => (int)_runtimeOptions.KittyKeyboardMode;

--- a/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
+++ b/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
@@ -1407,6 +1407,7 @@ namespace Termina.Layout
         public R3.Observable<string> TextChanged { get; }
         public void AddHistory(string entry) { }
         protected void ApplyHistoryEntry(string entry) { }
+        public bool CancelHistoryNavigation() { }
         public virtual void Clear() { }
         protected void DeleteSelection() { }
         public override void Dispose() { }

--- a/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
+++ b/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
@@ -512,6 +512,9 @@ namespace Termina.Input
     {
         public MouseScrollEvent(int Delta) { }
         public int Delta { get; init; }
+        public System.ConsoleModifiers Modifiers { get; init; }
+        public int? X { get; init; }
+        public int? Y { get; init; }
     }
     public sealed class PageKeyBindings
     {
@@ -1103,7 +1106,7 @@ namespace Termina.Layout
         public Termina.Layout.ScreenBounds Intersect(Termina.Layout.ScreenBounds other) { }
         public bool Intersects(Termina.Layout.ScreenBounds other) { }
     }
-    public sealed class ScrollableContainerNode : Termina.Layout.LayoutNode, System.IDisposable, Termina.Layout.IInvalidatingNode, Termina.Layout.ILayoutNode
+    public sealed class ScrollableContainerNode : Termina.Layout.LayoutNode, System.IDisposable, Termina.Layout.IInvalidatingNode, Termina.Layout.ILayoutNode, Termina.Layout.IScrollable
     {
         public ScrollableContainerNode() { }
         public Termina.Layout.AutoScrollPolicy AutoScroll { get; set; }

--- a/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
@@ -75,6 +75,8 @@ public class EscapeSequenceParserTests
         var scroll = Assert.Single(events);
         var mse = Assert.IsType<MouseScrollEvent>(scroll);
         Assert.Equal(+1, mse.Delta);
+        Assert.Equal(4, mse.X);
+        Assert.Equal(9, mse.Y);
     }
 
     [Fact]

--- a/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserTests.cs
@@ -64,6 +64,18 @@ public class EscapeSequenceParserTests
         Assert.IsType<KeyPressed>(events[0]);
     }
 
+    [Fact]
+    public void ConsoleRecord_ShiftEnter_PreservesShiftModifier()
+    {
+        var parser = new EscapeSequenceParser();
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(parser.Process(
+            new ConsoleKeyInfo('\r', ConsoleKey.Enter, shift: true, alt: false, control: false))));
+
+        Assert.Equal(ConsoleKey.Enter, pressed.KeyInfo.Key);
+        Assert.True(pressed.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
+    }
+
     // --- Mouse scroll up (button 64) ---
 
     [Fact]

--- a/tests/Termina.Tests/Input/PublicInputEventAdapterTests.cs
+++ b/tests/Termina.Tests/Input/PublicInputEventAdapterTests.cs
@@ -112,10 +112,14 @@ public class PublicInputEventAdapterTests
             PointerAction.Wheel,
             X: 3,
             Y: 4,
-            button));
+            button,
+            KeyModifiers.Control));
 
         var scroll = Assert.IsType<MouseScrollEvent>(Assert.Single(events));
         Assert.Equal(expectedDelta, scroll.Delta);
+        Assert.Equal(2, scroll.X);
+        Assert.Equal(3, scroll.Y);
+        Assert.Equal(ConsoleModifiers.Control, scroll.Modifiers);
     }
 
     [Fact]

--- a/tests/Termina.Tests/Layout/TextInputNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextInputNodeTests.cs
@@ -314,6 +314,45 @@ public class TextInputNodeTests : IDisposable
     }
 
     [Fact]
+    public void CancelHistoryNavigation_RestoresSavedInput()
+    {
+        using var node = new TextInputNode().WithHistory();
+        node.AddHistory("submitted");
+        TypeText(node, "in-progress");
+
+        PressUp(node);
+
+        Assert.True(node.CancelHistoryNavigation());
+        Assert.Equal("in-progress", node.Text);
+    }
+
+    [Fact]
+    public void CancelHistoryNavigation_ResetsNavigation()
+    {
+        using var node = new TextInputNode().WithHistory();
+        node.AddHistory("first");
+        node.AddHistory("second");
+        TypeText(node, "draft");
+
+        PressUp(node);
+        PressUp(node);
+        node.CancelHistoryNavigation();
+        PressDown(node);
+
+        Assert.Equal("draft", node.Text);
+    }
+
+    [Fact]
+    public void CancelHistoryNavigation_WithoutNavigation_ReturnsFalse()
+    {
+        using var node = new TextInputNode().WithHistory();
+        TypeText(node, "draft");
+
+        Assert.False(node.CancelHistoryNavigation());
+        Assert.Equal("draft", node.Text);
+    }
+
+    [Fact]
     public void History_MaxEntries_EvictsOldest()
     {
         using var node = new TextInputNode().WithHistory(maxEntries: 2);

--- a/tests/Termina.Tests/MouseScrollRoutingTests.cs
+++ b/tests/Termina.Tests/MouseScrollRoutingTests.cs
@@ -3,6 +3,7 @@
 
 using Termina.Input;
 using Termina.Layout;
+using Termina.Reactive;
 using Termina.Rendering;
 using Termina.Terminal;
 
@@ -131,5 +132,126 @@ public class MouseScrollRoutingTests
     {
         var evt = new MouseScrollEvent(-1);
         Assert.True(evt.Delta < 0);
+    }
+
+    [Fact]
+    public void MouseScrollEvent_RoutesToScrollableUnderPointer()
+    {
+        var (app, top, bottom) = CreateScrollApplication();
+        try
+        {
+            var topOffset = top.ScrollOffset;
+            var bottomOffset = bottom.ScrollOffset;
+
+            InvokeProcessEvent(app, new MouseScrollEvent(+1) { X = 2, Y = 2 });
+
+            Assert.Equal(topOffset - 3, top.ScrollOffset);
+            Assert.Equal(bottomOffset, bottom.ScrollOffset);
+        }
+        finally
+        {
+            app.Dispose();
+        }
+    }
+
+    [Fact]
+    public void LegacyMouseScroll_RoutesToScrollableUnderPointer()
+    {
+        var (app, top, bottom) = CreateScrollApplication();
+        try
+        {
+            var topOffset = top.ScrollOffset;
+            var bottomOffset = bottom.ScrollOffset;
+
+            InvokeProcessEvent(app, new MouseEvent(
+                X: 2,
+                Y: 7,
+                MouseButton.WheelUp,
+                MouseEventType.Scroll));
+
+            Assert.Equal(topOffset, top.ScrollOffset);
+            Assert.Equal(bottomOffset - 3, bottom.ScrollOffset);
+        }
+        finally
+        {
+            app.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ScrollableContainer_UsesMeasuredViewportThroughIScrollable()
+    {
+        var (app, top, _) = CreateScrollApplication();
+        try
+        {
+            var offset = top.ScrollOffset;
+
+            ((IScrollable)top).ScrollUp(4);
+
+            Assert.Equal(offset - 4, top.ScrollOffset);
+        }
+        finally
+        {
+            app.Dispose();
+        }
+    }
+
+    private static (TerminaApplication App, ScrollableContainerNode Top, ScrollableContainerNode Bottom)
+        CreateScrollApplication()
+    {
+        var top = CreateScrollable("Top");
+        var bottom = CreateScrollable("Bottom");
+        ScrollPage.Root = Layouts.Vertical()
+            .WithChild(top.Height(5))
+            .WithChild(bottom.Height(5));
+
+        var app = new TerminaApplication(new VirtualTerminal(20, 10), new TestServiceProvider());
+        app.RegisterRoute<ScrollPage, ScrollViewModel>("/scroll");
+        app.NavigateTo("/scroll");
+        InvokeRenderCurrentPage(app);
+        return (app, top, bottom);
+    }
+
+    private static ScrollableContainerNode CreateScrollable(string prefix) =>
+        new ScrollableContainerNode()
+            .WithContent(new TextNode(string.Join('\n',
+                Enumerable.Range(0, 20).Select(index => $"{prefix} {index}"))));
+
+    private static void InvokeProcessEvent(TerminaApplication app, object evt)
+    {
+        var method = typeof(TerminaApplication).GetMethod(
+            "ProcessEvent",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        Assert.NotNull(method);
+        method!.Invoke(app, [evt]);
+    }
+
+    private static void InvokeRenderCurrentPage(TerminaApplication app)
+    {
+        var method = typeof(TerminaApplication).GetMethod(
+            "RenderCurrentPage",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        Assert.NotNull(method);
+        method!.Invoke(app, []);
+    }
+
+    private sealed class TestServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => serviceType == typeof(IEnumerable<IInputSource>)
+            ? Array.Empty<IInputSource>()
+            : null;
+    }
+
+    private sealed class ScrollPage : ReactivePage<ScrollViewModel>
+    {
+        public static ILayoutNode Root { get; set; } = new EmptyNode();
+
+        public override ILayoutNode BuildLayout() => Root;
+    }
+
+    private sealed class ScrollViewModel : ReactiveViewModel
+    {
     }
 }

--- a/tests/Termina.Tests/Platform/UnixConsoleByteMappingTests.cs
+++ b/tests/Termina.Tests/Platform/UnixConsoleByteMappingTests.cs
@@ -138,6 +138,19 @@ public class UnixConsoleByteMappingTests
         Assert.Equal(expectedKey, kp.KeyInfo.Key);
     }
 
+    [Fact]
+    public void RawBytes_CsiUShiftEnter_PreservesShiftModifier()
+    {
+        var parser = new EscapeSequenceParser();
+        var events = "\x1b[13;2u"u8.ToArray()
+            .SelectMany(value => parser.Process(RawByteKeyMapper.ByteToKeyInfo(value)))
+            .ToList();
+
+        var pressed = Assert.IsType<KeyPressed>(Assert.Single(events));
+        Assert.Equal(ConsoleKey.Enter, pressed.KeyInfo.Key);
+        Assert.True(pressed.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
+    }
+
     /// <summary>
     /// UTF-8 multi-byte sequences must reassemble into one <see cref="ConsoleKeyInfo"/> per
     /// codepoint when fed through the same decoding logic the reader thread uses.


### PR DESCRIPTION
## Result

Termina now restores saved prompt drafts through an additive history API.
Termina also preserves wheel coordinates and routes input to the region under the pointer.

## Compatibility

- Existing method signatures remain unchanged.
- Existing `MouseScrollEvent(int)` construction remains valid.
- Full-screen and inline defaults remain unchanged.
- `ScrollableContainerNode` now implements the current `IScrollable` contract.

## Proof

- 1,710 Termina tests pass.
- Console-record, raw-byte, and Kitty modified Enter paths have direct tests.
- The public API approval test passes.
- The changed files pass `dotnet format --verify-no-changes`.
- Slopwatch reports no new findings against `origin/dev`.
- The docs build passes.
- A local `0.17.0-beta.4` package build passes.

Closes #368.
Relates to #240 and #366.
