### PR TITLE
Fix concurrent container disposal

### DIFF
--- a/src/Termina/Layout/LayoutNode.cs
+++ b/src/Termina/Layout/LayoutNode.cs
@@ -183,6 +183,7 @@ public abstract class ContainerNode : LayoutNode, IContainerNode, IInvalidatingN
     private readonly List<ILayoutNode> _children = new();
     private readonly List<IDisposable> _childInvalidationSubscriptions = new();
     private readonly Subject<Unit> _invalidated = new();
+    private int _disposeState;
 
     /// <inheritdoc />
     public Observable<Unit> Invalidated => _invalidated;
@@ -231,6 +232,12 @@ public abstract class ContainerNode : LayoutNode, IContainerNode, IInvalidatingN
     /// <inheritdoc />
     public override void Dispose()
     {
+        // Layout teardown can race with a render pass that retires the same container.
+        // Claim disposal atomically before completing the R3 subject; Subject.Dispose()
+        // deliberately throws if OnCompleted() is attempted a second time.
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+            return;
+
         // Dispose child invalidation subscriptions
         foreach (var subscription in _childInvalidationSubscriptions)
         {

--- a/tests/Termina.Tests/Layout/LayoutNodeLifecycleTests.cs
+++ b/tests/Termina.Tests/Layout/LayoutNodeLifecycleTests.cs
@@ -3,6 +3,7 @@
 
 using R3;
 using Termina.Layout;
+using Termina.Rendering;
 
 namespace Termina.Tests.Layout;
 
@@ -343,6 +344,29 @@ public class LayoutNodeLifecycleTests
     }
 
     [Fact]
+    public async Task ContainerNode_ConcurrentDispose_DisposesChildrenOnce()
+    {
+        var child = new BlockingDisposeNode();
+        var container = Layouts.Vertical(child);
+
+        var firstDispose = Task.Run(container.Dispose);
+        await child.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var secondDispose = Task.Run(container.Dispose);
+        try
+        {
+            await secondDispose.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            child.AllowDisposeToFinish.TrySetResult();
+            await firstDispose.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+
+        Assert.Equal(1, child.DisposeCount);
+    }
+
+    [Fact]
     public void LayoutNode_OnDeactivate_DoesNotDisposeSubjects()
     {
         // Arrange
@@ -389,5 +413,30 @@ public class LayoutNodeLifecycleTests
         {
             node.Submitted.Subscribe(_ => { });
         });
+    }
+
+    private sealed class BlockingDisposeNode : LayoutNode
+    {
+        public TaskCompletionSource DisposeStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowDisposeToFinish { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int DisposeCount { get; private set; }
+
+        public override Size Measure(Size available) => Size.Zero;
+
+        public override void Render(IRenderContext context, Rect bounds)
+        {
+        }
+
+        public override void Dispose()
+        {
+            DisposeCount++;
+            DisposeStarted.TrySetResult();
+            AllowDisposeToFinish.Task.GetAwaiter().GetResult();
+            base.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- make ContainerNode disposal atomic and idempotent
- prevent a second teardown from completing an already-disposed R3 subject
- add a deterministic concurrent-disposal regression test

## Incident evidence

Netclaw native smoke failed with ObjectDisposedException in R3 Subject.OnCompleted through ContainerNode.Dispose and KeyedDynamicLayoutNode.DisposeRetiredChildren. The regression test produces the same R3 stack on unpatched dev and passes with this change.

## Validation

- dotnet build Termina.slnx -c Release --no-restore
- dotnet test Termina.slnx -c Release --no-build --no-restore: 1,713 passed
- Slopwatch on both changed files: 0 issues
- git diff --check