### PR TITLE
fix(streaming): clamp scrolling to the viewport

### DIFF
--- a/src/Termina/Components/Streaming/PersistedStreamBuffer.cs
+++ b/src/Termina/Components/Streaming/PersistedStreamBuffer.cs
@@ -225,10 +225,21 @@ public class PersistedStreamBuffer : IStreamingTextBuffer
     /// <param name="viewportWidth">Width for word wrapping calculation.</param>
     public void ScrollUp(int lines = 1, int viewportWidth = 80)
     {
+        ScrollUp(lines, viewportWidth, viewportHeight: 1);
+    }
+
+    /// <summary>
+    /// Scrolls up without moving the oldest content above the viewport.
+    /// </summary>
+    /// <param name="lines">Number of lines to scroll.</param>
+    /// <param name="viewportWidth">Width for word wrapping calculation.</param>
+    /// <param name="viewportHeight">Number of visible rows.</param>
+    public void ScrollUp(int lines, int viewportWidth, int viewportHeight)
+    {
         lock (_lock)
         {
             _userScrolled = true;
-            var maxScroll = GetMaxScrollOffset(viewportWidth);
+            var maxScroll = GetMaxScrollOffset(viewportWidth, viewportHeight);
             _scrollOffset = Math.Min(_scrollOffset + lines, maxScroll);
         }
     }
@@ -269,10 +280,20 @@ public class PersistedStreamBuffer : IStreamingTextBuffer
     /// <param name="viewportWidth">Width for word wrapping calculation.</param>
     public void ScrollToTop(int viewportWidth = 80)
     {
+        ScrollToTop(viewportWidth, viewportHeight: 1);
+    }
+
+    /// <summary>
+    /// Scrolls to the oldest viewport without moving content above it.
+    /// </summary>
+    /// <param name="viewportWidth">Width for word wrapping calculation.</param>
+    /// <param name="viewportHeight">Number of visible rows.</param>
+    public void ScrollToTop(int viewportWidth, int viewportHeight)
+    {
         lock (_lock)
         {
             _userScrolled = true;
-            _scrollOffset = GetMaxScrollOffset(viewportWidth);
+            _scrollOffset = GetMaxScrollOffset(viewportWidth, viewportHeight);
         }
     }
 
@@ -352,8 +373,18 @@ public class PersistedStreamBuffer : IStreamingTextBuffer
     /// </param>
     public int GetMaxScrollOffset(int viewportWidth)
     {
+        return GetMaxScrollOffset(viewportWidth, viewportHeight: 1);
+    }
+
+    /// <summary>
+    /// Returns the maximum scroll offset that keeps the oldest content at the top of the viewport.
+    /// </summary>
+    /// <param name="viewportWidth">Width for word wrapping calculation.</param>
+    /// <param name="viewportHeight">Number of visible rows.</param>
+    public int GetMaxScrollOffset(int viewportWidth, int viewportHeight)
+    {
         var totalWrapped = GetWrappedLineCount(viewportWidth);
-        return Math.Max(0, totalWrapped - 1); // Can scroll up to see first line at bottom
+        return Math.Max(0, totalWrapped - Math.Max(1, viewportHeight));
     }
 
     private IEnumerable<StyledLine> GetAllStyledLinesInternal()

--- a/src/Termina/Layout/StreamingTextNode.cs
+++ b/src/Termina/Layout/StreamingTextNode.cs
@@ -470,7 +470,7 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
     {
         if (_buffer is PersistedStreamBuffer persisted)
         {
-            persisted.ScrollUp(lines, viewportWidth);
+            persisted.ScrollUp(lines, viewportWidth, _lastViewportHeight);
             NotifyChanged();
         }
     }
@@ -525,7 +525,7 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
                 // Ctrl+Home scrolls to top
                 if (_buffer is PersistedStreamBuffer persisted)
                 {
-                    persisted.ScrollToTop(viewportWidth);
+                    persisted.ScrollToTop(viewportWidth, _lastViewportHeight);
                     NotifyChanged();
                 }
                 return true;
@@ -613,7 +613,7 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
     /// Returns <see langword="false"/> before the first render.
     /// </remarks>
     public bool CanScrollUp => _buffer is PersistedStreamBuffer p &&
-        p.ScrollOffset < p.GetMaxScrollOffset(_lastViewportWidth);
+        p.ScrollOffset < p.GetMaxScrollOffset(_lastViewportWidth, _lastViewportHeight);
 
     /// <inheritdoc cref="IScrollable.CanScrollDown"/>
     /// <remarks>
@@ -658,6 +658,7 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
         // Update cached viewport dimensions for IScrollable
         _lastViewportWidth = contentWidth;
         _lastViewportHeight = bounds.Height;
+        ClampScrollOffsetToViewport(contentWidth, bounds.Height);
 
         // Get styled lines from buffer
         var styledLines = _buffer.GetVisibleStyledLines(bounds.Height, contentWidth);
@@ -714,6 +715,16 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
             DrawScrollbar(streamContext, bounds, contentWidth);
     }
 
