### PR TITLE
fix(input): preserve kitty associated text

### DIFF
--- a/docs/concepts/terminal-input-modes.md
+++ b/docs/concepts/terminal-input-modes.md
@@ -120,9 +120,11 @@ Termina can negotiate kitty keyboard protocol flags during app startup:
 - `DisambiguateOnly` (`1`)
 - `ReportAllKeys` (`8`)
 - `ReportAllKeysPlusDisambiguate` (`9`)
+- `ReportAllKeysWithAssociatedText` (`25`)
 - `ReportAllKeysWithEventTypes` (`11`)
 
-Use `ReportAllKeys` or `ReportAllKeysPlusDisambiguate` when you want the parser to treat real arrows and wheel ticks as structurally distinct byte streams under alternate-scroll.
+Use `ReportAllKeysWithAssociatedText` when an application accepts text and must also treat real arrows and wheel ticks as structurally distinct byte streams under alternate-scroll.
+The associated-text flag preserves keyboard-layout output such as uppercase letters, shifted symbols, composed text, and input method editor (IME) text.
 
 ## Input capability result
 

--- a/src/Termina/Hosting/TerminaRuntimeOptions.cs
+++ b/src/Termina/Hosting/TerminaRuntimeOptions.cs
@@ -108,6 +108,11 @@ public enum KittyKeyboardMode
     ReportAllKeysPlusDisambiguate = 9,
 
     /// <summary>
+    /// Flags 16 | 8 | 1: report associated text and all keys, and disambiguate escape codes.
+    /// </summary>
+    ReportAllKeysWithAssociatedText = 25,
+
+    /// <summary>
     /// Flags 8 | 2 | 1: report all keys, event types, and disambiguate escape codes.
     /// </summary>
     ReportAllKeysWithEventTypes = 11,

--- a/src/Termina/Input/KittyCsiUKeyboardDecoder.cs
+++ b/src/Termina/Input/KittyCsiUKeyboardDecoder.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Termina.Input;
 
 /// <summary>
@@ -28,6 +30,7 @@ internal static class KittyCsiUKeyboardDecoder
         int keycode;
         var modValue = 1;
         var phase = KeyEventPhase.Press;
+        string? associatedText = null;
 
         if (semicolon < 0)
         {
@@ -52,7 +55,11 @@ internal static class KittyCsiUKeyboardDecoder
             var rest = inner[(semicolon + 1)..];
             var nextSemi = rest.IndexOf(';');
             if (nextSemi >= 0)
+            {
+                if (!TryDecodeAssociatedText(rest[(nextSemi + 1)..], out associatedText))
+                    return false;
                 rest = rest[..nextSemi];
+            }
 
             var modPart = rest;
             var colon = rest.IndexOf(':');
@@ -88,12 +95,29 @@ internal static class KittyCsiUKeyboardDecoder
         if ((modBits & 2) != 0) modifiers |= KeyModifiers.Alt;
         if ((modBits & 4) != 0) modifiers |= KeyModifiers.Control;
 
-        var (key, associatedText) = MapKeycodeToKeyStroke(keycode);
-        if (key == TerminaKey.None && associatedText is null)
+        var (key, fallbackText) = MapKeycodeToKeyStroke(keycode);
+        var textOutput = associatedText ?? fallbackText;
+        if (key == TerminaKey.None && textOutput is null)
             return true;
 
-        result = new KeyStroke(key, modifiers, phase, associatedText);
+        result = new KeyStroke(key, modifiers, phase, textOutput);
         return true;
+    }
+
+    private static bool TryDecodeAssociatedText(string value, out string? text)
+    {
+        text = null;
+        var builder = new StringBuilder();
+        foreach (var part in value.Split(':'))
+        {
+            if (!int.TryParse(part, out var codePoint) || !Rune.IsValid(codePoint))
+                return false;
+
+            builder.Append(new Rune(codePoint));
+        }
+
+        text = builder.ToString();
+        return text.Length > 0;
     }
 
     private static (TerminaKey Key, string? Text) MapKeycodeToKeyStroke(int keycode) => keycode switch

--- a/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
+++ b/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
@@ -387,6 +387,7 @@ namespace Termina.Hosting
         DisambiguateOnly = 1,
         ReportAllKeys = 8,
         ReportAllKeysPlusDisambiguate = 9,
+        ReportAllKeysWithAssociatedText = 25,
         ReportAllKeysWithEventTypes = 11,
     }
     public enum ScrollInputMode

