### PR TITLE
Fix text area draft history traversal

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,48 +10,13 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>0.17.0-beta.4</VersionPrefix>
-    <PackageReleaseNotes>**New Features**
+    <VersionPrefix>0.17.0-beta.5</VersionPrefix>
+    <PackageReleaseNotes>**Bug Fixes**
 
-- **Added prompt history cancellation** ([#368](https://github.com/Aaronontheweb/termina/issues/368))
-  - `CancelHistoryNavigation` restores the draft that existed before history navigation.
-  - The API resets history navigation without a change to current method signatures.
-
-- **Added pointer-aware wheel routing** ([#240](https://github.com/Aaronontheweb/termina/issues/240))
-  - `MouseScrollEvent` preserves zero-based pointer coordinates and keyboard modifiers.
-  - Termina routes wheel input to the measured scroll region under the pointer.
-  - `ScrollableContainerNode` now implements the current `IScrollable` contract.
-
-- **Added a modified Enter key capability result** ([#240](https://github.com/Aaronontheweb/termina/issues/240))
-  - Termina queries active Kitty keyboard flags without a terminal-name guess.
-  - `TerminalInputCapabilitiesChanged` reports whether modified Enter keys remain distinct.
-  - Windows console records report native modifier support.
-
-- **Added semantic clipboard content for copyable text**
-  - `WithSemanticContent` separates complete clipboard text from compact display text.
-  - `TryCopy` reports clipboard failure and preserves the current selection.
-
-- **Added an opt-in inline presentation mode** ([#366](https://github.com/Aaronontheweb/termina/issues/366))
-  - `TerminalPresentationMode.Inline` keeps settled output in the primary buffer.
-  - `IInlineOutput` commits stable layouts above one bounded live region.
-  - `ScrollInputMode.NativeTerminal` leaves selection and scrollback under terminal control.
-
-- **Added extend-only terminal control APIs** ([#370](https://github.com/Aaronontheweb/termina/issues/370))
-  - `IInlineTerminalControl` adds relative cursor operations without a change to `IAnsiTerminal`.
-  - `AnsiTerminal` and `VirtualTerminal` implement the new contract.
-  - Full-screen mode remains the default mode.
-
-**Bug Fixes**
-
-- **Restored all terminal and input state after a render failure**
-  - Termina now cancels input tasks before it propagates a render exception.
-  - Termina restores the cursor, mouse modes, keyboard modes, and input mode.
-
-**Compatibility**
-
-- Current enum values and public signatures keep their behavior.
-- The current `AnsiTerminal(bool)` constructor keeps its behavior.
-- An API approval test now prevents accidental contract changes.</PackageReleaseNotes>
+- **Corrected text-area prompt history traversal** ([#368](https://github.com/Aaronontheweb/termina/issues/368))
+  - Up recalls prompt history from the first visual line and saves the current draft.
+  - Down restores the saved draft from the last visual line.
+  - Up and Down keep their current visual movement between multiline rows.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+# Release Notes — Termina 0.17.0-beta.5
+
+**Release date:** 2026-08-11
+
+####
+
+**Bug Fixes**
+
+- **Corrected text-area prompt history traversal** ([#368](https://github.com/Aaronontheweb/termina/issues/368))
+  - Up recalls prompt history from the first visual line and saves the current draft.
+  - Down restores the saved draft from the last visual line.
+  - Up and Down keep their current visual movement between multiline rows.
+
+####
+
 # Release Notes — Termina 0.17.0-beta.4
 
 **Release date:** 2026-08-11

--- a/docs/components/text-area-node.md
+++ b/docs/components/text-area-node.md
@@ -32,7 +32,7 @@ textArea.Submitted.Subscribe(text => Console.WriteLine($"Submitted:\n{text}"));
 | `←/→` | Move cursor |
 | `Ctrl+←/→` | Move by word |
 | `Shift+←/→` | Select text |
-| `↑/↓` | Move between visual lines (or history when text is empty) |
+| `↑/↓` | Move between visual lines, then traverse history at the first or last boundary |
 | `Home` | Start of current visual line |
 | `End` | End of current visual line |
 | `Ctrl+Home` | Start of document |
@@ -122,7 +122,8 @@ When at the limit, Ctrl+Enter is consumed but no newline is inserted.
 
 ## Input History
 
-Like `TextInputNode`, history is opt-in. When the text area is empty, Up/Down navigate history. When there is content, Up/Down navigate between visual lines instead:
+Like `TextInputNode`, history is opt-in. Up and Down move between visual lines first.
+Up recalls history from the first visual line. Down restores the saved draft from the last visual line.
 
 ```csharp
 var textArea = new TextAreaNode()
@@ -179,7 +180,7 @@ new TextAreaNode()
 | **Lines** | Single-line | Multi-line |
 | **Enter** | Submit | Submit |
 | **Newline** | N/A | `Ctrl+Enter` or `Alt+Enter` (configurable) |
-| **Up/Down** | History only | Visual lines (history when empty) |
+| **Up/Down** | History only | Visual lines, then history at the first or last boundary |
 | **Home/End** | Start/end of text | Start/end of visual line |
 | **Multi-line paste** | Summary placeholder | Summary placeholder |
 | **Height** | Fixed 1 row | Auto (1–10 rows, configurable) |

--- a/src/Termina/Layout/TextAreaNode.cs
+++ b/src/Termina/Layout/TextAreaNode.cs
@@ -184,7 +184,10 @@ public sealed class TextAreaNode : TextInputBaseNode
         var (row, col) = GetVisualPosition(displayPos, lines);
 
         if (row == 0)
-            return true; // At top — consume the key
+        {
+            base.HandleUpArrow();
+            return true;
+        }
 
         var previousLine = lines[row - 1];
         var targetCol = Math.Min(col, previousLine.ColumnCount);
@@ -205,7 +208,10 @@ public sealed class TextAreaNode : TextInputBaseNode
         var (row, col) = GetVisualPosition(displayPos, lines);
 
         if (row >= lines.Count - 1)
-            return true; // At bottom — consume the key
+        {
+            base.HandleDownArrow();
+            return true;
+        }
 
         var nextLine = lines[row + 1];
         var targetCol = Math.Min(col, nextLine.ColumnCount);

--- a/tests/Termina.Tests/Layout/TextAreaNodeTests.cs
+++ b/tests/Termina.Tests/Layout/TextAreaNodeTests.cs
@@ -403,7 +403,7 @@ public class TextAreaNodeTests : IDisposable
 
     #endregion
 
-    #region Up/Down History (when empty)
+    #region Up/Down History
 
     [Fact]
     public void UpArrow_WhenEmpty_NoHistory_ReturnsFalse()
@@ -445,6 +445,37 @@ public class TextAreaNodeTests : IDisposable
         // Down arrow with empty text and history enabled — should consume the key
         var handled = node.HandleInput(new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false));
         Assert.True(handled);
+    }
+
+    [Fact]
+    public void UpArrow_AtTop_WithHistory_RecallsEntryAndSavesDraft()
+    {
+        using var node = new TextAreaNode().WithHistory();
+
+        TypeText(node, "previous entry");
+        Submit(node);
+        node.Clear();
+        TypeText(node, "saved draft");
+
+        PressUpArrow(node);
+
+        Assert.Equal("previous entry", node.Text);
+    }
+
+    [Fact]
+    public void DownArrow_AtBottom_AfterHistoryRecall_RestoresDraft()
+    {
+        using var node = new TextAreaNode().WithHistory();
+
+        TypeText(node, "previous entry");
+        Submit(node);
+        node.Clear();
+        TypeText(node, "saved draft");
+        PressUpArrow(node);
+
+        PressDownArrow(node);
+
+        Assert.Equal("saved draft", node.Text);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- route Up to prompt history at the first visual line
- route Down to prompt history at the last visual line
- preserve visual row movement inside multiline text
- add direct draft recall and restoration tests
- prepare `0.17.0-beta.5`

Closes #368

## Proof

- `dotnet test Termina.slnx --no-restore`: 1,712 passed
- focused `TextAreaNodeTests`: 62 passed
- Slopwatch: zero new findings
- `dotnet format` for changed C# files: passed
- docs build: passed
- local beta.5 package creation: passed

A disposable Netclaw tape found this defect against the Spark inference endpoint. A corrected tape will validate the package after publication.