+    private void ClampScrollOffsetToViewport(int viewportWidth, int viewportHeight)
+    {
+        if (_buffer is not PersistedStreamBuffer persisted)
+            return;
+
+        var maxScroll = persisted.GetMaxScrollOffset(viewportWidth, viewportHeight);
+        if (persisted.ScrollOffset > maxScroll)
+            persisted.ScrollToTop(viewportWidth, viewportHeight);
+    }
+
     private bool ShouldDrawScrollbar(Rect bounds)
     {
         if (_scrollbarOptions == null || _buffer is not PersistedStreamBuffer persisted)
@@ -736,7 +747,7 @@ public sealed class StreamingTextNode : LayoutNode, IInvalidatingNode, IScrollab
         if (_buffer is not PersistedStreamBuffer persisted) return;
 
         var scrollOffset = persisted.ScrollOffset;
-        var maxScroll = persisted.GetMaxScrollOffset(contentWidth);
+        var maxScroll = persisted.GetMaxScrollOffset(contentWidth, bounds.Height);
         if (maxScroll <= 0) return;
 
         var x = bounds.Width - 1;

--- a/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
+++ b/tests/Termina.Tests/Api/Snapshots/PublicApiApprovalTests.Public_api_matches_the_approved_contract.verified.txt
@@ -131,13 +131,16 @@ namespace Termina.Components.Streaming
         public System.Collections.Generic.IReadOnlyList<string> GetAllLines() { }
         public System.Collections.Generic.IReadOnlyList<Termina.Components.Streaming.StyledLine> GetAllStyledLines() { }
         public int GetMaxScrollOffset(int viewportWidth) { }
+        public int GetMaxScrollOffset(int viewportWidth, int viewportHeight) { }
         public System.Collections.Generic.IReadOnlyList<string> GetVisibleLines(int viewportHeight, int viewportWidth) { }
         public System.Collections.Generic.IReadOnlyList<Termina.Components.Streaming.StyledLine> GetVisibleStyledLines(int viewportHeight, int viewportWidth) { }
         public int GetWrappedLineCount(int viewportWidth) { }
         public void ScrollDown(int lines = 1) { }
         public void ScrollToBottom() { }
         public void ScrollToTop(int viewportWidth = 80) { }
+        public void ScrollToTop(int viewportWidth, int viewportHeight) { }
         public void ScrollUp(int lines = 1, int viewportWidth = 80) { }
+        public void ScrollUp(int lines, int viewportWidth, int viewportHeight) { }
     }
     public sealed class SpinnerSegment : System.IDisposable, Termina.Components.Streaming.IAnimatedTextSegment, Termina.Components.Streaming.ITextSegment
     {

--- a/tests/Termina.Tests/MouseScrollRoutingTests.cs
+++ b/tests/Termina.Tests/MouseScrollRoutingTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Petabridge, LLC. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using Termina.Components.Streaming;
 using Termina.Input;
 using Termina.Layout;
 using Termina.Reactive;
@@ -75,6 +76,49 @@ public class MouseScrollRoutingTests
 
         // After scrolling up, can scroll back down
         Assert.True(node.CanScrollDown);
+    }
+
+    [Fact]
+    public void ScrollUp_StopsWhenTheOldestContentFillsTheViewport()
+    {
+        var buffer = new PersistedStreamBuffer();
+        var node = new StreamingTextNode(buffer);
+        for (var i = 0; i < 30; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        ((IScrollable)node).ScrollUp(100);
+
+        Assert.Equal(20, buffer.ScrollOffset);
+        Assert.False(node.CanScrollUp);
+        Assert.Equal(
+            Enumerable.Range(0, 10).Select(index => $"Line {index}"),
+            buffer.GetVisibleLines(10, 40));
+    }
+
+    [Fact]
+    public void Render_ClampsAnExistingOffsetAfterTheViewportGetsTaller()
+    {
+        var buffer = new PersistedStreamBuffer();
+        var node = new StreamingTextNode(buffer);
+        for (var i = 0; i < 30; i++)
+            node.AppendLine($"Line {i}");
+
+        var terminal = new VirtualTerminal(40, 10);
+        var context = new RegionRenderContext(terminal, 0, 0, 40, 10);
+        node.Render(context, new Rect(0, 0, 40, 1));
+        ((IScrollable)node).ScrollUp(100);
+        Assert.Equal(29, buffer.ScrollOffset);
+
+        node.Render(context, new Rect(0, 0, 40, 10));
+
+        Assert.Equal(20, buffer.ScrollOffset);
+        Assert.Equal(
+            Enumerable.Range(0, 10).Select(index => $"Line {index}"),
+            buffer.GetVisibleLines(10, 40));
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`PersistedStreamBuffer` calculates its maximum scroll offset as `wrapped lines - 1`. This lets a multi-row viewport move the oldest line to its bottom row. The rows above it become blank, and the newest content disappears far below the viewport.

For 30 lines in a 10-row viewport, scrolling to the top produced offset 29 instead of 20.

## Change

- Include the viewport height when calculating the maximum scroll offset.
- Pass the measured viewport height through `StreamingTextNode` scrolling and Ctrl+Home handling.
- Re-clamp an existing offset during render after the viewport grows or content reflows.
- Use the same viewport-aware bound for scrollbar state.

The existing width-only methods remain compatible and retain their one-row semantics.

## Validation

- Added tests for scrolling to the oldest full viewport and for re-clamping after a viewport resize.
- `dotnet test tests/Termina.Tests/Termina.Tests.csproj` — 1,715 passed.
- `dotnet build Termina.slnx` — passed with zero warnings and zero errors.

This pull request was prepared by an AI coding agent.