--- a/tests/Termina.Tests/Hosting/TerminaRuntimeOptionsTests.cs
+++ b/tests/Termina.Tests/Hosting/TerminaRuntimeOptionsTests.cs
@@ -26,6 +26,7 @@ public class TerminaRuntimeOptionsTests
         Assert.Equal(0, (int)ScrollInputMode.LegacyMouseTracking);
         Assert.Equal(1, (int)ScrollInputMode.AlternateScroll);
         Assert.Equal(2, (int)ScrollInputMode.NativeTerminal);
+        Assert.Equal(25, (int)KittyKeyboardMode.ReportAllKeysWithAssociatedText);
     }
 
     [Fact]

--- a/tests/Termina.Tests/Input/EscapeSequenceParserKittyTests.cs
+++ b/tests/Termina.Tests/Input/EscapeSequenceParserKittyTests.cs
@@ -262,6 +262,7 @@ public class EscapeSequenceParserKittyTests
         Assert.Single(events);
         var press = Assert.IsType<KeyPressed>(events[0]);
         Assert.Equal(ConsoleKey.A, press.KeyInfo.Key);
+        Assert.Equal('A', press.KeyInfo.KeyChar);
         Assert.True((press.KeyInfo.Modifiers & ConsoleModifiers.Shift) != 0);
     }
 

--- a/tests/Termina.Tests/Input/KittyCsiUKeyboardDecoderTests.cs
+++ b/tests/Termina.Tests/Input/KittyCsiUKeyboardDecoderTests.cs
@@ -8,15 +8,18 @@ namespace Termina.Tests.Input;
 public class KittyCsiUKeyboardDecoderTests
 {
     [Theory]
-    [InlineData("[13;5u", ConsoleKey.Enter, '\r', false, false, true)]
-    [InlineData("[13;2u", ConsoleKey.Enter, '\r', true, false, false)]
-    [InlineData("[13;6u", ConsoleKey.Enter, '\r', true, false, true)]
-    [InlineData("[13u", ConsoleKey.Enter, '\r', false, false, false)]
-    [InlineData("[97;2;65u", ConsoleKey.A, 'a', true, false, false)]
+    [InlineData("[13;5u", ConsoleKey.Enter, "\r", false, false, true)]
+    [InlineData("[13;2u", ConsoleKey.Enter, "\r", true, false, false)]
+    [InlineData("[13;6u", ConsoleKey.Enter, "\r", true, false, true)]
+    [InlineData("[13u", ConsoleKey.Enter, "\r", false, false, false)]
+    [InlineData("[97;2;65u", ConsoleKey.A, "A", true, false, false)]
+    [InlineData("[49;2;33u", ConsoleKey.D1, "!", true, false, false)]
+    [InlineData("[0;1;229u", ConsoleKey.None, "å", false, false, false)]
+    [InlineData("[0;1;72:105u", ConsoleKey.None, "Hi", false, false, false)]
     public void TryDecode_StandardSequence_ReturnsKeyStroke(
         string sequence,
         ConsoleKey expectedKey,
-        char expectedChar,
+        string expectedText,
         bool shift,
         bool alt,
         bool ctrl)
@@ -26,7 +29,7 @@ public class KittyCsiUKeyboardDecoderTests
         Assert.True(decoded);
         Assert.NotNull(keyStroke);
         Assert.Equal(ToTerminaKey(expectedKey), keyStroke!.Key);
-        Assert.Equal(expectedChar.ToString(), keyStroke.Text);
+        Assert.Equal(expectedText, keyStroke.Text);
         Assert.Equal(KeyEventPhase.Press, keyStroke.Phase);
         Assert.Equal(shift, keyStroke.Modifiers.HasFlag(KeyModifiers.Shift));
         Assert.Equal(alt, keyStroke.Modifiers.HasFlag(KeyModifiers.Alt));


### PR DESCRIPTION
## Problem

`KittyCsiUKeyboardDecoder` ignores the associated-text field in CSI-u input. Applications that enable `report_all_keys` therefore receive the base key instead of the produced text. For example, Shift+A becomes `a`, and Shift+1 becomes `1`.

## Change

- Decode the CSI-u associated-text code points, including multiple Unicode scalar values.
- Prefer associated text over the base key text while preserving the physical key and modifiers.
- Add `ReportAllKeysWithAssociatedText` as the flags 16 | 8 | 1 preset for text-entry applications.
- Document when to use the new preset.

## Validation

- `dotnet test tests/Termina.Tests/Termina.Tests.csproj` — 1,716 passed.
- `dotnet build Termina.slnx` — passed with zero warnings and zero errors.

This pull request was prepared by an AI coding agent.