### PR TITLE
Fix tail follow after large content updates

### DIFF
--- a/src/Termina/Layout/ScrollableContainerNode.cs
+++ b/src/Termina/Layout/ScrollableContainerNode.cs
@@ -239,7 +239,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode, ISc
         _invalidated.OnNext(Unit.Default);
     }
 
-    private void ApplyAutoScrollPolicy()
+    private void ApplyAutoScrollPolicy(bool? wasNearBottom = null)
     {
         switch (AutoScroll)
         {
@@ -248,7 +248,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode, ISc
                 break;
             case AutoScrollPolicy.TailWhenAtBottom:
                 // If we were at or near the bottom before, stay at the bottom
-                if (IsNearBottom || _previousContentHeight <= _viewportHeight)
+                if ((wasNearBottom ?? IsNearBottom) || _previousContentHeight <= _viewportHeight)
                 {
                     _scrollOffset = MaxScroll;
                 }
@@ -274,6 +274,8 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode, ISc
     /// <inheritdoc />
     public override Size Measure(Size available)
     {
+        var wasNearBottom = IsNearBottom;
+
         // Calculate available width accounting for scrollbar
         var contentWidth = ShowScrollbar && available.Width > 1
             ? available.Width - 1
@@ -290,7 +292,7 @@ public sealed class ScrollableContainerNode : LayoutNode, IInvalidatingNode, ISc
         // Apply auto-scroll if content height changed
         if (_contentHeight != _previousContentHeight)
         {
-            ApplyAutoScrollPolicy();
+            ApplyAutoScrollPolicy(wasNearBottom);
         }
 
         var width = WidthConstraint.Compute(available.Width, contentSize.Width + (ShowScrollbar ? 1 : 0), available.Width);

--- a/tests/Termina.Tests/Layout/ScrollableContainerNodeAutoScrollTests.cs
+++ b/tests/Termina.Tests/Layout/ScrollableContainerNodeAutoScrollTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Petabridge, LLC. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using Termina.Layout;
+
+namespace Termina.Tests.Layout;
+
+public class ScrollableContainerNodeAutoScrollTests
+{
+    [Fact]
+    public void TailWhenAtBottom_FollowsContentThatGrowsByMoreThanTheThreshold()
+    {
+        var node = CreateNode(20);
+        node.Measure(new Size(40, 5));
+        node.ScrollToBottom();
+
+        node.WithContent(CreateContent(50));
+        node.Measure(new Size(40, 5));
+
+        Assert.Equal(node.MaxScroll, node.ScrollOffset);
+        Assert.False(node.CanScrollDown);
+    }
+
+    [Fact]
+    public void TailWhenAtBottom_PreservesTheOffsetWhenTheUserScrolledUp()
+    {
+        var node = CreateNode(20);
+        node.Measure(new Size(40, 5));
+        node.ScrollToBottom();
+        node.PageUp();
+        var offset = node.ScrollOffset;
+
+        node.WithContent(CreateContent(50));
+        node.Measure(new Size(40, 5));
+
+        Assert.Equal(offset, node.ScrollOffset);
+        Assert.True(node.CanScrollDown);
+    }
+
+    private static ScrollableContainerNode CreateNode(int lineCount) =>
+        new ScrollableContainerNode()
+            .WithAutoScroll(AutoScrollPolicy.TailWhenAtBottom)
+            .WithScrollbar(false)
+            .WithContent(CreateContent(lineCount));
+
+    private static TextNode CreateContent(int lineCount) =>
+        new(string.Join('\n', Enumerable.Range(1, lineCount).Select(index => $"Line {index}")));
+}


### PR DESCRIPTION
## Summary

- Preserve the pre-measure tail state.
- Keep the view at the tail after a large content update.
- Preserve a manual scroll offset.

## Proof

- `dotnet test Termina.slnx`
- 1,714 tests passed.